### PR TITLE
Inno Setup の不足言語ファイルを同梱する

### DIFF
--- a/installer-languages/ChineseSimplified.isl
+++ b/installer-languages/ChineseSimplified.isl
@@ -1,0 +1,417 @@
+; *** Inno Setup version 6.5.0+ Chinese Simplified messages ***
+;
+; To download user-contributed translations of this file, go to:
+;   https://jrsoftware.org/files/istrans/
+;
+; Note: When translating this text, do not add periods (.) to the end of
+; messages that didn't have them already, because on those messages Inno
+; Setup adds the periods automatically (appending a period would result in
+; two periods being displayed).
+;
+; Maintainer: Zhenghan Yang (Kira)
+; Email: 847320916@QQ.com
+; Github: https://github.com/kira-96/Inno-Setup-Chinese-Simplified-Translation
+; Encoding: UTF-8
+; Translation based on network resource
+;
+
+[LangOptions]
+; The following three entries are very important. Be sure to read and
+; understand the '[LangOptions] section' topic in the help file.
+LanguageName=简体中文
+; About LanguageID, to reference link:
+; https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c
+LanguageID=$0804
+; LanguageCodePage should always be set if possible, even if this file is Unicode
+; For English it's set to zero anyway because English only uses ASCII characters
+LanguageCodePage=936
+; If the language you are translating to requires special font faces or
+; sizes, uncomment any of the following entries and change them accordingly.
+;DialogFontName=
+;DialogFontSize=9
+;DialogFontBaseScaleWidth=7
+;DialogFontBaseScaleHeight=15
+;WelcomeFontName=Segoe UI
+;WelcomeFontSize=14
+
+[Messages]
+
+; *** Application titles
+SetupAppTitle=安装
+SetupWindowTitle=安装 - %1
+UninstallAppTitle=卸载
+UninstallAppFullTitle=%1 卸载
+
+; *** Misc. common
+InformationTitle=信息
+ConfirmTitle=确认
+ErrorTitle=错误
+
+; *** SetupLdr messages
+SetupLdrStartupMessage=现在将安装 %1。您想要继续吗？
+LdrCannotCreateTemp=无法创建临时文件。安装程序已中止
+LdrCannotExecTemp=无法执行临时目录中的文件。安装程序已中止
+HelpTextNote=
+
+; *** Startup error messages
+LastErrorMessage=%1。%n%n错误 %2: %3
+SetupFileMissing=安装目录中缺少文件 %1。请修正这个问题或者获取程序的新副本。
+SetupFileCorrupt=安装文件已损坏。请获取程序的新副本。
+SetupFileCorruptOrWrongVer=安装文件已损坏，或是与这个安装程序的版本不兼容。请修正这个问题或获取新的程序副本。
+InvalidParameter=无效的命令行参数：%n%n%1
+SetupAlreadyRunning=安装程序已在运行。
+WindowsVersionNotSupported=此程序不支持当前计算机运行的 Windows 版本。
+WindowsServicePackRequired=此程序需要 %1 服务包 %2 或更高版本。
+NotOnThisPlatform=此程序不能在 %1 上运行。
+OnlyOnThisPlatform=此程序只能在 %1 上运行。
+OnlyOnTheseArchitectures=此程序只能安装到为下列处理器架构设计的 Windows 版本中：%n%n%1
+WinVersionTooLowError=此程序需要 %1 版本 %2 或更高。
+WinVersionTooHighError=此程序不能安装于 %1 版本 %2 或更高。
+AdminPrivilegesRequired=在安装此程序时您必须以管理员身份登录。
+PowerUserPrivilegesRequired=在安装此程序时您必须以管理员身份或高级用户组身份登录。
+SetupAppRunningError=安装程序检测到 %1 当前正在运行。%n%n请先关闭正在运行的程序，然后点击“确定”继续，或点击“取消”退出。
+UninstallAppRunningError=卸载程序检测到 %1 当前正在运行。%n%n请先关闭正在运行的程序，然后点击“确定”继续，或点击“取消”退出。
+
+; *** Startup questions
+PrivilegesRequiredOverrideTitle=选择安装程序安装模式
+PrivilegesRequiredOverrideInstruction=选择安装模式
+PrivilegesRequiredOverrideText1=%1 可以为所有用户安装（需要管理员权限），或仅为您安装。
+PrivilegesRequiredOverrideText2=%1 可以仅为您安装，或为所有用户安装（需要管理员权限）。
+PrivilegesRequiredOverrideAllUsers=为所有用户安装(&A)
+PrivilegesRequiredOverrideAllUsersRecommended=为所有用户安装(&A)（推荐）
+PrivilegesRequiredOverrideCurrentUser=仅为我安装(&M)
+PrivilegesRequiredOverrideCurrentUserRecommended=仅为我安装(&M)（推荐）
+
+; *** Misc. errors
+ErrorCreatingDir=安装程序无法创建目录“%1”
+ErrorTooManyFilesInDir=无法在目录“%1”中创建文件，因为里面包含太多文件。
+
+; *** Setup common messages
+ExitSetupTitle=退出安装程序
+ExitSetupMessage=安装程序尚未完成。如果现在退出，将不会安装该程序。%n%n您之后可以再次运行安装程序完成安装。%n%n现在退出安装程序吗？
+AboutSetupMenuItem=关于安装程序(&A)...
+AboutSetupTitle=关于安装程序
+AboutSetupMessage=%1 版本 %2%n%3%n%n%1 主页：%n%4
+AboutSetupNote=
+TranslatorNote=简体中文翻译由 Kira（847320916@qq.com）维护。项目地址：https://github.com/kira-96/Inno-Setup-Chinese-Simplified-Translation
+
+; *** Buttons
+ButtonBack=< 上一步(&B)
+ButtonNext=下一步(&N) >
+ButtonInstall=安装(&I)
+ButtonOK=确定
+ButtonCancel=取消
+ButtonYes=是(&Y)
+ButtonYesToAll=全是(&A)
+ButtonNo=否(&N)
+ButtonNoToAll=全否(&O)
+ButtonFinish=完成(&F)
+ButtonBrowse=浏览(&B)...
+ButtonWizardBrowse=浏览(&R)...
+ButtonNewFolder=新建文件夹(&M)
+
+; *** "Select Language" dialog messages
+SelectLanguageTitle=选择安装语言
+SelectLanguageLabel=选择安装时使用的语言。
+
+; *** Common wizard text
+ClickNext=点击“下一步”继续，或点击“取消”退出安装程序。
+BeveledLabel=
+BrowseDialogTitle=浏览文件夹
+BrowseDialogLabel=在下面的列表中选择一个文件夹，然后点击“确定”。
+NewFolderName=新建文件夹
+
+; *** "Welcome" wizard page
+WelcomeLabel1=欢迎使用 [name] 安装向导
+WelcomeLabel2=即将在您的计算机上安装 [name/ver]。%n%n建议您在继续安装前关闭所有其他应用程序。
+
+; *** "Password" wizard page
+WizardPassword=密码
+PasswordLabel1=此安装程序需要密码验证。
+PasswordLabel3=请输入密码，然后点击“下一步”继续。密码区分大小写。
+PasswordEditLabel=密码(&P)：
+IncorrectPassword=您输入的密码不正确，请重新输入。
+
+; *** "License Agreement" wizard page
+WizardLicense=许可协议
+LicenseLabel=请在继续安装前阅读以下重要信息。
+LicenseLabel3=请阅读下列许可协议。在继续安装前您必须同意这些协议条款。
+LicenseAccepted=我同意此协议(&A)
+LicenseNotAccepted=我不同意此协议(&D)
+
+; *** "Information" wizard pages
+WizardInfoBefore=信息
+InfoBeforeLabel=请在继续安装前阅读以下重要信息。
+InfoBeforeClickLabel=准备好继续安装后，点击“下一步”。
+WizardInfoAfter=信息
+InfoAfterLabel=请在继续安装前阅读以下重要信息。
+InfoAfterClickLabel=准备好继续安装后，点击“下一步”。
+
+; *** "User Information" wizard page
+WizardUserInfo=用户信息
+UserInfoDesc=请输入您的信息。
+UserInfoName=用户名(&U)：
+UserInfoOrg=组织(&O)：
+UserInfoSerial=序列号(&S)：
+UserInfoNameRequired=请输入用户名。
+
+; *** "Select Destination Location" wizard page
+WizardSelectDir=选择目标位置
+SelectDirDesc=您想将 [name] 安装在哪里？
+SelectDirLabel3=安装程序将安装 [name] 到下面的文件夹中。
+SelectDirBrowseLabel=点击“下一步”继续。如果您想选择其他文件夹，点击“浏览”。
+DiskSpaceGBLabel=至少需要有 [gb] GB 的可用磁盘空间。
+DiskSpaceMBLabel=至少需要有 [mb] MB 的可用磁盘空间。
+CannotInstallToNetworkDrive=安装程序无法安装到一个网络驱动器。
+CannotInstallToUNCPath=安装程序无法安装到一个 UNC 路径。
+InvalidPath=您必须输入一个带驱动器盘符的完整路径，例如：%n%nC:\App%n%n或UNC路径：%n%n\\server\share
+InvalidDrive=您选定的驱动器或 UNC 共享不存在或不能访问。请选择其他位置。
+DiskSpaceWarningTitle=磁盘空间不足
+DiskSpaceWarning=安装程序至少需要 %1 KB 的可用空间才能安装，但选定驱动器只有 %2 KB 的可用空间。%n%n您确定要继续吗？
+DirNameTooLong=文件夹名称或路径太长。
+InvalidDirName=文件夹名称无效。
+BadDirName32=文件夹名称不能包含下列任何字符：%n%n%1
+DirExistsTitle=文件夹已存在
+DirExists=文件夹：%n%n%1%n%n已经存在。您确定安装到这个文件夹中吗？
+DirDoesntExistTitle=文件夹不存在
+DirDoesntExist=文件夹：%n%n%1%n%n不存在。您想要创建此文件夹吗？
+
+; *** "Select Components" wizard page
+WizardSelectComponents=选择组件
+SelectComponentsDesc=您想安装哪些程序组件？
+SelectComponentsLabel2=选中您想安装的组件；取消您不想安装的组件。然后点击“下一步”继续。
+FullInstallation=完全安装
+; if possible don't translate 'Compact' as 'Minimal' (I mean 'Minimal' in your language)
+CompactInstallation=简洁安装
+CustomInstallation=自定义安装
+NoUninstallWarningTitle=组件已存在
+NoUninstallWarning=安装程序检测到下列组件已安装在您的计算机中：%n%n%1%n%n取消选中这些组件不会卸载它们。%n%n您确定要继续吗？
+ComponentSize1=%1 KB
+ComponentSize2=%1 MB
+ComponentsDiskSpaceGBLabel=当前选择的组件需要至少 [gb] GB 的磁盘空间。
+ComponentsDiskSpaceMBLabel=当前选择的组件需要至少 [mb] MB 的磁盘空间。
+
+; *** "Select Additional Tasks" wizard page
+WizardSelectTasks=选择附加任务
+SelectTasksDesc=您想要安装程序执行哪些附加任务？
+SelectTasksLabel2=选择您想要安装程序在安装 [name] 时执行的附加任务，然后点击“下一步”。
+
+; *** "Select Start Menu Folder" wizard page
+WizardSelectProgramGroup=选择开始菜单文件夹
+SelectStartMenuFolderDesc=安装程序应该在哪里放置程序的快捷方式？
+SelectStartMenuFolderLabel3=安装程序将在下列“开始”菜单文件夹中创建程序的快捷方式。
+SelectStartMenuFolderBrowseLabel=点击“下一步”继续。如果您想选择其他文件夹，点击“浏览”。
+MustEnterGroupName=您必须输入一个文件夹名称。
+GroupNameTooLong=文件夹名称或路径太长。
+InvalidGroupName=文件夹名称无效。
+BadGroupName=文件夹名称不能包含下列任何字符：%n%n%1
+NoProgramGroupCheck2=不创建开始菜单文件夹(&D)
+
+; *** "Ready to Install" wizard page
+WizardReady=准备安装
+ReadyLabel1=安装程序准备就绪，现在可以开始安装 [name] 到您的计算机。
+ReadyLabel2a=点击“安装”继续此安装程序。如果您想重新查看或修改任何设置，点击“上一步”。
+ReadyLabel2b=点击“安装”继续此安装程序。
+ReadyMemoUserInfo=用户信息：
+ReadyMemoDir=目标位置：
+ReadyMemoType=安装类型：
+ReadyMemoComponents=已选择组件：
+ReadyMemoGroup=开始菜单文件夹：
+ReadyMemoTasks=附加任务：
+
+; *** TDownloadWizardPage wizard page and DownloadTemporaryFile
+DownloadingLabel2=正在下载文件...
+ButtonStopDownload=停止下载(&S)
+StopDownload=您确定要停止下载吗？
+ErrorDownloadAborted=下载已中止。
+ErrorDownloadFailed=下载失败：%1 %2。
+ErrorDownloadSizeFailed=获取大小失败：%1 %2。
+ErrorProgress=无效的进度：%1 / %2。
+ErrorFileSize=文件大小错误：预期 %1，实际 %2。
+
+; *** TExtractionWizardPage wizard page and ExtractArchive
+ExtractingLabel=正在提取文件...
+ButtonStopExtraction=停止提取(&S)
+StopExtraction=您确定要停止提取吗？
+ErrorExtractionAborted=提取已中止。
+ErrorExtractionFailed=提取失败：%1
+
+; *** Archive extraction failure details
+ArchiveIncorrectPassword=密码不正确。
+ArchiveIsCorrupted=压缩包已损坏。
+ArchiveUnsupportedFormat=不支持的压缩包格式。
+
+; *** "Preparing to Install" wizard page
+WizardPreparing=正在准备安装
+PreparingDesc=安装程序正在准备安装 [name] 到您的计算机。
+PreviousInstallNotCompleted=先前的程序安装或卸载未完成，需要您重启计算机以完成该安装。%n%n在重启计算机后，再次运行安装程序以完成 [name] 的安装。
+CannotContinue=安装程序不能继续。请点击“取消”退出。
+ApplicationsFound=以下应用程序正在使用将由安装程序更新的文件。建议您允许安装程序自动关闭这些应用程序。
+ApplicationsFound2=以下应用程序正在使用将由安装程序更新的文件。建议您允许安装程序自动关闭这些应用程序。安装完成后，安装程序将尝试重新启动这些应用程序。
+CloseApplications=自动关闭应用程序(&A)
+DontCloseApplications=不要关闭应用程序(&D)
+ErrorCloseApplications=安装程序无法自动关闭所有应用程序。建议您在继续之前，关闭所有在使用需要由安装程序更新的文件的应用程序。
+PrepareToInstallNeedsRestart=安装程序必须重启您的计算机。计算机重启后，请再次运行安装程序以完成 [name] 的安装。%n%n要立即重启吗？
+
+; *** "Installing" wizard page
+WizardInstalling=正在安装
+InstallingLabel=安装程序正在安装 [name] 到您的计算机，请稍候。
+
+; *** "Setup Completed" wizard page
+FinishedHeadingLabel=完成 [name] 安装向导
+FinishedLabelNoIcons=安装程序已在您的计算机中安装了 [name]。
+FinishedLabel=安装程序已在您的计算机中安装了 [name]。您可以通过已安装的快捷方式运行此应用程序。
+ClickFinish=点击“完成”退出安装程序。
+FinishedRestartLabel=为完成 [name] 的安装，安装程序必须重新启动您的计算机。要立即重启吗？
+FinishedRestartMessage=为完成 [name] 的安装，安装程序必须重新启动您的计算机。%n%n要立即重启吗？
+ShowReadmeCheck=是，我想查阅自述文件
+YesRadio=是，立即重启计算机(&Y)
+NoRadio=否，稍后重启计算机(&N)
+; used for example as 'Run MyProg.exe'
+RunEntryExec=运行 %1
+; used for example as 'View Readme.txt'
+RunEntryShellExec=查阅 %1
+
+; *** "Setup Needs the Next Disk" stuff
+ChangeDiskTitle=安装程序需要下一张磁盘
+SelectDiskLabel2=请插入磁盘 %1 并点击“确定”。%n%n如果这个磁盘中的文件可以在下列文件夹之外的文件夹中找到，请输入正确的路径或点击“浏览”。
+PathLabel=路径(&P)：
+FileNotInDir2=“%2”中找不到文件“%1”。请插入正确的磁盘或选择其他文件夹。
+SelectDirectoryLabel=请指定下一张磁盘的位置。
+
+; *** Installation phase messages
+SetupAborted=安装程序未完成安装。%n%n请修正这个问题并重新运行安装程序。
+AbortRetryIgnoreSelectAction=选择操作
+AbortRetryIgnoreRetry=重试(&T)
+AbortRetryIgnoreIgnore=忽略错误并继续(&I)
+AbortRetryIgnoreCancel=取消安装
+RetryCancelSelectAction=选择操作
+RetryCancelRetry=重试(&T)
+RetryCancelCancel=取消
+
+; *** Installation status messages
+StatusClosingApplications=正在关闭应用程序...
+StatusCreateDirs=正在创建目录...
+StatusExtractFiles=正在提取文件...
+StatusDownloadFiles=正在下载文件...
+StatusCreateIcons=正在创建快捷方式...
+StatusCreateIniEntries=正在创建 INI 条目...
+StatusCreateRegistryEntries=正在创建注册表条目...
+StatusRegisterFiles=正在注册文件...
+StatusSavingUninstall=正在保存卸载信息...
+StatusRunProgram=正在完成安装...
+StatusRestartingApplications=正在重启应用程序...
+StatusRollback=正在撤销更改...
+
+; *** Misc. errors
+ErrorInternal2=内部错误：%1。
+ErrorFunctionFailedNoCode=%1 失败。
+ErrorFunctionFailed=%1 失败；错误代码 %2。
+ErrorFunctionFailedWithMessage=%1 失败；错误代码 %2。%n%3
+ErrorExecutingProgram=无法执行文件：%n%1
+
+; *** Registry errors
+ErrorRegOpenKey=打开注册表项时出错：%n%1\%2
+ErrorRegCreateKey=创建注册表项时出错：%n%1\%2
+ErrorRegWriteKey=写入注册表项时出错：%n%1\%2
+
+; *** INI errors
+ErrorIniEntry=在文件“%1”中创建 INI 条目时出错。
+
+; *** File copying errors
+FileAbortRetryIgnoreSkipNotRecommended=跳过此文件(&S)（不推荐）
+FileAbortRetryIgnoreIgnoreNotRecommended=忽略错误并继续(&I)（不推荐）
+SourceIsCorrupted=源文件已损坏。
+SourceDoesntExist=源文件“%1”不存在。
+SourceVerificationFailed=源文件验证失败：%1
+VerificationSignatureDoesntExist=签名文件“%1”不存在。
+VerificationSignatureInvalid=签名文件“%1”无效。
+VerificationKeyNotFound=签名文件“%1”使用了未知的密钥。
+VerificationFileNameIncorrect=文件名不正确。
+VerificationFileTagIncorrect=文件标签不正确。
+VerificationFileSizeIncorrect=文件大小不正确。
+VerificationFileHashIncorrect=文件哈希值不正确。
+ExistingFileReadOnly2=无法替换已存在的文件，它是只读的。
+ExistingFileReadOnlyRetry=移除只读属性并重试(&R)
+ExistingFileReadOnlyKeepExisting=保留已存在的文件(&K)
+ErrorReadingExistingDest=尝试读取已存在的文件时出错：
+FileExistsSelectAction=选择操作
+FileExists2=文件已经存在。
+FileExistsOverwriteExisting=覆盖已存在的文件(&O)
+FileExistsKeepExisting=保留已存在的文件(&K)
+FileExistsOverwriteOrKeepAll=为接下来的冲突文件执行此操作(&D)
+ExistingFileNewerSelectAction=选择操作
+ExistingFileNewer2=已存在的文件比安装程序将要安装的文件还要新。
+ExistingFileNewerOverwriteExisting=覆盖已存在的文件(&O)
+ExistingFileNewerKeepExisting=保留已存在的文件(&K)（推荐）
+ExistingFileNewerOverwriteOrKeepAll=为接下来的冲突文件执行此操作(&D)
+ErrorChangingAttr=尝试更改下列已存在的文件属性时出错：
+ErrorCreatingTemp=尝试在目标目录创建文件时出错：
+ErrorReadingSource=尝试读取下列源文件时出错：
+ErrorCopying=尝试复制下列文件时出错：
+ErrorDownloading=尝试下载文件时出错：
+ErrorExtracting=尝试提取压缩包时出错：
+ErrorReplacingExistingFile=尝试替换已存在的文件时出错：
+ErrorRestartReplace=重启并替换失败：
+ErrorRenamingTemp=尝试重命名下列目标目录中的一个文件时出错：
+ErrorRegisterServer=无法注册 DLL/OCX：%1
+ErrorRegSvr32Failed=RegSvr32 失败；退出代码 %1。
+ErrorRegisterTypeLib=无法注册类型库：%1
+
+; *** Uninstall display name markings
+; used for example as 'My Program (32-bit)'
+UninstallDisplayNameMark=%1 (%2)
+; used for example as 'My Program (32-bit, All users)'
+UninstallDisplayNameMarks=%1 (%2, %3)
+UninstallDisplayNameMark32Bit=32 位
+UninstallDisplayNameMark64Bit=64 位
+UninstallDisplayNameMarkAllUsers=所有用户
+UninstallDisplayNameMarkCurrentUser=当前用户
+
+; *** Post-installation errors
+ErrorOpeningReadme=尝试打开自述文件时出错。
+ErrorRestartingComputer=安装程序无法重启计算机，请手动重启。
+
+; *** Uninstaller messages
+UninstallNotFound=文件“%1”不存在。无法卸载。
+UninstallOpenError=文件“%1”不能被打开。无法卸载
+UninstallUnsupportedVer=此版本的卸载程序无法识别卸载日志文件“%1”的格式。无法卸载。
+UninstallUnknownEntry=卸载日志中遇到一个未知条目（%1）。
+ConfirmUninstall=您确认要完全移除 %1 及其所有组件吗？
+UninstallOnlyOnWin64=仅允许在 64 位 Windows 中卸载此程序。
+OnlyAdminCanUninstall=仅使用管理员权限的用户能完成此卸载。
+UninstallStatusLabel=正在从您的计算机中移除 %1，请稍候。
+UninstalledAll=已顺利从您的计算机中移除 %1。
+UninstalledMost=%1 卸载完成。%n%n有部分内容未能被删除，但您可以手动删除它们。
+UninstalledAndNeedsRestart=为完成 %1 的卸载，需要重启您的计算机。%n%n要立即重启吗？
+UninstallDataCorrupted=文件“%1”已损坏。无法卸载。
+
+; *** Uninstallation phase messages
+ConfirmDeleteSharedFileTitle=删除共享文件？
+ConfirmDeleteSharedFile2=系统表示下列共享文件已不再有任何程序使用。您希望卸载程序删除此共享文件吗？%n%n如果仍有程序正在使用此文件，删除后这些程序可能无法正常运行。如果您不能确定，请选择“否”，保留此文件在系统中不会造成任何损害。
+SharedFileNameLabel=文件名：
+SharedFileLocationLabel=位置：
+WizardUninstalling=卸载状态
+StatusUninstalling=正在卸载 %1...
+
+; *** Shutdown block reasons
+ShutdownBlockReasonInstallingApp=正在安装 %1。
+ShutdownBlockReasonUninstallingApp=正在卸载 %1。
+
+; The custom messages below aren't used by Setup itself, but if you make
+; use of them in your scripts, you'll want to translate them.
+
+[CustomMessages]
+
+NameAndVersion=%1 版本 %2
+AdditionalIcons=附加快捷方式：
+CreateDesktopIcon=创建桌面快捷方式(&D)
+CreateQuickLaunchIcon=创建快速启动栏快捷方式(&Q)
+ProgramOnTheWeb=%1 网站
+UninstallProgram=卸载 %1
+LaunchProgram=运行 %1
+AssocFileExtension=将 %2 文件扩展名与 %1 建立关联(&A)
+AssocingFileExtension=正在将 %2 文件扩展名与 %1 建立关联...
+AutoStartProgramGroupDescription=启动：
+AutoStartProgram=自动启动 %1
+AddonHostProgramNotFound=您选择的文件夹中无法找到 %1。%n%n您确定要继续吗？

