### PR TITLE
Windows リリースビルドを自己完結配布に統一する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -377,3 +377,4 @@ scripts/
 !scripts/
 scripts/*
 !scripts/build-windows-setup.ps1
+!scripts/verify-windows-installer.ps1

--- a/.gitignore
+++ b/.gitignore
@@ -374,3 +374,6 @@ redist/
 .harness-backup/
 docs/
 scripts/
+!scripts/
+scripts/*
+!scripts/build-windows-setup.ps1

--- a/StudyDocumentManager.Data/Helpers/DatabaseHelper.cs
+++ b/StudyDocumentManager.Data/Helpers/DatabaseHelper.cs
@@ -11,6 +11,7 @@ namespace StudyDocumentManager.Data.Helpers;
 /// </summary>
 public class DatabaseHelper
 {
+    private const string DatabasePathEnvironmentVariable = "SDM_DATABASE_PATH";
     private string? _databasePath;
     private string? _connectionString;
 
@@ -50,6 +51,15 @@ public class DatabaseHelper
 
     private static string GetDefaultDatabasePath()
     {
+        var configuredPath = Environment.GetEnvironmentVariable(DatabasePathEnvironmentVariable);
+        if (!string.IsNullOrWhiteSpace(configuredPath))
+        {
+            if (!Path.IsPathFullyQualified(configuredPath))
+                throw new InvalidOperationException($"{DatabasePathEnvironmentVariable} must be an absolute path.");
+
+            return Path.GetFullPath(configuredPath);
+        }
+
         var localAppData = Environment.GetFolderPath(
             Environment.SpecialFolder.LocalApplicationData,
             Environment.SpecialFolderOption.DoNotVerify);

--- a/StudyDocumentManager.Tests/ViewModelLogicTests.cs
+++ b/StudyDocumentManager.Tests/ViewModelLogicTests.cs
@@ -35,6 +35,24 @@ public class DatabaseHelperDefaultPathTests
     }
 
     [Fact]
+    public void DatabasePath_WhenEnvironmentOverrideIsSet_ReturnsConfiguredPath()
+    {
+        var originalPath = Environment.GetEnvironmentVariable("SDM_DATABASE_PATH");
+        var configuredPath = Path.Combine(Path.GetTempPath(), $"sdm_override_{Guid.NewGuid():N}.db");
+
+        try
+        {
+            Environment.SetEnvironmentVariable("SDM_DATABASE_PATH", configuredPath);
+
+            Assert.Equal(Path.GetFullPath(configuredPath), new DatabaseHelper().DatabasePath);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("SDM_DATABASE_PATH", originalPath);
+        }
+    }
+
+    [Fact]
     public void InitializeDatabase_WhenDataFolderMissing_CreatesIt()
     {
         var tempRoot = Path.Combine(Path.GetTempPath(), $"sdm_mkdirtest_{Guid.NewGuid():N}");

--- a/docs/plans/active/2026-08-12-installer-language-selection.md
+++ b/docs/plans/active/2026-08-12-installer-language-selection.md
@@ -57,8 +57,8 @@ Out of scope:
 - [x] Apply language before `Resources["Loc"]` registration and `MainWindowModel` creation.
 - [x] Add four Inno Setup language entries and Windows UI language detection.
 - [x] Add resolver tests and run Debug/Release verification.
-- [ ] Run Inno Setup compiler syntax/build verification when `ISCC.exe` is available.
-- [ ] Re-read review threads and CI, then mark Issue and PR verification complete.
+- [x] Run Inno Setup compiler syntax/build verification with Inno Setup 6.7.0 and verify `DocumentManager_v4.0.0_Setup.exe` output.
+- [ ] Run installer lifecycle verification from a clean Windows environment, then re-read review threads and CI.
 
 ## Decisions
 

--- a/docs/plans/active/2026-08-12-installer-language-selection.md
+++ b/docs/plans/active/2026-08-12-installer-language-selection.md
@@ -69,7 +69,7 @@ Out of scope:
 ## Validation
 
 - Focused proof: `SupportedLanguageResolverTests`, 8 passing cases for supported, unsupported, saved, and invalid values.
-- Integration or end-to-end proof: Release build succeeded with 0 warnings and 0 errors; Release test suite passed 900/900. Inno Setup 6.7.0 built `DocumentManager_v4.0.0_Setup.exe`; `Check & Build`, Linux package, and Vercel Preview checks passed on PR #33.
+- Integration or end-to-end proof: Release build succeeded with 0 warnings and 0 errors; Release test suite passed 901/901. Inno Setup 6.7.0 built `DocumentManager_v4.0.0_Setup.exe`; `Check & Build`, Linux package, and Vercel Preview checks passed on PR #33.
 - Repository-required checks: `git diff --check` passed. The remaining installer proof requires a clean Windows VM for standard-user/UAC behavior and user-data retention.
 
 ## Result

--- a/docs/plans/active/2026-08-12-installer-language-selection.md
+++ b/docs/plans/active/2026-08-12-installer-language-selection.md
@@ -69,9 +69,9 @@ Out of scope:
 ## Validation
 
 - Focused proof: `SupportedLanguageResolverTests`, 8 passing cases for supported, unsupported, saved, and invalid values.
-- Integration or end-to-end proof: Release build succeeded with 0 warnings and 0 errors; Release test suite passed 896/896. Linux package and Vercel checks passed on PR #29.
-- Repository-required checks: `git diff --check` passed. Inno Setup compiler syntax check is pending because `ISCC.exe` is unavailable in the current environment.
+- Integration or end-to-end proof: Release build succeeded with 0 warnings and 0 errors; Release test suite passed 900/900. Inno Setup 6.7.0 built `DocumentManager_v4.0.0_Setup.exe`; `Check & Build`, Linux package, and Vercel Preview checks passed on PR #33.
+- Repository-required checks: `git diff --check` passed. The remaining installer proof requires a clean Windows VM for standard-user/UAC behavior and user-data retention.
 
 ## Result
 
-Pending final review and installer compiler verification. The implementation is not complete until valid review findings are resolved, CI is green, and the remaining verification limitation is either proven by CI or documented as an external dependency.
+Installer language entries and OS-locale startup resolution are implemented and compiler-verified. The clean-VM installer lifecycle and desktop runtime smoke gates remain release requirements; valid review findings and CI failures must be resolved before a marketing release.

--- a/scripts/build-windows-setup.ps1
+++ b/scripts/build-windows-setup.ps1
@@ -47,6 +47,9 @@ dotnet publish "StudyDocumentManager\StudyDocumentManager.csproj" `
     -p:DebugSymbols=false `
     -p:Version=$Version `
     -o $publishDir
+if ($LASTEXITCODE -ne 0) {
+    throw "dotnet publish failed with exit code $LASTEXITCODE"
+}
 
 $publishedExe = Join-Path $publishDir "DocumentManager.exe"
 if (-not (Test-Path $publishedExe)) {
@@ -54,6 +57,9 @@ if (-not (Test-Path $publishedExe)) {
 }
 
 & $isccPath "/DMyAppVersion=$Version" "/DPublishDir=$publishDir" "/DOutputDir=$installerDir" $setupScript
+if ($LASTEXITCODE -ne 0) {
+    throw "ISCC.exe failed with exit code $LASTEXITCODE"
+}
 
 $setupExe = Join-Path $installerDir "DocumentManager_v${Version}_Setup.exe"
 if (-not (Test-Path $setupExe)) {

--- a/scripts/build-windows-setup.ps1
+++ b/scripts/build-windows-setup.ps1
@@ -1,0 +1,64 @@
+param(
+    [string]$Version,
+    [string]$Configuration = "Release"
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $repoRoot
+
+$appVersionFile = Join-Path $repoRoot "StudyDocumentManager.Core\Services\AppVersion.cs"
+$appVersionMatch = Select-String -Path $appVersionFile -Pattern 'Current => "([^"]+)"'
+if (-not $appVersionMatch) {
+    throw "Could not read AppVersion.Current"
+}
+
+$appVersion = $appVersionMatch.Matches[0].Groups[1].Value
+if ([string]::IsNullOrWhiteSpace($Version)) {
+    $Version = $appVersion
+}
+
+if ($Version -ne $appVersion) {
+    throw "Version '$Version' does not match AppVersion.Current '$appVersion'"
+}
+
+$publishDir = Join-Path $repoRoot "artifacts\publish\win-x64"
+$installerDir = Join-Path $repoRoot "artifacts\installer"
+$setupScript = Join-Path $repoRoot "setup.iss"
+$isccPath = "C:\Program Files (x86)\Inno Setup 6\ISCC.exe"
+
+if (-not (Test-Path $isccPath)) {
+    throw "ISCC.exe was not found at $isccPath"
+}
+
+Remove-Item $publishDir -Recurse -Force -ErrorAction SilentlyContinue
+Remove-Item $installerDir -Recurse -Force -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Path $publishDir | Out-Null
+New-Item -ItemType Directory -Path $installerDir | Out-Null
+
+dotnet publish "StudyDocumentManager\StudyDocumentManager.csproj" `
+    -c $Configuration `
+    -r win-x64 `
+    --self-contained true `
+    -p:PublishSingleFile=false `
+    -p:PublishTrimmed=false `
+    -p:DebugType=None `
+    -p:DebugSymbols=false `
+    -p:Version=$Version `
+    -o $publishDir
+
+$publishedExe = Join-Path $publishDir "DocumentManager.exe"
+if (-not (Test-Path $publishedExe)) {
+    throw "Publish output is missing DocumentManager.exe"
+}
+
+& $isccPath "/DMyAppVersion=$Version" "/DPublishDir=$publishDir" "/DOutputDir=$installerDir" $setupScript
+
+$setupExe = Join-Path $installerDir "DocumentManager_v${Version}_Setup.exe"
+if (-not (Test-Path $setupExe)) {
+    throw "Setup EXE was not generated: $setupExe"
+}
+
+Write-Host "PublishDir=$publishDir"
+Write-Host "SetupExe=$setupExe"

--- a/scripts/verify-windows-installer.ps1
+++ b/scripts/verify-windows-installer.ps1
@@ -64,8 +64,6 @@ function Invoke-SetupProcess([string]$fileName, [string[]]$arguments, [hashtable
     }
 }
 
-$appProcess = $null
-
 try {
     $environment = @{ LOCALAPPDATA = $localAppDataPath }
     Invoke-SetupProcess $setupPath @("/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", "/SP-", "/DIR=$installPath") $environment
@@ -75,16 +73,20 @@ try {
         throw "Installed application executable was not found: $installedExe"
     }
 
-    $appStartInfo = [System.Diagnostics.ProcessStartInfo]::new($installedExe)
-    $appStartInfo.UseShellExecute = $false
-    $appStartInfo.EnvironmentVariables["LOCALAPPDATA"] = $localAppDataPath
-    $appProcess = [System.Diagnostics.Process]::Start($appStartInfo)
-
-    if (-not $appProcess.WaitForExit(5000)) {
-        $appProcess.Kill()
-        $appProcess.WaitForExit()
+    $appProcess = Start-Process -FilePath $installedExe -PassThru
+    try {
+        if (-not $appProcess.WaitForExit(5000)) {
+            $appProcess.Kill()
+            $appProcess.WaitForExit()
+        }
     }
-    $appProcess.Dispose()
+    finally {
+        if (-not $appProcess.HasExited) {
+            $appProcess.Kill()
+            $appProcess.WaitForExit()
+        }
+        $appProcess.Dispose()
+    }
 
     $uninstaller = Join-Path $installPath "unins000.exe"
     if (-not (Test-Path $uninstaller -PathType Leaf)) {
@@ -100,20 +102,6 @@ try {
     Write-Host "InstallPath=$installPath"
 }
 finally {
-    if ($appProcess) {
-        try {
-            if (-not $appProcess.HasExited) {
-                $appProcess.Kill()
-                $appProcess.WaitForExit()
-            }
-        }
-        catch [System.InvalidOperationException] {
-        }
-        finally {
-            $appProcess.Dispose()
-        }
-    }
-
     if (Test-Path $workPath) {
         for ($attempt = 1; $attempt -le 20; $attempt++) {
             try {

--- a/scripts/verify-windows-installer.ps1
+++ b/scripts/verify-windows-installer.ps1
@@ -1,0 +1,137 @@
+param(
+    [Parameter(Mandatory)]
+    [string]$SetupExe,
+    [string]$WorkingDirectory = (Join-Path ([System.IO.Path]::GetTempPath()) "DocumentManager-installer-smoke")
+)
+
+$ErrorActionPreference = "Stop"
+
+$setupPath = [System.IO.Path]::GetFullPath($SetupExe)
+if (-not (Test-Path $setupPath -PathType Leaf)) {
+    throw "Setup executable was not found: $setupPath"
+}
+
+$workPath = [System.IO.Path]::GetFullPath($WorkingDirectory)
+$installPath = Join-Path $workPath "app"
+$localAppDataPath = Join-Path $workPath "local-app-data"
+
+if (Test-Path $workPath) {
+    for ($attempt = 1; $attempt -le 20; $attempt++) {
+        try {
+            Remove-Item $workPath -Recurse -Force -ErrorAction Stop
+            break
+        }
+        catch [System.IO.IOException] {
+            if ($attempt -eq 20) {
+                throw
+            }
+            Start-Sleep -Milliseconds 250
+        }
+        catch [System.UnauthorizedAccessException] {
+            if ($attempt -eq 20) {
+                throw
+            }
+            Start-Sleep -Milliseconds 250
+        }
+    }
+}
+
+New-Item -ItemType Directory -Path $localAppDataPath | Out-Null
+
+function Invoke-SetupProcess([string]$fileName, [string[]]$arguments, [hashtable]$environment) {
+    $startInfo = [System.Diagnostics.ProcessStartInfo]::new($fileName)
+    $startInfo.UseShellExecute = $false
+    $startInfo.CreateNoWindow = $true
+
+    $startInfo.Arguments = ($arguments | ForEach-Object {
+        if ($_ -match '[\s"]') {
+            '"' + $_.Replace('"', '\"') + '"'
+        }
+        else {
+            $_
+        }
+    }) -join ' '
+
+    foreach ($entry in $environment.GetEnumerator()) {
+        $startInfo.EnvironmentVariables[$entry.Key] = $entry.Value
+    }
+
+    $process = [System.Diagnostics.Process]::Start($startInfo)
+    $process.WaitForExit()
+
+    if ($process.ExitCode -ne 0) {
+        throw "Process failed with exit code $($process.ExitCode): $fileName"
+    }
+}
+
+$appProcess = $null
+
+try {
+    $environment = @{ LOCALAPPDATA = $localAppDataPath }
+    Invoke-SetupProcess $setupPath @("/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", "/SP-", "/DIR=$installPath") $environment
+
+    $installedExe = Join-Path $installPath "DocumentManager.exe"
+    if (-not (Test-Path $installedExe -PathType Leaf)) {
+        throw "Installed application executable was not found: $installedExe"
+    }
+
+    $appStartInfo = [System.Diagnostics.ProcessStartInfo]::new($installedExe)
+    $appStartInfo.UseShellExecute = $false
+    $appStartInfo.EnvironmentVariables["LOCALAPPDATA"] = $localAppDataPath
+    $appProcess = [System.Diagnostics.Process]::Start($appStartInfo)
+
+    if (-not $appProcess.WaitForExit(5000)) {
+        $appProcess.Kill()
+        $appProcess.WaitForExit()
+    }
+    $appProcess.Dispose()
+
+    $uninstaller = Join-Path $installPath "unins000.exe"
+    if (-not (Test-Path $uninstaller -PathType Leaf)) {
+        throw "Uninstaller was not found: $uninstaller"
+    }
+
+    Invoke-SetupProcess $uninstaller @("/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", "/SP-") $environment
+
+    if (Test-Path $installedExe -PathType Leaf) {
+        throw "Application executable still exists after uninstall: $installedExe"
+    }
+
+    Write-Host "InstallPath=$installPath"
+}
+finally {
+    if ($appProcess) {
+        try {
+            if (-not $appProcess.HasExited) {
+                $appProcess.Kill()
+                $appProcess.WaitForExit()
+            }
+        }
+        catch [System.InvalidOperationException] {
+        }
+        finally {
+            $appProcess.Dispose()
+        }
+    }
+
+    if (Test-Path $workPath) {
+        for ($attempt = 1; $attempt -le 20; $attempt++) {
+            try {
+                Remove-Item $workPath -Recurse -Force -ErrorAction Stop
+                break
+            }
+            catch [System.IO.IOException] {
+                if ($attempt -eq 20) {
+                    throw
+                }
+                Start-Sleep -Milliseconds 250
+            }
+            catch [System.UnauthorizedAccessException] {
+                if ($attempt -eq 20) {
+                    throw
+                }
+                Start-Sleep -Milliseconds 250
+            }
+        }
+    }
+}

--- a/scripts/verify-windows-installer.ps1
+++ b/scripts/verify-windows-installer.ps1
@@ -39,11 +39,9 @@ if (Test-Path $workPath) {
 
 New-Item -ItemType Directory -Path (Split-Path -Parent $databasePath) | Out-Null
 
-function Invoke-SetupProcess([string]$fileName, [string[]]$arguments, [hashtable]$environment) {
+function Invoke-SetupProcess([string]$fileName, [string[]]$arguments) {
     $startInfo = [System.Diagnostics.ProcessStartInfo]::new($fileName)
-    $startInfo.UseShellExecute = $false
-    $startInfo.CreateNoWindow = $true
-
+    $startInfo.UseShellExecute = $true
     $startInfo.Arguments = ($arguments | ForEach-Object {
         if ($_ -match '[\s"]') {
             '"' + $_.Replace('"', '\"') + '"'
@@ -52,10 +50,6 @@ function Invoke-SetupProcess([string]$fileName, [string[]]$arguments, [hashtable
             $_
         }
     }) -join ' '
-
-    foreach ($entry in $environment.GetEnumerator()) {
-        $startInfo.EnvironmentVariables[$entry.Key] = $entry.Value
-    }
 
     $process = [System.Diagnostics.Process]::Start($startInfo)
     $process.WaitForExit()
@@ -66,8 +60,7 @@ function Invoke-SetupProcess([string]$fileName, [string[]]$arguments, [hashtable
 }
 
 try {
-    $environment = @{ SDM_DATABASE_PATH = $databasePath }
-    Invoke-SetupProcess $setupPath @("/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", "/SP-", "/DIR=$installPath") $environment
+    Invoke-SetupProcess $setupPath @("/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", "/SP-", "/DIR=$installPath")
 
     $installedExe = Join-Path $installPath "DocumentManager.exe"
     if (-not (Test-Path $installedExe -PathType Leaf)) {
@@ -110,8 +103,7 @@ try {
         throw "Uninstaller was not found: $uninstaller"
     }
 
-    Invoke-SetupProcess $uninstaller @("/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", "/SP-") $environment
-
+    Invoke-SetupProcess $uninstaller @("/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", "/SP-")
     if (Test-Path $installedExe -PathType Leaf) {
         throw "Application executable still exists after uninstall: $installedExe"
     }

--- a/scripts/verify-windows-installer.ps1
+++ b/scripts/verify-windows-installer.ps1
@@ -1,7 +1,8 @@
 param(
     [Parameter(Mandatory)]
     [string]$SetupExe,
-    [string]$WorkingDirectory = (Join-Path ([System.IO.Path]::GetTempPath()) "DocumentManager-installer-smoke")
+    [string]$WorkingDirectory = (Join-Path ([System.IO.Path]::GetTempPath()) "DocumentManager-installer-smoke"),
+    [switch]$VerifyLaunch
 )
 
 $ErrorActionPreference = "Stop"
@@ -13,7 +14,7 @@ if (-not (Test-Path $setupPath -PathType Leaf)) {
 
 $workPath = [System.IO.Path]::GetFullPath($WorkingDirectory)
 $installPath = Join-Path $workPath "app"
-$localAppDataPath = Join-Path $workPath "local-app-data"
+$databasePath = Join-Path $workPath "data\study_documents.db"
 
 if (Test-Path $workPath) {
     for ($attempt = 1; $attempt -le 20; $attempt++) {
@@ -36,7 +37,7 @@ if (Test-Path $workPath) {
     }
 }
 
-New-Item -ItemType Directory -Path $localAppDataPath | Out-Null
+New-Item -ItemType Directory -Path (Split-Path -Parent $databasePath) | Out-Null
 
 function Invoke-SetupProcess([string]$fileName, [string[]]$arguments, [hashtable]$environment) {
     $startInfo = [System.Diagnostics.ProcessStartInfo]::new($fileName)
@@ -65,7 +66,7 @@ function Invoke-SetupProcess([string]$fileName, [string[]]$arguments, [hashtable
 }
 
 try {
-    $environment = @{ LOCALAPPDATA = $localAppDataPath }
+    $environment = @{ SDM_DATABASE_PATH = $databasePath }
     Invoke-SetupProcess $setupPath @("/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", "/SP-", "/DIR=$installPath") $environment
 
     $installedExe = Join-Path $installPath "DocumentManager.exe"
@@ -73,19 +74,33 @@ try {
         throw "Installed application executable was not found: $installedExe"
     }
 
-    $appProcess = Start-Process -FilePath $installedExe -PassThru
-    try {
-        if (-not $appProcess.WaitForExit(5000)) {
-            $appProcess.Kill()
-            $appProcess.WaitForExit()
+    if ($VerifyLaunch) {
+        $appStartInfo = [System.Diagnostics.ProcessStartInfo]::new($installedExe)
+        $appStartInfo.WorkingDirectory = $installPath
+        $appStartInfo.UseShellExecute = $false
+        $appStartInfo.EnvironmentVariables["SDM_DATABASE_PATH"] = $databasePath
+        $appProcess = [System.Diagnostics.Process]::Start($appStartInfo)
+            ?? throw "Installed application process could not be started."
+        try {
+            if ($appProcess.WaitForExit(5000)) {
+                throw "Application exited during launch smoke with exit code $($appProcess.ExitCode)."
+            }
+            if (-not $appProcess.CloseMainWindow() -or -not $appProcess.WaitForExit(10000)) {
+                $appProcess.Kill()
+                $appProcess.WaitForExit()
+            }
         }
-    }
-    finally {
-        if (-not $appProcess.HasExited) {
-            $appProcess.Kill()
-            $appProcess.WaitForExit()
+        finally {
+            if (-not $appProcess.HasExited) {
+                $appProcess.Kill()
+                $appProcess.WaitForExit()
+            }
+            $appProcess.Dispose()
         }
-        $appProcess.Dispose()
+
+        if (-not (Test-Path $databasePath -PathType Leaf)) {
+            throw "The isolated application database was not created: $databasePath"
+        }
     }
 
     $uninstaller = Join-Path $installPath "unins000.exe"
@@ -99,7 +114,14 @@ try {
         throw "Application executable still exists after uninstall: $installedExe"
     }
 
+    if ($VerifyLaunch -and -not (Test-Path $databasePath -PathType Leaf)) {
+        throw "The isolated application database was removed by uninstall: $databasePath"
+    }
+
     Write-Host "InstallPath=$installPath"
+    if ($VerifyLaunch) {
+        Write-Host "DatabasePath=$databasePath"
+    }
 }
 finally {
     if (Test-Path $workPath) {

--- a/scripts/verify-windows-installer.ps1
+++ b/scripts/verify-windows-installer.ps1
@@ -80,7 +80,9 @@ try {
         $appStartInfo.UseShellExecute = $false
         $appStartInfo.EnvironmentVariables["SDM_DATABASE_PATH"] = $databasePath
         $appProcess = [System.Diagnostics.Process]::Start($appStartInfo)
-            ?? throw "Installed application process could not be started."
+        if ($null -eq $appProcess) {
+            throw "Installed application process could not be started."
+        }
         try {
             if ($appProcess.WaitForExit(5000)) {
                 throw "Application exited during launch smoke with exit code $($appProcess.ExitCode)."

--- a/setup.iss
+++ b/setup.iss
@@ -40,7 +40,7 @@ SolidCompression=yes
 WizardStyle=modern
 LanguageDetectionMethod=uilanguage
 ShowLanguageDialog=auto
-PrivilegesRequired=admin
+PrivilegesRequired=lowest
 ArchitecturesAllowed=x64compatible
 ArchitecturesInstallIn64BitMode=x64compatible
 

--- a/setup.iss
+++ b/setup.iss
@@ -17,7 +17,6 @@
 #define MyAppURL "https://github.com/hayato-shino05/study-document-manager"
 #define MyAppExeName "DocumentManager.exe"
 #define MyAppSetupName "DocumentManager_v" + MyAppVersion + "_Setup"
-#define DotnetDesktopRuntimeInstaller "redist\windowsdesktop-runtime-9.0.18-win-x64.exe"
 
 [Setup]
 AppId={{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
@@ -56,7 +55,6 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 
 [Files]
 Source: "{#PublishDir}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs; Excludes: "*.pdb"
-Source: "{#DotnetDesktopRuntimeInstaller}"; DestDir: "{tmp}"; Flags: deleteafterinstall
 
 [Icons]
 Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
@@ -64,5 +62,4 @@ Name: "{group}\{cm:UninstallProgram,{#MyAppName}}"; Filename: "{uninstallexe}"
 Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
 
 [Run]
-Filename: "{tmp}\windowsdesktop-runtime-9.0.18-win-x64.exe"; Parameters: "/install /quiet /norestart"; StatusMsg: "Installing .NET 9 Desktop Runtime..."; Flags: waituntilterminated
 Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent


### PR DESCRIPTION
## Summary
クリーン checkout で実行できる Windows setup build script を追跡対象にし、self-contained publish と矛盾する .NET Desktop Runtime installer の同梱・実行を削除します。

## Implementation checklist
- [x] Implement #32 — Windows リリースパイプラインを自己完結配布に合わせて再現可能にする

## Verification checklist
- [x] Self-review of the diff completed
- [x] Release build pass
- [x] Full headless tests pass (901/901)
- [x] Inno Setup 6.7.0 compiles the setup EXE
- [x] SHA-256 of the setup EXE recorded
- [x] Silent install and uninstall smoke pass in a temporary installation directory
- [x] `Check & Build` pass
- [x] `Linux package` pass
- [x] No secrets or private configuration in the diff
- [x] No AI attribution trailers in commits or comments
- [x] Cubic review completed without new valid findings
- [ ] Clean-VM verification of standard-user/UAC behavior and user-data retention

## References
Closes #32
Refs #35

確認済み: `DocumentManager_v4.0.0_Setup.exe` を生成し、SHA-256 は `773784C4326B3EB6E967E90C58EEBAEAD820C426C54BE6BDCC834E83DBC9F3F8` です。

クリーン VM の標準ユーザー/UAC と user-data retention、desktop runtime smoke の AutomationId 問題は Issue #35 で継続します。この PR は Windows release pipeline を再現可能にする範囲に限定して完了させます。