### PR TITLE
Desktop smoke の UI Automation 可視性を回復する

### DIFF
--- a/StudyDocumentManager.DesktopSmokeTests/DesktopAppFixture.cs
+++ b/StudyDocumentManager.DesktopSmokeTests/DesktopAppFixture.cs
@@ -33,8 +33,8 @@ public sealed class DesktopAppFixture : IDisposable
 
             using var process = Process.Start(startInfo)
                 ?? throw new InvalidOperationException("DocumentManager process を開始できませんでした。");
-            App = Application.Attach(process.Id);
             _processId = process.Id;
+            App = Application.Attach(process.Id);
             _automation = new UIA3Automation();
             Window = WaitUntil(
                 () => App.GetMainWindow(_automation!)!,

--- a/StudyDocumentManager.DesktopSmokeTests/DesktopAppFixture.cs
+++ b/StudyDocumentManager.DesktopSmokeTests/DesktopAppFixture.cs
@@ -23,9 +23,18 @@ public sealed class DesktopAppFixture : IDisposable
 
         try
         {
-            SeedDatabase(PublishFolder);
-            App = Application.Launch(Path.Combine(PublishFolder, "DocumentManager.exe"));
-            _processId = App.ProcessId;
+            var databasePath = SeedDatabase(PublishFolder);
+            var startInfo = new ProcessStartInfo(Path.Combine(PublishFolder, "DocumentManager.exe"))
+            {
+                WorkingDirectory = PublishFolder,
+                UseShellExecute = false
+            };
+            startInfo.Environment["SDM_DATABASE_PATH"] = databasePath;
+
+            using var process = Process.Start(startInfo)
+                ?? throw new InvalidOperationException("DocumentManager process を開始できませんでした。");
+            App = Application.Attach(process.Id);
+            _processId = process.Id;
             _automation = new UIA3Automation();
             Window = WaitUntil(
                 () => App.GetMainWindow(_automation!)!,
@@ -151,14 +160,15 @@ public sealed class DesktopAppFixture : IDisposable
     }
 }
 
-    private static void SeedDatabase(string publishFolder)
+    private static string SeedDatabase(string publishFolder)
     {
         var dataFolder = Path.Combine(publishFolder, "data");
         if (Directory.Exists(dataFolder))
             Directory.Delete(dataFolder, recursive: true);
 
+        var databasePath = Path.Combine(dataFolder, "study_documents.db");
         var database = new DatabaseHelper();
-        database.SetDatabasePath(Path.Combine(dataFolder, "study_documents.db"));
+        database.SetDatabasePath(databasePath);
         database.InitializeDatabase();
         database.InsertDocumentWithCatalogs(new StudyDocument
         {
@@ -168,6 +178,7 @@ public sealed class DesktopAppFixture : IDisposable
             Notes = "Seeded for desktop smoke tests"
         });
         database.CloseAllConnections();
+        return databasePath;
     }
 
     private void RequestProcessClose()

--- a/StudyDocumentManager.DesktopSmokeTests/StudyDocumentManager.DesktopSmokeTests.csproj
+++ b/StudyDocumentManager.DesktopSmokeTests/StudyDocumentManager.DesktopSmokeTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
@@ -17,6 +17,7 @@
     </PackageReference>
     <PackageReference Include="FlaUI.Core" Version="5.0.0" />
     <PackageReference Include="FlaUI.UIA3" Version="5.0.0" />
+    <PackageReference Include="System.Windows.Extensions" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/StudyDocumentManager/Views/AddEdit.axaml
+++ b/StudyDocumentManager/Views/AddEdit.axaml
@@ -4,7 +4,8 @@
              xmlns:loc="using:StudyDocumentManager.Markup"
              x:Class="StudyDocumentManager.Views.AddEdit"
              x:DataType="vm:AddEditModel"
-             AutomationProperties.AutomationId="Screen_AddEdit">
+             AutomationProperties.AutomationId="Screen_AddEdit"
+             AutomationProperties.AccessibilityView="Control">
 
     <Border Background="{StaticResource ContentBackground}"
             Padding="{StaticResource PaddingPage}">

--- a/StudyDocumentManager/Views/BatchImport.axaml
+++ b/StudyDocumentManager/Views/BatchImport.axaml
@@ -4,7 +4,8 @@
         xmlns:loc="using:StudyDocumentManager.Markup"
                      x:Class="StudyDocumentManager.Views.BatchImport"
              x:DataType="vm:BatchImportModel"
-             AutomationProperties.AutomationId="Screen_BatchImport">
+             AutomationProperties.AutomationId="Screen_BatchImport"
+             AutomationProperties.AccessibilityView="Control">
 
     <Border Background="{StaticResource ContentBackground}" Padding="{StaticResource PaddingPage}">
         <DockPanel>

--- a/StudyDocumentManager/Views/Dashboard.axaml
+++ b/StudyDocumentManager/Views/Dashboard.axaml
@@ -7,7 +7,8 @@
         xmlns:loc="using:StudyDocumentManager.Markup"
                      x:Class="StudyDocumentManager.Views.Dashboard"
              x:DataType="vm:DashboardModel"
-             AutomationProperties.AutomationId="Screen_Dashboard">
+             AutomationProperties.AutomationId="Screen_Dashboard"
+             AutomationProperties.AccessibilityView="Control">
 
     <UserControl.Resources>
         <conv:DeadlineBrushConverter x:Key="DeadlineBrushConverter"/>

--- a/StudyDocumentManager/Views/Report.axaml
+++ b/StudyDocumentManager/Views/Report.axaml
@@ -4,7 +4,8 @@
         xmlns:loc="using:StudyDocumentManager.Markup"
                      x:Class="StudyDocumentManager.Views.Report"
              x:DataType="vm:ReportModel"
-             AutomationProperties.AutomationId="Screen_Report">
+             AutomationProperties.AutomationId="Screen_Report"
+             AutomationProperties.AccessibilityView="Control">
 
     <Border Background="{StaticResource ContentBackground}" Padding="{StaticResource PaddingPage}">
         <DockPanel>

--- a/StudyDocumentManager/Views/TreeMap.axaml
+++ b/StudyDocumentManager/Views/TreeMap.axaml
@@ -4,7 +4,8 @@
         xmlns:loc="using:StudyDocumentManager.Markup"
                      x:Class="StudyDocumentManager.Views.TreeMap"
              x:DataType="vm:TreeMapModel"
-             AutomationProperties.AutomationId="Screen_TreeMap">
+             AutomationProperties.AutomationId="Screen_TreeMap"
+             AutomationProperties.AccessibilityView="Control">
 
     <Border Classes="page-wrapper">
         <DockPanel>


### PR DESCRIPTION
## Summary
Release publish を対象とする FlaUI desktop smoke で Dashboard の AutomationId を検出できない問題を修正し、ユーザーデータから隔離した runtime release proof を回復します。

## Target branch
`development`

## Type
- [x] Bug fix

## Implementation checklist
- [x] Implement #35 — Desktop smoke の UI Automation 可視性を回復する

## Verification checklist
- [x] Self-review of the diff completed
- [x] Project compile-check passes
- [x] Tests added or updated for behavior changes
- [x] Release publish desktop smoke passes
- [x] No secrets, tokens, or private config in the diff
- [x] Human-clean commit and discussion history confirmed
- [x] Issue sub-task checklist fully ticked
- [x] CI green

## Test plan
- Release build: 0 warning / 0 error
- Headless tests: 901/901
- Release publish desktop smoke: 4/4
- `git diff --check`: clean
- CI: `Check & Build`、`Linux package`、`Vercel Preview Comments` success
- GitHub Advanced Security 未有効のため secret scanning API は利用不可。対象 diff の手動 review では credential、token、private config なし。

## References
Closes #35