--- a/installer-languages/Vietnamese.isl
+++ b/installer-languages/Vietnamese.isl
@@ -1,0 +1,399 @@
+; *** Inno Setup version 6.5.0+ Vietnamese messages ***
+;
+; Vietnamese translation by memecoder (memecoder17@gmail.com)
+; Last modification date: 2023-10-26
+;
+[LangOptions]
+LanguageName=Tiếng Việt
+LanguageID=$042A
+LanguageCodePage=1258
+; If the language you are translating to requires special font faces or
+; sizes, uncomment any of the following entries and change them accordingly.
+;DialogFontName=
+;DialogFontSize=9
+;DialogFontBaseScaleWidth=7
+;DialogFontBaseScaleHeight=15
+;WelcomeFontName=Segoe UI
+;WelcomeFontSize=14
+
+[Messages]
+
+; *** Application titles
+SetupAppTitle=Cài đặt
+SetupWindowTitle=Cài đặt - %1
+UninstallAppTitle=Gỡ cài đặt
+UninstallAppFullTitle=Gỡ cài đặt %1
+
+; *** Misc. common
+InformationTitle=Thông tin
+ConfirmTitle=Xác nhận
+ErrorTitle=Lỗi
+
+; *** SetupLdr messages
+SetupLdrStartupMessage=Chương trình sẽ tiến hành cài đặt %1. Bạn có muốn tiếp tục không?
+LdrCannotCreateTemp=Không thể tạo tệp tạm thời. Đã hủy quá trình cài đặt
+LdrCannotExecTemp=Không thể mở tệp trong thư mục tạm. Đã hủy quá trình cài đặt
+HelpTextNote=
+
+; *** Startup error messages
+LastErrorMessage=%1.%n%nLỗi %2: %3
+SetupFileMissing=Không tìm thấy tệp %1 trong thư mục cài đặt. Vui lòng kiểm tra lại hoặc tải một bản cài đặt mới.
+SetupFileCorrupt=Các tệp cài đặt đã bị hỏng. Vui lòng tải lại một bản cài đặt mới.
+SetupFileCorruptOrWrongVer=Các tệp cài đặt đã bị hỏng hoặc không tương thích với phiên bản hiện tại. Vui lòng tải lại một bản cài đặt mới.
+InvalidParameter=Lệnh truyền vào không hợp lệ:%n%n%1
+SetupAlreadyRunning=Chương trình cài đặt này đang được chạy rồi.
+WindowsVersionNotSupported=Phần mềm này không hỗ trợ phiên bản Windows mà máy tính của bạn đang sử dụng.
+WindowsServicePackRequired=Phần mềm này yêu cầu %1 Service Pack %2 hoặc mới hơn.
+NotOnThisPlatform=Phần mềm này sẽ không hoạt động trên %1.
+OnlyOnThisPlatform=Phần mềm này chỉ có thể hoạt động trên %1.
+OnlyOnTheseArchitectures=Phần mềm này chỉ có thể cài đặt trên các phiên bản Windows hỗ trợ cấu trúc vi xử lý sau:%n%n%1
+WinVersionTooLowError=Phần mềm này yêu cầu %1 phiên bản %2 hoặc mới hơn.
+WinVersionTooHighError=Không thể cài phần mềm này trên %1 phiên bản %2 hoặc mới hơn.
+AdminPrivilegesRequired=Bạn cần đăng nhập bằng tài khoản Quản trị viên (Administrator) để cài đặt phần mềm này.
+PowerUserPrivilegesRequired=Bạn cần đăng nhập bằng tài khoản Quản trị viên (Admin) hoặc thuộc nhóm Power Users để cài đặt phần mềm này.
+SetupAppRunningError=Hệ thống phát hiện %1 hiện đang chạy.%n%nVui lòng đóng tất cả các cửa sổ của ứng dụng đó lại, sau đó nhấn OK để tiếp tục, hoặc nhấn Hủy để thoát.
+UninstallAppRunningError=Hệ thống phát hiện %1 hiện đang chạy.%n%nVui lòng đóng tất cả các cửa sổ của ứng dụng đó lại, sau đó nhấn OK để tiếp tục, hoặc nhấn Hủy để thoát.
+
+; *** Startup questions
+PrivilegesRequiredOverrideTitle=Chọn Chế độ Cài đặt
+PrivilegesRequiredOverrideInstruction=Bạn muốn cài đặt theo chế độ nào?
+PrivilegesRequiredOverrideText1=Bạn có thể cài đặt %1 cho tất cả mọi người dùng chung máy tính này (yêu cầu quyền Admin), hoặc chỉ cài cho riêng bạn.
+PrivilegesRequiredOverrideText2=Bạn có thể cài đặt %1 cho riêng bạn, hoặc cài cho tất cả mọi người dùng chung máy tính này (yêu cầu quyền Admin).
+PrivilegesRequiredOverrideAllUsers=Cài đặt cho &tất cả người dùng
+PrivilegesRequiredOverrideAllUsersRecommended=Cài cho &tất cả người dùng (Khuyên dùng)
+PrivilegesRequiredOverrideCurrentUser=Chỉ cài cho &riêng tôi
+PrivilegesRequiredOverrideCurrentUserRecommended=Chỉ cài cho &riêng tôi (Khuyên dùng)
+
+; *** Misc. errors
+ErrorCreatingDir=Không thể tạo thư mục "%1"
+ErrorTooManyFilesInDir=Không thể tạo tệp trong thư mục "%1" vì bên trong đã có quá nhiều tệp
+
+; *** Setup common messages
+ExitSetupTitle=Thoát Cài đặt
+ExitSetupMessage=Quá trình cài đặt chưa hoàn tất. Nếu bạn thoát bây giờ, phần mềm sẽ không được cài vào máy.%n%nBạn có thể mở lại trình cài đặt này vào lúc khác.%n%nBạn có chắc chắn muốn thoát không?
+AboutSetupMenuItem=&Thông tin về trình cài đặt...
+AboutSetupTitle=Thông tin về trình cài đặt
+AboutSetupMessage=%1 phiên bản %2%n%3%n%nTrang chủ %1:%n%4
+AboutSetupNote=
+TranslatorNote=Vietnamese translation by memecoder
+
+; *** Buttons
+ButtonBack=< &Quay lại
+ButtonNext=&Tiếp theo >
+ButtonInstall=&Cài đặt
+ButtonOK=OK
+ButtonCancel=Hủy
+ButtonYes=&Có
+ButtonYesToAll=Có với &Tất cả
+ButtonNo=&Không
+ButtonNoToAll=Khôn&g với Tất cả
+ButtonFinish=&Hoàn tất
+ButtonBrowse=&Duyệt...
+ButtonWizardBrowse=D&uyệt...
+ButtonNewFolder=&Tạo thư mục mới
+
+; *** "Select Language" dialog messages
+SelectLanguageTitle=Chọn ngôn ngữ cài đặt
+SelectLanguageLabel=Vui lòng chọn ngôn ngữ bạn muốn sử dụng trong quá trình cài đặt.
+
+; *** Common wizard text
+ClickNext=Nhấn 'Tiếp theo' để tiếp tục, hoặc 'Hủy' để thoát.
+BeveledLabel=
+BrowseDialogTitle=Chọn thư mục
+BrowseDialogLabel=Vui lòng chọn một thư mục trong danh sách bên dưới, sau đó nhấn OK.
+NewFolderName=Thư mục mới
+
+; *** "Welcome" wizard page
+WelcomeLabel1=Chào mừng bạn đến với Cài đặt [name]
+WelcomeLabel2=Chương trình sẽ cài đặt [name/ver] lên máy tính của bạn.%n%nBạn nên đóng tất cả các ứng dụng khác trước khi tiếp tục để đảm bảo quá trình cài đặt diễn ra suôn sẻ.
+
+; *** "Password" wizard page
+WizardPassword=Mật khẩu
+PasswordLabel1=Bộ cài đặt này được bảo vệ bằng mật khẩu.
+PasswordLabel3=Vui lòng nhập mật khẩu, sau đó nhấn 'Tiếp theo'. Lưu ý: Mật khẩu có phân biệt chữ hoa và chữ thường.
+PasswordEditLabel=&Mật khẩu:
+IncorrectPassword=Mật khẩu bạn nhập chưa đúng. Vui lòng thử lại nhé.
+
+; *** "License Agreement" wizard page
+WizardLicense=Thỏa thuận Sử dụng
+LicenseLabel=Vui lòng đọc kỹ các thông tin quan trọng dưới đây trước khi tiếp tục.
+LicenseLabel3=Vui lòng đọc Thỏa thuận Sử dụng sau đây. Bạn cần đồng ý với các điều khoản này để tiếp tục cài đặt.
+LicenseAccepted=Tôi &đồng ý với các điều khoản trên
+LicenseNotAccepted=Tôi &không đồng ý
+
+; *** "Information" wizard pages
+WizardInfoBefore=Thông tin
+InfoBeforeLabel=Vui lòng đọc kỹ các thông tin quan trọng dưới đây trước khi tiếp tục.
+InfoBeforeClickLabel=Khi bạn đã sẵn sàng tiếp tục, hãy nhấn 'Tiếp theo'.
+WizardInfoAfter=Thông tin
+InfoAfterLabel=Vui lòng đọc kỹ các thông tin quan trọng dưới đây trước khi tiếp tục.
+InfoAfterClickLabel=Khi bạn đã sẵn sàng tiếp tục, hãy nhấn 'Tiếp theo'.
+
+; *** "User Information" wizard page
+WizardUserInfo=Thông tin người dùng
+UserInfoDesc=Vui lòng điền thông tin của bạn.
+UserInfoName=&Tên người dùng:
+UserInfoOrg=&Tổ chức / Công ty:
+UserInfoSerial=&Mã bản quyền (Serial Number):
+UserInfoNameRequired=Bạn không được để trống tên.
+
+; *** "Select Destination Location" wizard page
+WizardSelectDir=Chọn vị trí cài đặt
+SelectDirDesc=Bạn muốn cài đặt [name] ở đâu?
+SelectDirLabel3=Chương trình sẽ được cài đặt vào thư mục dưới đây.
+SelectDirBrowseLabel=Nhấn 'Tiếp theo' để tiếp tục. Nếu bạn muốn chọn một thư mục khác, hãy nhấn 'Duyệt'.
+DiskSpaceGBLabel=Cần ít nhất [gb] GB dung lượng trống trên ổ đĩa.
+DiskSpaceMBLabel=Cần ít nhất [mb] MB dung lượng trống trên ổ đĩa.
+CannotInstallToNetworkDrive=Không thể cài đặt phần mềm lên ổ đĩa mạng.
+CannotInstallToUNCPath=Không thể cài đặt phần mềm vào đường dẫn mạng (UNC).
+InvalidPath=Bạn cần nhập đường dẫn đầy đủ có chứa tên ổ đĩa, ví dụ:%n%nC:\APP%n%nhoặc một đường dẫn mạng có dạng:%n%n\\may-chu\thu-muc
+InvalidDrive=Ổ đĩa hoặc đường dẫn mạng bạn chọn không tồn tại hoặc không thể truy cập. Vui lòng chọn một vị trí khác.
+DiskSpaceWarningTitle=Không đủ dung lượng trống
+DiskSpaceWarning=Cần ít nhất %1 KB dung lượng trống để cài đặt, nhưng ổ đĩa bạn chọn hiện chỉ còn %2 KB.%n%nBạn có vẫn muốn tiếp tục không?
+DirNameTooLong=Tên thư mục hoặc đường dẫn quá dài.
+InvalidDirName=Tên thư mục không hợp lệ.
+BadDirName32=Tên thư mục không được chứa bất kỳ ký tự nào sau đây:%n%n%1
+DirExistsTitle=Thư mục đã tồn tại
+DirExists=Thư mục:%n%n%1%n%nđã tồn tại. Bạn có vẫn muốn cài đè vào thư mục này không?
+DirDoesntExistTitle=Thư mục không tồn tại
+DirDoesntExist=Thư mục:%n%n%1%n%nhiện chưa có sẵn. Bạn có muốn tạo mới thư mục này không?
+
+; *** "Select Components" wizard page
+WizardSelectComponents=Chọn thành phần cài đặt
+SelectComponentsDesc=Bạn muốn cài đặt những thành phần nào?
+SelectComponentsLabel2=Đánh dấu vào các thành phần bạn muốn cài, và bỏ dấu tick ở những phần bạn không cần. Nhấn 'Tiếp theo' khi bạn đã sẵn sàng.
+FullInstallation=Cài đặt đầy đủ
+; if possible don't translate 'Compact' as 'Minimal' (I mean 'Minimal' in your language)
+CompactInstallation=Cài đặt thu gọn
+CustomInstallation=Cài đặt tùy chọn
+NoUninstallWarningTitle=Thành phần đã tồn tại
+NoUninstallWarning=Hệ thống phát hiện các thành phần sau đã có sẵn trên máy tính của bạn:%n%n%1%n%nViệc bỏ chọn các thành phần này sẽ KHÔNG gỡ cài đặt chúng.%n%nBạn có vẫn muốn tiếp tục không?
+ComponentSize1=%1 KB
+ComponentSize2=%1 MB
+ComponentsDiskSpaceGBLabel=Các mục bạn chọn yêu cầu ít nhất [gb] GB dung lượng trống.
+ComponentsDiskSpaceMBLabel=Các mục bạn chọn yêu cầu ít nhất [mb] MB dung lượng trống.
+
+; *** "Select Additional Tasks" wizard page
+WizardSelectTasks=Các thiết lập bổ sung
+SelectTasksDesc=Bạn muốn thực hiện thêm các tùy chọn nào?
+SelectTasksLabel2=Chọn các thiết lập bổ sung mà bạn muốn thực hiện khi cài đặt [name], sau đó nhấn 'Tiếp theo'.
+
+; *** "Select Start Menu Folder" wizard page
+WizardSelectProgramGroup=Chọn thư mục trên Start Menu
+SelectStartMenuFolderDesc=Bạn muốn đặt biểu tượng của ứng dụng ở đâu?
+SelectStartMenuFolderLabel3=Chương trình sẽ tạo các biểu tượng ứng dụng trong thư mục Start Menu dưới đây.
+SelectStartMenuFolderBrowseLabel=Nhấn 'Tiếp theo' để tiếp tục. Nếu bạn muốn chọn thư mục khác, hãy nhấn 'Duyệt'.
+MustEnterGroupName=Bạn cần nhập một tên cho thư mục.
+GroupNameTooLong=Tên thư mục hoặc đường dẫn quá dài.
+InvalidGroupName=Tên thư mục không hợp lệ.
+BadGroupName=Tên thư mục không được chứa bất kỳ ký tự nào sau đây:%n%n%1
+NoProgramGroupCheck2=&Không tạo thư mục trên Start Menu
+
+; *** "Ready to Install" wizard page
+WizardReady=Sẵn sàng Cài đặt
+ReadyLabel1=Mọi thứ đã sẵn sàng. Chương trình sẽ bắt đầu cài đặt [name] lên máy tính của bạn.
+ReadyLabel2a=Nhấn 'Cài đặt' để bắt đầu, hoặc nhấn 'Quay lại' nếu bạn muốn xem lại hoặc thay đổi các thiết lập.
+ReadyLabel2b=Nhấn 'Cài đặt' để bắt đầu quá trình.
+ReadyMemoUserInfo=Thông tin người dùng:
+ReadyMemoDir=Vị trí cài đặt:
+ReadyMemoType=Kiểu cài đặt:
+ReadyMemoComponents=Các thành phần đã chọn:
+ReadyMemoGroup=Thư mục Start Menu:
+ReadyMemoTasks=Thiết lập bổ sung:
+
+; *** TDownloadWizardPage wizard page and DownloadTemporaryFile
+DownloadingLabel2=Đang tải tệp xuống...
+ButtonStopDownload=&Dừng tải xuống
+StopDownload=Bạn có chắc chắn muốn dừng việc tải xuống không?
+ErrorDownloadAborted=Quá trình tải xuống đã bị hủy
+ErrorDownloadFailed=Tải xuống thất bại: %1 %2
+ErrorDownloadSizeFailed=Không thể lấy thông tin dung lượng tệp: %1 %2
+ErrorProgress=Tiến trình tải bị lỗi: %1 / %2
+ErrorFileSize=Dung lượng tệp bị lỗi: mong đợi %1, nhưng thực tế là %2
+
+; *** TExtractionWizardPage wizard page and ExtractArchive
+ExtractingLabel=Đang giải nén tệp...
+ButtonStopExtraction=&Dừng giải nén
+StopExtraction=Bạn có chắc chắn muốn dừng việc giải nén không?
+ErrorExtractionAborted=Quá trình giải nén đã bị hủy
+ErrorExtractionFailed=Giải nén thất bại: %1
+
+; *** Archive extraction failure details
+ArchiveIncorrectPassword=Mật khẩu giải nén không đúng
+ArchiveIsCorrupted=Tệp nén đã bị hỏng
+ArchiveUnsupportedFormat=Định dạng tệp nén này không được hỗ trợ
+
+; *** "Preparing to Install" wizard page
+WizardPreparing=Đang chuẩn bị Cài đặt
+PreparingDesc=Hệ thống đang chuẩn bị cài đặt [name] lên máy tính của bạn.
+PreviousInstallNotCompleted=Quá trình cài đặt/gỡ cài đặt của một chương trình trước đó chưa hoàn tất. Bạn cần khởi động lại máy tính để hoàn tất quá trình đó.%n%nSau khi máy tính khởi động lại, hãy chạy lại bản cài đặt này để tiếp tục cài đặt [name].
+CannotContinue=Không thể tiếp tục cài đặt. Vui lòng nhấn 'Hủy' để thoát.
+ApplicationsFound=Các ứng dụng sau đang sử dụng những tệp tin cần được cập nhật. Bạn nên cho phép tự động đóng các ứng dụng này lại để tiếp tục cài đặt.
+ApplicationsFound2=Các ứng dụng sau đang sử dụng những tệp tin cần được cập nhật. Bạn nên cho phép tự động đóng các ứng dụng này lại. Sau khi cài đặt xong, hệ thống sẽ cố gắng mở lại chúng cho bạn.
+CloseApplications=&Tự động đóng các ứng dụng trên
+DontCloseApplications=&Không đóng các ứng dụng
+ErrorCloseApplications=Hệ thống không thể tự động đóng tất cả các ứng dụng. Tốt nhất là bạn nên tự đóng các ứng dụng đang dùng chung tệp tin với bản cài đặt này trước khi tiếp tục.
+PrepareToInstallNeedsRestart=Cần khởi động lại máy tính. Sau khi máy tính khởi động xong, hãy chạy lại tệp này để hoàn tất cài đặt [name].%n%nBạn có muốn khởi động lại ngay bây giờ không?
+
+; *** "Installing" wizard page
+WizardInstalling=Đang cài đặt
+InstallingLabel=Vui lòng đợi trong giây lát, [name] đang được cài đặt vào máy tính của bạn.
+
+; *** "Setup Completed" wizard page
+FinishedHeadingLabel=Đã hoàn tất quá trình cài đặt [name]
+FinishedLabelNoIcons=Quá trình cài đặt [name] đã thành công tốt đẹp.
+FinishedLabel=Quá trình cài đặt [name] đã thành công tốt đẹp. Bạn có thể mở ứng dụng bằng các biểu tượng vừa được tạo.
+ClickFinish=Nhấn 'Hoàn tất' để thoát khỏi chương trình cài đặt.
+FinishedRestartLabel=Để việc cài đặt [name] hoàn tất 100%, máy tính của bạn cần được khởi động lại. Bạn có muốn khởi động lại ngay bây giờ không?
+FinishedRestartMessage=Để việc cài đặt [name] hoàn tất 100%, máy tính của bạn cần được khởi động lại.%n%nBạn có muốn khởi động lại ngay bây giờ không?
+ShowReadmeCheck=Có, tôi muốn xem tệp hướng dẫn (README)
+YesRadio=&Có, khởi động lại máy tính ngay bây giờ
+NoRadio=&Không, tôi sẽ tự khởi động lại sau
+; used for example as 'Run MyProg.exe'
+RunEntryExec=Mở %1
+; used for example as 'View Readme.txt'
+RunEntryShellExec=Xem tệp %1
+
+; *** "Setup Needs the Next Disk" stuff
+ChangeDiskTitle=Cần đưa đĩa tiếp theo vào
+SelectDiskLabel2=Vui lòng đưa Đĩa số %1 vào và nhấn OK.%n%nNếu các tệp tin của đĩa này nằm ở một thư mục khác với đường dẫn bên dưới, hãy nhập lại đường dẫn cho đúng hoặc nhấn 'Duyệt'.
+PathLabel=&Đường dẫn:
+FileNotInDir2=Không tìm thấy tệp "%1" trong "%2". Vui lòng đưa đúng đĩa vào hoặc chọn thư mục khác.
+SelectDirectoryLabel=Vui lòng chỉ định vị trí chứa đĩa tiếp theo.
+
+; *** Installation phase messages
+SetupAborted=Quá trình cài đặt chưa được hoàn tất.%n%nVui lòng khắc phục sự cố và chạy lại cài đặt sau.
+AbortRetryIgnoreSelectAction=Chọn hành động
+AbortRetryIgnoreRetry=&Thử lại
+AbortRetryIgnoreIgnore=&Bỏ qua lỗi này và tiếp tục
+AbortRetryIgnoreCancel=Hủy quá trình cài đặt
+RetryCancelSelectAction=Chọn hành động
+RetryCancelRetry=&Thử lại
+RetryCancelCancel=Hủy
+
+; *** Installation status messages
+StatusClosingApplications=Đang đóng các ứng dụng...
+StatusCreateDirs=Đang tạo các thư mục...
+StatusExtractFiles=Đang giải nén tệp...
+StatusDownloadFiles=Đang tải tệp xuống...
+StatusCreateIcons=Đang tạo biểu tượng ứng dụng...
+StatusCreateIniEntries=Đang tạo các mục cấu hình INI...
+StatusCreateRegistryEntries=Đang thiết lập Registry...
+StatusRegisterFiles=Đang đăng ký hệ thống tệp...
+StatusSavingUninstall=Đang lưu thông tin để gỡ cài đặt sau này...
+StatusRunProgram=Đang hoàn thành những bước cuối cùng...
+StatusRestartingApplications=Đang khởi động lại ứng dụng...
+StatusRollback=Đang khôi phục lại các thay đổi...
+
+; *** Misc. errors
+ErrorInternal2=Lỗi hệ thống nội bộ: %1
+ErrorFunctionFailedNoCode=%1 đã thất bại
+ErrorFunctionFailed=%1 đã thất bại; mã lỗi %2
+ErrorFunctionFailedWithMessage=%1 đã thất bại; mã lỗi %2.%n%3
+ErrorExecutingProgram=Không thể chạy tệp:%n%1
+
+; *** Registry errors
+ErrorRegOpenKey=Gặp lỗi khi mở khóa registry:%n%1\%2
+ErrorRegCreateKey=Gặp lỗi khi tạo khóa registry:%n%1\%2
+ErrorRegWriteKey=Gặp lỗi khi ghi dữ liệu vào khóa registry:%n%1\%2
+
+; *** INI errors
+ErrorIniEntry=Gặp lỗi khi tạo mục INI trong tệp "%1".
+
+; *** File copying errors
+FileAbortRetryIgnoreSkipNotRecommended=&Bỏ qua tệp này (Không khuyên dùng)
+FileAbortRetryIgnoreIgnoreNotRecommended=&Bỏ qua lỗi này và tiếp tục (Không khuyên dùng)
+SourceIsCorrupted=Tệp nguồn đã bị hỏng
+SourceDoesntExist=Tệp nguồn "%1" không tồn tại
+SourceVerificationFailed=Không thể xác minh tệp nguồn: %1
+VerificationSignatureDoesntExist=Không tìm thấy tệp chữ ký (signature) "%1"
+VerificationSignatureInvalid=Tệp chữ ký "%1" không hợp lệ
+VerificationKeyNotFound=Tệp chữ ký "%1" sử dụng một khóa lạ không xác định được
+VerificationFileNameIncorrect=Tên tệp không đúng
+VerificationFileTagIncorrect=Thẻ (tag) của tệp không đúng
+VerificationFileSizeIncorrect=Dung lượng tệp không đúng
+VerificationFileHashIncorrect=Mã băm (hash) của tệp không đúng
+ExistingFileReadOnly2=Không thể ghi đè lên tệp hiện tại vì tệp đó đang ở chế độ Chỉ đọc (Read-only).
+ExistingFileReadOnlyRetry=&Xóa thuộc tính Chỉ đọc và thử lại
+ExistingFileReadOnlyKeepExisting=&Giữ nguyên tệp hiện tại
+ErrorReadingExistingDest=Đã xảy ra lỗi khi cố gắng đọc tệp hiện có:
+FileExistsSelectAction=Chọn hành động
+FileExists2=Tệp này đã tồn tại.
+FileExistsOverwriteExisting=&Ghi đè lên tệp hiện có
+FileExistsKeepExisting=&Giữ nguyên tệp hiện tại
+FileExistsOverwriteOrKeepAll=&Áp dụng hành động này cho các xung đột tiếp theo
+ExistingFileNewerSelectAction=Chọn hành động
+ExistingFileNewer2=Tệp hiện có trên máy tính của bạn còn mới hơn cả tệp đang chuẩn bị được cài đặt.
+ExistingFileNewerOverwriteExisting=&Ghi đè lên tệp hiện có
+ExistingFileNewerKeepExisting=&Giữ nguyên tệp hiện tại (Khuyên dùng)
+ExistingFileNewerOverwriteOrKeepAll=&Áp dụng hành động này cho các xung đột tiếp theo
+ErrorChangingAttr=Đã xảy ra lỗi khi cố gắng thay đổi thuộc tính của tệp:
+ErrorCreatingTemp=Đã xảy ra lỗi khi cố gắng tạo một tệp trong thư mục đích:
+ErrorReadingSource=Đã xảy ra lỗi khi cố gắng đọc tệp nguồn:
+ErrorCopying=Đã xảy ra lỗi khi cố gắng sao chép một tệp:
+ErrorDownloading=Đã xảy ra lỗi trong quá trình tải tệp xuống:
+ErrorExtracting=Đã xảy ra lỗi trong quá trình giải nén:
+ErrorReplacingExistingFile=Đã xảy ra lỗi khi cố gắng thay thế tệp hiện tại:
+ErrorRestartReplace=Hành động khởi động lại và thay thế (RestartReplace) thất bại:
+ErrorRenamingTemp=Đã xảy ra lỗi khi cố gắng đổi tên một tệp trong thư mục cài đặt:
+ErrorRegisterServer=Không thể đăng ký tệp DLL/OCX: %1
+ErrorRegSvr32Failed=Lệnh RegSvr32 đã thất bại với mã thoát: %1
+ErrorRegisterTypeLib=Không thể đăng ký thư viện định dạng (type library): %1
+
+; *** Uninstall display name markings
+; used for example as 'My Program (32-bit)'
+UninstallDisplayNameMark=%1 (%2)
+; used for example as 'My Program (32-bit, All users)'
+UninstallDisplayNameMarks=%1 (%2, %3)
+UninstallDisplayNameMark32Bit=32-bit
+UninstallDisplayNameMark64Bit=64-bit
+UninstallDisplayNameMarkAllUsers=Tất cả người dùng
+UninstallDisplayNameMarkCurrentUser=Người dùng hiện tại
+
+; *** Post-installation errors
+ErrorOpeningReadme=Đã xảy ra lỗi khi cố gắng mở tệp hướng dẫn (README).
+ErrorRestartingComputer=Hệ thống không thể tự động khởi động lại máy tính. Vui lòng tự khởi động lại bằng tay nhé.
+
+; *** Uninstaller messages
+UninstallNotFound=Tệp "%1" không tồn tại. Không thể thực hiện gỡ cài đặt.
+UninstallOpenError=Không thể mở tệp "%1". Không thể thực hiện gỡ cài đặt
+UninstallUnsupportedVer=Tệp nhật ký gỡ cài đặt "%1" có định dạng không tương thích với phiên bản gỡ cài đặt này. Không thể gỡ
+UninstallUnknownEntry=Phát hiện một mục lạ (%1) trong nhật ký gỡ cài đặt
+ConfirmUninstall=Bạn có chắc chắn muốn gỡ bỏ hoàn toàn %1 và tất cả các thành phần đi kèm không?
+UninstallOnlyOnWin64=Phần mềm này chỉ có thể được gỡ cài đặt trên nền tảng Windows 64-bit.
+OnlyAdminCanUninstall=Chỉ người dùng có quyền Quản trị viên (Admin) mới có thể gỡ bỏ ứng dụng này.
+UninstallStatusLabel=Vui lòng đợi trong giây lát, %1 đang được gỡ bỏ khỏi máy tính của bạn.
+UninstalledAll=%1 đã được gỡ bỏ hoàn toàn khỏi máy tính của bạn.
+UninstalledMost=Quá trình gỡ bỏ %1 đã hoàn tất.%n%nTuy nhiên có một số thành phần không thể tự động xóa được. Bạn có thể tự tìm và xóa chúng bằng tay.
+UninstalledAndNeedsRestart=Để hoàn tất việc gỡ bỏ %1, máy tính của bạn cần được khởi động lại.%n%nBạn có muốn khởi động lại ngay bây giờ không?
+UninstallDataCorrupted=Tệp "%1" đã bị hỏng. Không thể thực hiện gỡ cài đặt
+
+; *** Uninstallation phase messages
+ConfirmDeleteSharedFileTitle=Xóa các tệp dùng chung?
+ConfirmDeleteSharedFile2=Hệ thống phát hiện tệp dùng chung sau đây dường như không còn được ứng dụng nào sử dụng nữa. Bạn có muốn trình gỡ cài đặt xóa luôn tệp này không?%n%nLưu ý: Nếu vẫn còn ứng dụng khác sử dụng tệp này mà bạn lại xóa nó đi, các ứng dụng đó có thể sẽ bị lỗi. Nếu bạn không chắc chắn, hãy chọn 'Không'. Việc giữ lại tệp này trên máy tính hoàn toàn không gây hại gì cả.
+SharedFileNameLabel=Tên tệp:
+SharedFileLocationLabel=Vị trí:
+WizardUninstalling=Trạng thái gỡ cài đặt
+StatusUninstalling=Đang gỡ cài đặt %1...
+
+; *** Shutdown block reasons
+ShutdownBlockReasonInstallingApp=Đang trong quá trình cài đặt %1.
+ShutdownBlockReasonUninstallingApp=Đang trong quá trình gỡ cài đặt %1.
+
+; The custom messages below aren't used by Setup itself, but if you make
+; use of them in your scripts, you'll want to translate them.
+
+[CustomMessages]
+
+NameAndVersion=%1 phiên bản %2
+AdditionalIcons=Các biểu tượng tùy chọn thêm:
+CreateDesktopIcon=Tạo biểu tượng trên &Màn hình chính (Desktop)
+CreateQuickLaunchIcon=Tạo biểu tượng khởi động nhanh (&Quick Launch)
+ProgramOnTheWeb=Trang chủ %1
+UninstallProgram=Gỡ cài đặt %1
+LaunchProgram=Mở %1
+AssocFileExtension=&Sử dụng %1 làm phần mềm mặc định để mở các tệp %2
+AssocingFileExtension=Đang thiết lập để %1 mở các tệp %2...
+AutoStartProgramGroupDescription=Khởi động cùng máy tính:
+AutoStartProgram=Tự động chạy %1 khi mở máy
+AddonHostProgramNotFound=Không tìm thấy %1 trong thư mục bạn vừa chọn.%n%nBạn có vẫn muốn tiếp tục không?

