### PR TITLE
feat: update .gitignore and README.md with new badges; enhance setup script for .NET Framework 4.8 installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -357,3 +357,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# Redistributable installers (binary, do not commit)
+redist/

--- a/README.md
+++ b/README.md
@@ -4,11 +4,15 @@
 
 > **Quản lý tài liệu cá nhân - Đơn giản, Hiệu quả, Riêng tư**
 
-[![.NET Framework](https://img.shields.io/badge/.NET%20Framework-4.8-512BD4?logo=.net)](https://dotnet.microsoft.com/)
-[![SQLite](https://img.shields.io/badge/SQLite-Local%20DB-003B57?logo=sqlite)](https://www.sqlite.org/)
-[![Windows Forms](https://img.shields.io/badge/Windows%20Forms-C%23-239120?logo=c-sharp)](https://docs.microsoft.com/dotnet/desktop/winforms/)
-[![Version](https://img.shields.io/badge/Version-3.0.2-blue.svg)](https://github.com/hayato-shino05/study-document-manager/releases)
-[![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
+[![.NET Framework](https://img.shields.io/badge/.NET_Framework-4.8-512BD4?style=for-the-badge&logo=dotnet&logoColor=white)](https://dotnet.microsoft.com/)
+[![SQLite](https://img.shields.io/badge/SQLite-Local_DB-003B57?style=for-the-badge&logo=sqlite&logoColor=white)](https://www.sqlite.org/)
+[![C#](https://img.shields.io/badge/C%23-Windows_Forms-239120?style=for-the-badge&logo=csharp&logoColor=white)](https://docs.microsoft.com/dotnet/desktop/winforms/)
+[![Windows](https://img.shields.io/badge/Platform-Windows-0078D4?style=for-the-badge&logo=windows&logoColor=white)](https://www.microsoft.com/windows)
+
+[![Version](https://img.shields.io/badge/Version-3.0.2-14B8A6?style=for-the-badge&logo=semver&logoColor=white)](https://github.com/hayato-shino05/study-document-manager/releases)
+[![Downloads](https://img.shields.io/github/downloads/hayato-shino05/study-document-manager/total?style=for-the-badge&color=10B981&logo=github&logoColor=white&label=Downloads)](https://github.com/hayato-shino05/study-document-manager/releases)
+[![License](https://img.shields.io/badge/License-MIT-F59E0B?style=for-the-badge&logo=opensourceinitiative&logoColor=white)](LICENSE)
+[![Stars](https://img.shields.io/github/stars/hayato-shino05/study-document-manager?style=for-the-badge&color=EF4444&logo=github&logoColor=white)](https://github.com/hayato-shino05/study-document-manager)
 
 </div>
 

--- a/setup.iss
+++ b/setup.iss
@@ -33,10 +33,14 @@ ArchitecturesInstallIn64BitMode=x64compatible
 Name: "vietnamese"; MessagesFile: "compiler:Default.isl"
 
 [Tasks]
+Name: "installnet48"; Description: "Cài đặt .NET Framework 4.8 (bắt buộc để chạy ứng dụng)"; GroupDescription: "Yêu cầu hệ thống:"; Check: not IsNet48Installed
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 Name: "quicklaunchicon"; Description: "{cm:CreateQuickLaunchIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked; OnlyBelowVersion: 6.1; Check: not IsAdminInstallMode
 
 [Files]
+; .NET Framework 4.8 Web Installer (~1.5 MB) - đặt file ndp48-web.exe vào thư mục redist/
+Source: "redist\ndp48-web.exe"; DestDir: "{tmp}"; Flags: deleteafterinstall; Tasks: installnet48; Check: not IsNet48Installed
+; Application files
 Source: "study-document-manager\bin\Release\study-document-manager.exe"; DestDir: "{app}"; Flags: ignoreversion
 Source: "study-document-manager\bin\Release\study-document-manager.exe.config"; DestDir: "{app}"; Flags: ignoreversion
 Source: "study-document-manager\bin\Release\*.dll"; DestDir: "{app}"; Flags: ignoreversion
@@ -51,4 +55,26 @@ Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: de
 Name: "{userappdata}\Microsoft\Internet Explorer\Quick Launch\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: quicklaunchicon
 
 [Run]
+; Cài .NET Framework 4.8 trước (shellexec sẽ tự yêu cầu quyền Admin/UAC)
+Filename: "{tmp}\ndp48-web.exe"; Parameters: "/passive /norestart"; StatusMsg: "Đang cài đặt .NET Framework 4.8... Vui lòng chờ."; Flags: shellexec waituntilterminated; Tasks: installnet48; Check: not IsNet48Installed
+; Khởi chạy ứng dụng sau cài đặt
 Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
+
+[Code]
+function IsNet48Installed: Boolean;
+var
+  Release: Cardinal;
+begin
+  Result := RegQueryDWordValue(HKLM, 'SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full', 'Release', Release) and (Release >= 528040);
+end;
+
+procedure CurPageChanged(CurPageID: Integer);
+begin
+  // Hiển thị thông báo nếu .NET 4.8 chưa cài và user ở trang chọn Tasks
+  if (CurPageID = wpSelectTasks) and (not IsNet48Installed) then
+  begin
+    MsgBox('.NET Framework 4.8 chưa được cài đặt trên máy.' + #13#10 + #13#10 +
+           'Hãy đánh dấu tùy chọn "Cài đặt .NET Framework 4.8" bên dưới.' + #13#10 +
+           'Ứng dụng yêu cầu .NET 4.8 để hoạt động.', mbInformation, MB_OK);
+  end;
+end;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the installer to detect and install .NET Framework 4.8 if needed, with a clear prompt during setup. Also refreshed README badges and added redist/ to .gitignore to keep installers out of the repo.

- New Features
  - Adds an installer task to install .NET 4.8 (ndp48-web.exe, passive, waits) before first launch.
  - Shows a message on the Tasks page if .NET 4.8 is missing.

- Migration
  - Place ndp48-web.exe in redist/ before building the installer (the folder is git-ignored).

<sup>Written for commit 9ccb6c11be626627bdd92fa58eacc725f2eaa238. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