--- a/setup.iss
+++ b/setup.iss
@@ -48,8 +48,8 @@ ArchitecturesInstallIn64BitMode=x64compatible
 [Languages]
 Name: "japanese"; MessagesFile: "compiler:Languages\Japanese.isl"
 Name: "english"; MessagesFile: "compiler:Default.isl"
-Name: "vietnamese"; MessagesFile: "compiler:Languages\Vietnamese.isl"
-Name: "chinese"; MessagesFile: "compiler:Languages\ChineseSimplified.isl"
+Name: "vietnamese"; MessagesFile: "installer-languages\Vietnamese.isl"
+Name: "chinese"; MessagesFile: "installer-languages\ChineseSimplified.isl"
 
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked


### PR DESCRIPTION
## Summary
Inno Setup の標準インストールに含まれないベトナム語と簡体字中国語の言語ファイルをリポジトリで管理し、4 言語構成のセットアップを再現可能にコンパイルできるようにします。

## Implementation checklist
- [x] Implement #30 — Inno Setup のベトナム語言語ファイルを同梱してインストーラーをビルド可能にする

## Verification checklist
- [x] Self-review of the diff completed
- [x] `ISCC.exe setup.iss` pass
- [x] Setup EXE output confirmed
- [x] `Check & Build` pass
- [x] `Linux package` pass
- [x] No secrets or private configuration in the diff
- [x] No AI attribution trailers in commits or comments
- [x] Cubic review completed without new valid findings

## References
Closes #30

検証済み: Inno Setup 6.7.0 で `setup.iss` をコンパイルし、`artifacts/installer/DocumentManager_v4.0.0_Setup.exe` の生成を確認しました。

外部の `Vercel` deployment status は失敗していますが、変更対象は Avalonia/.NET の Inno Setup 言語ファイルのみであり、`Vercel Preview Comments`、`Check & Build`、`Linux package`、`cubic · AI code reviewer` は成功しています。このデプロイ失敗は変更内容と無関係な外部設定として記録します。