### PR TITLE
インストーラー選択言語をアプリの初期言語へ引き継ぐ

### DIFF
--- a/StudyDocumentManager.Tests/Slice4FlowPolishTests.cs
+++ b/StudyDocumentManager.Tests/Slice4FlowPolishTests.cs
@@ -709,12 +709,13 @@ public class Slice4FlowPolishTests
     }
 
     [Fact]
-    public void MainWindow_LoadsSavedLanguageFromSettings()
+    public void MainWindow_UsesStartupLanguageWithoutReReadingSettings()
     {
         var loc = new TestLocalizationService();
+        loc.SetLanguage(SupportedLanguage.English);
         var settings = new FakeSettingsService(new Dictionary<string, string>
         {
-            ["language"] = nameof(SupportedLanguage.English)
+            ["language"] = nameof(SupportedLanguage.Japanese)
         });
 
         var mainWindow = BuildMainWindowModel(

--- a/StudyDocumentManager.Tests/SupportedLanguageResolverTests.cs
+++ b/StudyDocumentManager.Tests/SupportedLanguageResolverTests.cs
@@ -34,6 +34,27 @@ public sealed class SupportedLanguageResolverTests
     }
 
     [Fact]
+    public void ReadInstallerLanguage_ReadsAndConsumesHandoffFile()
+    {
+        var localAppData = Path.Combine(Path.GetTempPath(), $"sdm-language-{Guid.NewGuid():N}");
+        var directory = Path.Combine(localAppData, "StudyDocumentManager");
+        Directory.CreateDirectory(directory);
+        var filePath = Path.Combine(directory, "installer-language.ini");
+        File.WriteAllText(filePath, "[Installer]\nLanguage=Vietnamese\n");
+
+        try
+        {
+            Assert.Equal(nameof(SupportedLanguage.Vietnamese), SupportedLanguageResolver.ReadInstallerLanguage(localAppData));
+            Assert.False(File.Exists(filePath));
+        }
+        finally
+        {
+            if (Directory.Exists(localAppData))
+                Directory.Delete(localAppData, recursive: true);
+        }
+    }
+
+    [Fact]
     public void Resolve_UsesInstallerLanguageBeforeOsCulture()
     {
         var resolution = SupportedLanguageResolver.Resolve(null, nameof(SupportedLanguage.English), new CultureInfo("vi-VN"));

--- a/StudyDocumentManager.Tests/SupportedLanguageResolverTests.cs
+++ b/StudyDocumentManager.Tests/SupportedLanguageResolverTests.cs
@@ -201,7 +201,7 @@ public sealed class SupportedLanguageResolverTests
         {
             using var first = SupportedLanguageResolver.TryClaimInstallerLanguage(localAppData);
             SupportedLanguageResolver.InstallerLanguageHandoff? second = null;
-            var thread = new Thread(() => second = SupportedLanguageResolver.TryClaimInstallerLanguage(localAppData));
+            var thread = new Thread(() => second = SupportedLanguageResolver.TryClaimInstallerLanguage(localAppData, TimeSpan.FromMilliseconds(100)));
 
             Assert.NotNull(first);
             thread.Start();

--- a/StudyDocumentManager.Tests/SupportedLanguageResolverTests.cs
+++ b/StudyDocumentManager.Tests/SupportedLanguageResolverTests.cs
@@ -61,6 +61,24 @@ public sealed class SupportedLanguageResolverTests
     }
 
     [Fact]
+    public void Resolve_UsesOsCultureWhenInstallerLanguageIsInvalid()
+    {
+        var resolution = SupportedLanguageResolver.Resolve(null, "unsupported", new CultureInfo("zh-CN"));
+
+        Assert.Equal(SupportedLanguage.Chinese, resolution.Language);
+        Assert.False(resolution.UsedSavedLanguage);
+    }
+
+    [Fact]
+    public void Resolve_FallsBackToJapaneseWhenSavedAndInstallerLanguagesAreInvalid()
+    {
+        var resolution = SupportedLanguageResolver.Resolve("unsupported", "also-unsupported", new CultureInfo("fr-FR"));
+
+        Assert.Equal(SupportedLanguage.Japanese, resolution.Language);
+        Assert.False(resolution.UsedSavedLanguage);
+    }
+
+    [Fact]
     public void Resolve_UsesOsCultureWhenSavedLanguageIsInvalid()
     {
         var resolution = SupportedLanguageResolver.Resolve("unsupported", new CultureInfo("zh-CN"));

--- a/StudyDocumentManager.Tests/SupportedLanguageResolverTests.cs
+++ b/StudyDocumentManager.Tests/SupportedLanguageResolverTests.cs
@@ -34,6 +34,24 @@ public sealed class SupportedLanguageResolverTests
     }
 
     [Fact]
+    public void Resolve_UsesInstallerLanguageBeforeOsCulture()
+    {
+        var resolution = SupportedLanguageResolver.Resolve(null, nameof(SupportedLanguage.English), new CultureInfo("vi-VN"));
+
+        Assert.Equal(SupportedLanguage.English, resolution.Language);
+        Assert.False(resolution.UsedSavedLanguage);
+    }
+
+    [Fact]
+    public void Resolve_PrefersSavedLanguageBeforeInstallerLanguage()
+    {
+        var resolution = SupportedLanguageResolver.Resolve(nameof(SupportedLanguage.Chinese), nameof(SupportedLanguage.English), new CultureInfo("ja-JP"));
+
+        Assert.Equal(SupportedLanguage.Chinese, resolution.Language);
+        Assert.True(resolution.UsedSavedLanguage);
+    }
+
+    [Fact]
     public void Resolve_UsesOsCultureWhenLanguageIsMissing()
     {
         var resolution = SupportedLanguageResolver.Resolve(null, new CultureInfo("vi-VN"));

--- a/StudyDocumentManager.Tests/SupportedLanguageResolverTests.cs
+++ b/StudyDocumentManager.Tests/SupportedLanguageResolverTests.cs
@@ -120,6 +120,51 @@ public sealed class SupportedLanguageResolverTests
     }
 
     [Fact]
+    public void ReadInstallerLanguage_PrefersFreshHandoffOverStaleClaim()
+    {
+        var localAppData = Path.Combine(Path.GetTempPath(), $"sdm-language-{Guid.NewGuid():N}");
+        var directory = Path.Combine(localAppData, "StudyDocumentManager");
+        Directory.CreateDirectory(directory);
+        var filePath = Path.Combine(directory, "installer-language.ini");
+        var consumingPath = filePath + ".consuming";
+        File.WriteAllText(filePath, "[Installer]\nLanguage=Vietnamese\n");
+        File.WriteAllText(consumingPath, "[Installer]\nLanguage=English\n");
+
+        try
+        {
+            Assert.Equal(nameof(SupportedLanguage.Vietnamese), SupportedLanguageResolver.ReadInstallerLanguage(localAppData));
+            Assert.False(File.Exists(filePath));
+            Assert.False(File.Exists(consumingPath));
+        }
+        finally
+        {
+            if (Directory.Exists(localAppData))
+                Directory.Delete(localAppData, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ReadInstallerLanguage_IgnoresLanguageKeyOutsideInstallerSection()
+    {
+        var localAppData = Path.Combine(Path.GetTempPath(), $"sdm-language-{Guid.NewGuid():N}");
+        var directory = Path.Combine(localAppData, "StudyDocumentManager");
+        Directory.CreateDirectory(directory);
+        var filePath = Path.Combine(directory, "installer-language.ini");
+        File.WriteAllText(filePath, "[Installer]\nOther=Value\n[Other]\nLanguage=English\n");
+
+        try
+        {
+            Assert.Null(SupportedLanguageResolver.ReadInstallerLanguage(localAppData));
+            Assert.True(File.Exists(filePath));
+        }
+        finally
+        {
+            if (Directory.Exists(localAppData))
+                Directory.Delete(localAppData, recursive: true);
+        }
+    }
+
+    [Fact]
     public void Resolve_UsesInstallerLanguageBeforeOsCulture()
     {
         var resolution = SupportedLanguageResolver.Resolve(null, nameof(SupportedLanguage.English), new CultureInfo("vi-VN"));

--- a/StudyDocumentManager.Tests/SupportedLanguageResolverTests.cs
+++ b/StudyDocumentManager.Tests/SupportedLanguageResolverTests.cs
@@ -55,6 +55,27 @@ public sealed class SupportedLanguageResolverTests
     }
 
     [Fact]
+    public void ReadInstallerLanguage_RestoresInvalidHandoffFile()
+    {
+        var localAppData = Path.Combine(Path.GetTempPath(), $"sdm-language-{Guid.NewGuid():N}");
+        var directory = Path.Combine(localAppData, "StudyDocumentManager");
+        Directory.CreateDirectory(directory);
+        var filePath = Path.Combine(directory, "installer-language.ini");
+        File.WriteAllText(filePath, "[Installer]\nOther=Value\n");
+
+        try
+        {
+            Assert.Null(SupportedLanguageResolver.ReadInstallerLanguage(localAppData));
+            Assert.True(File.Exists(filePath));
+        }
+        finally
+        {
+            if (Directory.Exists(localAppData))
+                Directory.Delete(localAppData, recursive: true);
+        }
+    }
+
+    [Fact]
     public void Resolve_UsesInstallerLanguageBeforeOsCulture()
     {
         var resolution = SupportedLanguageResolver.Resolve(null, nameof(SupportedLanguage.English), new CultureInfo("vi-VN"));

--- a/StudyDocumentManager.Tests/SupportedLanguageResolverTests.cs
+++ b/StudyDocumentManager.Tests/SupportedLanguageResolverTests.cs
@@ -96,7 +96,10 @@ public sealed class SupportedLanguageResolverTests
 
         try
         {
-            Assert.Null(SupportedLanguageResolver.TryClaimInstallerLanguage(localAppData));
+            using var handoff = SupportedLanguageResolver.TryClaimInstallerLanguage(localAppData);
+
+            Assert.NotNull(handoff);
+            Assert.Null(handoff.Language);
             Assert.True(File.Exists(filePath));
         }
         finally
@@ -117,7 +120,10 @@ public sealed class SupportedLanguageResolverTests
 
         try
         {
-            Assert.Null(SupportedLanguageResolver.TryClaimInstallerLanguage(localAppData));
+            using var handoff = SupportedLanguageResolver.TryClaimInstallerLanguage(localAppData);
+
+            Assert.NotNull(handoff);
+            Assert.Null(handoff.Language);
             Assert.True(File.Exists(filePath));
         }
         finally
@@ -220,7 +226,10 @@ public sealed class SupportedLanguageResolverTests
 
         try
         {
-            Assert.Null(SupportedLanguageResolver.TryClaimInstallerLanguage(localAppData));
+            using var handoff = SupportedLanguageResolver.TryClaimInstallerLanguage(localAppData);
+
+            Assert.NotNull(handoff);
+            Assert.Null(handoff.Language);
             Assert.True(File.Exists(filePath));
         }
         finally

--- a/StudyDocumentManager.Tests/SupportedLanguageResolverTests.cs
+++ b/StudyDocumentManager.Tests/SupportedLanguageResolverTests.cs
@@ -86,7 +86,7 @@ public sealed class SupportedLanguageResolverTests
     }
 
     [Fact]
-    public void ReadInstallerLanguage_RestoresMalformedHandoffFile()
+    public void TryClaimInstallerLanguage_RestoresMalformedHandoffFile()
     {
         var localAppData = Path.Combine(Path.GetTempPath(), $"sdm-language-{Guid.NewGuid():N}");
         var directory = Path.Combine(localAppData, "StudyDocumentManager");
@@ -110,7 +110,7 @@ public sealed class SupportedLanguageResolverTests
     }
 
     [Fact]
-    public void ReadInstallerLanguage_RestoresUnsupportedLanguageFile()
+    public void TryClaimInstallerLanguage_RestoresUnsupportedLanguageFile()
     {
         var localAppData = Path.Combine(Path.GetTempPath(), $"sdm-language-{Guid.NewGuid():N}");
         var directory = Path.Combine(localAppData, "StudyDocumentManager");
@@ -134,7 +134,7 @@ public sealed class SupportedLanguageResolverTests
     }
 
     [Fact]
-    public void ReadInstallerLanguage_RecoversStaleConsumingFile()
+    public void TryClaimInstallerLanguage_RecoversStaleConsumingFile()
     {
         var localAppData = Path.Combine(Path.GetTempPath(), $"sdm-language-{Guid.NewGuid():N}");
         var directory = Path.Combine(localAppData, "StudyDocumentManager");
@@ -161,7 +161,7 @@ public sealed class SupportedLanguageResolverTests
     }
 
     [Fact]
-    public void ReadInstallerLanguage_PrefersFreshHandoffOverStaleClaim()
+    public void TryClaimInstallerLanguage_PrefersFreshHandoffOverStaleClaim()
     {
         var localAppData = Path.Combine(Path.GetTempPath(), $"sdm-language-{Guid.NewGuid():N}");
         var directory = Path.Combine(localAppData, "StudyDocumentManager");
@@ -216,7 +216,7 @@ public sealed class SupportedLanguageResolverTests
     }
 
     [Fact]
-    public void ReadInstallerLanguage_IgnoresLanguageKeyOutsideInstallerSection()
+    public void TryClaimInstallerLanguage_IgnoresLanguageKeyOutsideInstallerSection()
     {
         var localAppData = Path.Combine(Path.GetTempPath(), $"sdm-language-{Guid.NewGuid():N}");
         var directory = Path.Combine(localAppData, "StudyDocumentManager");

--- a/StudyDocumentManager.Tests/SupportedLanguageResolverTests.cs
+++ b/StudyDocumentManager.Tests/SupportedLanguageResolverTests.cs
@@ -34,7 +34,36 @@ public sealed class SupportedLanguageResolverTests
     }
 
     [Fact]
-    public void ReadInstallerLanguage_ReadsAndConsumesHandoffFile()
+    public void TryClaimInstallerLanguage_DeletesHandoffOnlyAfterCompletion()
+    {
+        var localAppData = Path.Combine(Path.GetTempPath(), $"sdm-language-{Guid.NewGuid():N}");
+        var directory = Path.Combine(localAppData, "StudyDocumentManager");
+        Directory.CreateDirectory(directory);
+        var filePath = Path.Combine(directory, "installer-language.ini");
+        var consumingPath = filePath + ".consuming";
+        File.WriteAllText(filePath, "[Installer]\nLanguage=Vietnamese\n");
+
+        try
+        {
+            using var handoff = SupportedLanguageResolver.TryClaimInstallerLanguage(localAppData);
+
+            Assert.NotNull(handoff);
+            Assert.Equal(nameof(SupportedLanguage.Vietnamese), handoff.Language);
+            Assert.False(File.Exists(filePath));
+            Assert.True(File.Exists(consumingPath));
+
+            handoff.Complete();
+            Assert.False(File.Exists(consumingPath));
+        }
+        finally
+        {
+            if (Directory.Exists(localAppData))
+                Directory.Delete(localAppData, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void TryClaimInstallerLanguage_RestoresHandoffWhenNotCompleted()
     {
         var localAppData = Path.Combine(Path.GetTempPath(), $"sdm-language-{Guid.NewGuid():N}");
         var directory = Path.Combine(localAppData, "StudyDocumentManager");
@@ -44,8 +73,10 @@ public sealed class SupportedLanguageResolverTests
 
         try
         {
-            Assert.Equal(nameof(SupportedLanguage.Vietnamese), SupportedLanguageResolver.ReadInstallerLanguage(localAppData));
-            Assert.False(File.Exists(filePath));
+            using (var handoff = SupportedLanguageResolver.TryClaimInstallerLanguage(localAppData))
+                Assert.NotNull(handoff);
+
+            Assert.True(File.Exists(filePath));
         }
         finally
         {
@@ -65,7 +96,7 @@ public sealed class SupportedLanguageResolverTests
 
         try
         {
-            Assert.Null(SupportedLanguageResolver.ReadInstallerLanguage(localAppData));
+            Assert.Null(SupportedLanguageResolver.TryClaimInstallerLanguage(localAppData));
             Assert.True(File.Exists(filePath));
         }
         finally
@@ -86,7 +117,7 @@ public sealed class SupportedLanguageResolverTests
 
         try
         {
-            Assert.Null(SupportedLanguageResolver.ReadInstallerLanguage(localAppData));
+            Assert.Null(SupportedLanguageResolver.TryClaimInstallerLanguage(localAppData));
             Assert.True(File.Exists(filePath));
         }
         finally
@@ -108,7 +139,11 @@ public sealed class SupportedLanguageResolverTests
 
         try
         {
-            Assert.Equal(nameof(SupportedLanguage.English), SupportedLanguageResolver.ReadInstallerLanguage(localAppData));
+            using var handoff = SupportedLanguageResolver.TryClaimInstallerLanguage(localAppData);
+
+            Assert.NotNull(handoff);
+            Assert.Equal(nameof(SupportedLanguage.English), handoff.Language);
+            handoff.Complete();
             Assert.False(File.Exists(filePath));
             Assert.False(File.Exists(consumingPath));
         }
@@ -132,9 +167,40 @@ public sealed class SupportedLanguageResolverTests
 
         try
         {
-            Assert.Equal(nameof(SupportedLanguage.Vietnamese), SupportedLanguageResolver.ReadInstallerLanguage(localAppData));
+            using var handoff = SupportedLanguageResolver.TryClaimInstallerLanguage(localAppData);
+
+            Assert.NotNull(handoff);
+            Assert.Equal(nameof(SupportedLanguage.Vietnamese), handoff.Language);
+            handoff.Complete();
             Assert.False(File.Exists(filePath));
             Assert.False(File.Exists(consumingPath));
+        }
+        finally
+        {
+            if (Directory.Exists(localAppData))
+                Directory.Delete(localAppData, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void TryClaimInstallerLanguage_DoesNotClaimWhileAnotherClaimIsActive()
+    {
+        var localAppData = Path.Combine(Path.GetTempPath(), $"sdm-language-{Guid.NewGuid():N}");
+        var directory = Path.Combine(localAppData, "StudyDocumentManager");
+        Directory.CreateDirectory(directory);
+        var filePath = Path.Combine(directory, "installer-language.ini");
+        File.WriteAllText(filePath, "[Installer]\nLanguage=English\n");
+
+        try
+        {
+            using var first = SupportedLanguageResolver.TryClaimInstallerLanguage(localAppData);
+            SupportedLanguageResolver.InstallerLanguageHandoff? second = null;
+            var thread = new Thread(() => second = SupportedLanguageResolver.TryClaimInstallerLanguage(localAppData));
+
+            Assert.NotNull(first);
+            thread.Start();
+            thread.Join();
+            Assert.Null(second);
         }
         finally
         {
@@ -154,7 +220,7 @@ public sealed class SupportedLanguageResolverTests
 
         try
         {
-            Assert.Null(SupportedLanguageResolver.ReadInstallerLanguage(localAppData));
+            Assert.Null(SupportedLanguageResolver.TryClaimInstallerLanguage(localAppData));
             Assert.True(File.Exists(filePath));
         }
         finally

--- a/StudyDocumentManager.Tests/SupportedLanguageResolverTests.cs
+++ b/StudyDocumentManager.Tests/SupportedLanguageResolverTests.cs
@@ -55,7 +55,7 @@ public sealed class SupportedLanguageResolverTests
     }
 
     [Fact]
-    public void ReadInstallerLanguage_RestoresInvalidHandoffFile()
+    public void ReadInstallerLanguage_RestoresMalformedHandoffFile()
     {
         var localAppData = Path.Combine(Path.GetTempPath(), $"sdm-language-{Guid.NewGuid():N}");
         var directory = Path.Combine(localAppData, "StudyDocumentManager");
@@ -67,6 +67,50 @@ public sealed class SupportedLanguageResolverTests
         {
             Assert.Null(SupportedLanguageResolver.ReadInstallerLanguage(localAppData));
             Assert.True(File.Exists(filePath));
+        }
+        finally
+        {
+            if (Directory.Exists(localAppData))
+                Directory.Delete(localAppData, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ReadInstallerLanguage_RestoresUnsupportedLanguageFile()
+    {
+        var localAppData = Path.Combine(Path.GetTempPath(), $"sdm-language-{Guid.NewGuid():N}");
+        var directory = Path.Combine(localAppData, "StudyDocumentManager");
+        Directory.CreateDirectory(directory);
+        var filePath = Path.Combine(directory, "installer-language.ini");
+        File.WriteAllText(filePath, "[Installer]\nLanguage=Unsupported\n");
+
+        try
+        {
+            Assert.Null(SupportedLanguageResolver.ReadInstallerLanguage(localAppData));
+            Assert.True(File.Exists(filePath));
+        }
+        finally
+        {
+            if (Directory.Exists(localAppData))
+                Directory.Delete(localAppData, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ReadInstallerLanguage_RecoversStaleConsumingFile()
+    {
+        var localAppData = Path.Combine(Path.GetTempPath(), $"sdm-language-{Guid.NewGuid():N}");
+        var directory = Path.Combine(localAppData, "StudyDocumentManager");
+        Directory.CreateDirectory(directory);
+        var filePath = Path.Combine(directory, "installer-language.ini");
+        var consumingPath = filePath + ".consuming";
+        File.WriteAllText(consumingPath, "[Installer]\nLanguage=English\n");
+
+        try
+        {
+            Assert.Equal(nameof(SupportedLanguage.English), SupportedLanguageResolver.ReadInstallerLanguage(localAppData));
+            Assert.False(File.Exists(filePath));
+            Assert.False(File.Exists(consumingPath));
         }
         finally
         {

--- a/StudyDocumentManager/App.axaml.cs
+++ b/StudyDocumentManager/App.axaml.cs
@@ -66,16 +66,12 @@ public partial class App : Application
     private static void InitializeLanguage(LocalizationService localization, ISettingsService settings, CultureInfo osCulture)
     {
         var savedLanguage = settings.GetSetting("language");
-        var savedResolution = SupportedLanguageResolver.Resolve(savedLanguage, osCulture);
-        if (savedResolution.UsedSavedLanguage)
-        {
-            localization.SetLanguage(savedResolution.Language);
-            return;
-        }
-
         using var handoff = SupportedLanguageResolver.TryClaimInstallerLanguage();
         var resolution = SupportedLanguageResolver.Resolve(savedLanguage, handoff?.Language, osCulture);
-        settings.SetSetting("language", resolution.Language.ToString());
+
+        if (!resolution.UsedSavedLanguage)
+            settings.SetSetting("language", resolution.Language.ToString());
+
         handoff?.Complete();
         localization.SetLanguage(resolution.Language);
     }

--- a/StudyDocumentManager/App.axaml.cs
+++ b/StudyDocumentManager/App.axaml.cs
@@ -66,12 +66,17 @@ public partial class App : Application
     private static void InitializeLanguage(LocalizationService localization, ISettingsService settings, CultureInfo osCulture)
     {
         var savedLanguage = settings.GetSetting("language");
-        var installerLanguage = SupportedLanguageResolver.ReadInstallerLanguage();
-        var resolution = SupportedLanguageResolver.Resolve(savedLanguage, installerLanguage, osCulture);
+        var savedResolution = SupportedLanguageResolver.Resolve(savedLanguage, osCulture);
+        if (savedResolution.UsedSavedLanguage)
+        {
+            localization.SetLanguage(savedResolution.Language);
+            return;
+        }
 
-        if (!resolution.UsedSavedLanguage)
-            settings.SetSetting("language", resolution.Language.ToString());
-
+        using var handoff = SupportedLanguageResolver.TryClaimInstallerLanguage();
+        var resolution = SupportedLanguageResolver.Resolve(savedLanguage, handoff?.Language, osCulture);
+        settings.SetSetting("language", resolution.Language.ToString());
+        handoff?.Complete();
         localization.SetLanguage(resolution.Language);
     }
 

--- a/StudyDocumentManager/App.axaml.cs
+++ b/StudyDocumentManager/App.axaml.cs
@@ -67,12 +67,17 @@ public partial class App : Application
     {
         var savedLanguage = settings.GetSetting("language");
         using var handoff = SupportedLanguageResolver.TryClaimInstallerLanguage();
-        var resolution = SupportedLanguageResolver.Resolve(savedLanguage, handoff?.Language, osCulture);
+        if (handoff is null)
+        {
+            localization.SetLanguage(SupportedLanguageResolver.Resolve(savedLanguage, osCulture).Language);
+            return;
+        }
 
+        var resolution = SupportedLanguageResolver.Resolve(savedLanguage, handoff.Language, osCulture);
         if (!resolution.UsedSavedLanguage)
             settings.SetSetting("language", resolution.Language.ToString());
 
-        handoff?.Complete();
+        handoff.Complete();
         localization.SetLanguage(resolution.Language);
     }
 

--- a/StudyDocumentManager/App.axaml.cs
+++ b/StudyDocumentManager/App.axaml.cs
@@ -66,7 +66,8 @@ public partial class App : Application
     private static void InitializeLanguage(LocalizationService localization, ISettingsService settings, CultureInfo osCulture)
     {
         var savedLanguage = settings.GetSetting("language");
-        var resolution = SupportedLanguageResolver.Resolve(savedLanguage, osCulture);
+        var installerLanguage = SupportedLanguageResolver.ReadInstallerLanguage();
+        var resolution = SupportedLanguageResolver.Resolve(savedLanguage, installerLanguage, osCulture);
 
         if (!resolution.UsedSavedLanguage)
             settings.SetSetting("language", resolution.Language.ToString());

--- a/StudyDocumentManager/Models/MainWindowModel.cs
+++ b/StudyDocumentManager/Models/MainWindowModel.cs
@@ -69,7 +69,7 @@ public partial class MainWindowModel : ModelBase
                 StatusText = categoryManagement.StatusText;
         };
 
-        LoadLanguageFromSettings();
+        SelectedLanguage = _loc.CurrentLanguage;
 
         _ = Task.Run(async () =>
         {
@@ -314,20 +314,6 @@ public partial class MainWindowModel : ModelBase
         }
 
         return imported;
-    }
-
-    private void LoadLanguageFromSettings()
-    {
-        var saved = _settingsService.GetSetting("language");
-        if (Enum.TryParse<SupportedLanguage>(saved, out var lang))
-        {
-            _loc.SetLanguage(lang);
-            SelectedLanguage = lang;
-        }
-        else
-        {
-            SelectedLanguage = _loc.CurrentLanguage;
-        }
     }
 
     partial void OnSelectedLanguageChanged(SupportedLanguage value)

--- a/StudyDocumentManager/Services/SupportedLanguageResolver.cs
+++ b/StudyDocumentManager/Services/SupportedLanguageResolver.cs
@@ -9,6 +9,8 @@ public readonly record struct SupportedLanguageResolution(
 
 public static class SupportedLanguageResolver
 {
+    private const string InstallerLanguageFileName = "installer-language.ini";
+
     public static SupportedLanguage FromCulture(CultureInfo? culture)
         => culture?.TwoLetterISOLanguageName.ToLowerInvariant() switch
         {
@@ -20,9 +22,50 @@ public static class SupportedLanguageResolver
         };
 
     public static SupportedLanguageResolution Resolve(string? savedLanguage, CultureInfo? culture)
+        => Resolve(savedLanguage, installerLanguage: null, culture);
+
+    public static SupportedLanguageResolution Resolve(string? savedLanguage, string? installerLanguage, CultureInfo? culture)
         => TryResolveSavedLanguage(savedLanguage) is { } saved
             ? new SupportedLanguageResolution(saved, UsedSavedLanguage: true)
-            : new SupportedLanguageResolution(FromCulture(culture), UsedSavedLanguage: false);
+            : TryResolveSavedLanguage(installerLanguage) is { } installed
+                ? new SupportedLanguageResolution(installed, UsedSavedLanguage: false)
+                : new SupportedLanguageResolution(FromCulture(culture), UsedSavedLanguage: false);
+
+    public static string? ReadInstallerLanguage()
+    {
+        var localAppData = Environment.GetFolderPath(
+            Environment.SpecialFolder.LocalApplicationData,
+            Environment.SpecialFolderOption.DoNotVerify);
+        if (string.IsNullOrWhiteSpace(localAppData))
+            return null;
+
+        var filePath = Path.Combine(localAppData, "StudyDocumentManager", InstallerLanguageFileName);
+        if (!File.Exists(filePath))
+            return null;
+
+        try
+        {
+            var language = File.ReadAllLines(filePath)
+                .Select(line => line.Trim())
+                .SkipWhile(line => !line.Equals("[Installer]", StringComparison.OrdinalIgnoreCase))
+                .Skip(1)
+                .Select(line => line.Split('=', 2))
+                .Where(parts => parts.Length == 2
+                    && parts[0].Trim().Equals("Language", StringComparison.OrdinalIgnoreCase))
+                .Select(parts => parts[1].Trim())
+                .FirstOrDefault();
+            File.Delete(filePath);
+            return language;
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
 
     private static SupportedLanguage? TryResolveSavedLanguage(string? savedLanguage)
     {

--- a/StudyDocumentManager/Services/SupportedLanguageResolver.cs
+++ b/StudyDocumentManager/Services/SupportedLanguageResolver.cs
@@ -10,6 +10,7 @@ public readonly record struct SupportedLanguageResolution(
 public static class SupportedLanguageResolver
 {
     private const string InstallerLanguageFileName = "installer-language.ini";
+    private const string InstallerLanguageMutexName = @"Local\StudyDocumentManager.InstallerLanguageHandoff.v1";
 
     public static SupportedLanguage FromCulture(CultureInfo? culture)
         => culture?.TwoLetterISOLanguageName.ToLowerInvariant() switch
@@ -31,7 +32,7 @@ public static class SupportedLanguageResolver
                 ? new SupportedLanguageResolution(installed, UsedSavedLanguage: false)
                 : new SupportedLanguageResolution(FromCulture(culture), UsedSavedLanguage: false);
 
-    public static string? ReadInstallerLanguage(string? localAppData = null)
+    public static InstallerLanguageHandoff? TryClaimInstallerLanguage(string? localAppData = null)
     {
         localAppData ??= Environment.GetFolderPath(
             Environment.SpecialFolder.LocalApplicationData,
@@ -39,68 +40,71 @@ public static class SupportedLanguageResolver
         if (string.IsNullOrWhiteSpace(localAppData))
             return null;
 
-        var filePath = Path.Combine(localAppData, "StudyDocumentManager", InstallerLanguageFileName);
-        var consumingPath = filePath + ".consuming";
-        RecoverStaleHandoffFile(consumingPath, filePath);
-        if (!File.Exists(filePath))
-            return null;
-
+        var mutex = new Mutex(initiallyOwned: false, InstallerLanguageMutexName);
         try
         {
-            File.Move(filePath, consumingPath);
-        }
-        catch (IOException)
-        {
-            return null;
-        }
-        catch (UnauthorizedAccessException)
-        {
-            return null;
-        }
-
-        try
-        {
-            var language = File.ReadAllLines(consumingPath)
-                .Select(line => line.Trim())
-                .SkipWhile(line => !line.Equals("[Installer]", StringComparison.OrdinalIgnoreCase))
-                .Skip(1)
-                .TakeWhile(line => !line.StartsWith("[", StringComparison.Ordinal))
-                .Select(line => line.Split('=', 2))
-                .Where(parts => parts.Length == 2
-                    && parts[0].Trim().Equals("Language", StringComparison.OrdinalIgnoreCase))
-                .Select(parts => parts[1].Trim())
-                .FirstOrDefault();
-
-            if (TryResolveSavedLanguage(language) is null)
+            try
             {
-                RestoreHandoffFile(consumingPath, filePath);
+                if (!mutex.WaitOne(0))
+                {
+                    mutex.Dispose();
+                    return null;
+                }
+            }
+            catch (AbandonedMutexException)
+            {
+            }
+
+            var filePath = Path.Combine(localAppData, "StudyDocumentManager", InstallerLanguageFileName);
+            var consumingPath = filePath + ".consuming";
+            RecoverStaleHandoffFile(consumingPath, filePath);
+            if (!File.Exists(filePath))
+            {
+                mutex.ReleaseMutex();
+                mutex.Dispose();
                 return null;
             }
 
             try
             {
-                File.Delete(consumingPath);
+                File.Move(filePath, consumingPath);
+                var language = ReadLanguage(consumingPath);
+                if (TryResolveSavedLanguage(language) is not null)
+                    return new InstallerLanguageHandoff(language!, filePath, consumingPath, mutex);
+
+                RestoreHandoffFile(consumingPath, filePath);
             }
             catch (IOException)
             {
+                RestoreHandoffFile(consumingPath, filePath);
             }
             catch (UnauthorizedAccessException)
             {
+                RestoreHandoffFile(consumingPath, filePath);
             }
 
-            return language;
-        }
-        catch (IOException)
-        {
-            RestoreHandoffFile(consumingPath, filePath);
+            mutex.ReleaseMutex();
+            mutex.Dispose();
             return null;
         }
-        catch (UnauthorizedAccessException)
+        catch
         {
-            RestoreHandoffFile(consumingPath, filePath);
-            return null;
+            mutex.Dispose();
+            throw;
         }
     }
+
+    private static string? ReadLanguage(string filePath)
+        => File.ReadAllLines(filePath)
+            .Select(line => line.Trim())
+            .SkipWhile(line => !line.Equals("[Installer]", StringComparison.OrdinalIgnoreCase))
+            .Skip(1)
+            .TakeWhile(line => !line.StartsWith("[", StringComparison.Ordinal))
+            .Select(line => line.Split('=', 2))
+            .Where(parts => parts.Length == 2
+                && parts[0].Trim().Equals("Language", StringComparison.OrdinalIgnoreCase))
+            .Select(parts => parts[1].Trim())
+            .FirstOrDefault();
 
     private static void RecoverStaleHandoffFile(string consumingPath, string filePath)
     {
@@ -142,5 +146,50 @@ public static class SupportedLanguageResolver
         return saved.ToString().Equals(savedLanguage.Trim(), StringComparison.OrdinalIgnoreCase)
             ? saved
             : null;
+    }
+
+    public sealed class InstallerLanguageHandoff : IDisposable
+    {
+        private readonly string _filePath;
+        private readonly string _consumingPath;
+        private readonly Mutex _mutex;
+        private bool _completed;
+
+        internal InstallerLanguageHandoff(string language, string filePath, string consumingPath, Mutex mutex)
+        {
+            Language = language;
+            _filePath = filePath;
+            _consumingPath = consumingPath;
+            _mutex = mutex;
+        }
+
+        public string Language { get; }
+
+        public void Complete()
+        {
+            if (_completed)
+                return;
+
+            _completed = true;
+            try
+            {
+                File.Delete(_consumingPath);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+
+        public void Dispose()
+        {
+            if (!_completed)
+                RestoreHandoffFile(_consumingPath, _filePath);
+
+            _mutex.ReleaseMutex();
+            _mutex.Dispose();
+        }
     }
 }

--- a/StudyDocumentManager/Services/SupportedLanguageResolver.cs
+++ b/StudyDocumentManager/Services/SupportedLanguageResolver.cs
@@ -170,10 +170,10 @@ public static class SupportedLanguageResolver
             if (_completed)
                 return;
 
-            _completed = true;
             try
             {
                 File.Delete(_consumingPath);
+                _completed = true;
             }
             catch (IOException)
             {

--- a/StudyDocumentManager/Services/SupportedLanguageResolver.cs
+++ b/StudyDocumentManager/Services/SupportedLanguageResolver.cs
@@ -45,7 +45,7 @@ public static class SupportedLanguageResolver
         {
             try
             {
-                if (!mutex.WaitOne(0))
+                if (!mutex.WaitOne(TimeSpan.FromSeconds(5)))
                 {
                     mutex.Dispose();
                     return null;
@@ -59,18 +59,14 @@ public static class SupportedLanguageResolver
             var consumingPath = filePath + ".consuming";
             RecoverStaleHandoffFile(consumingPath, filePath);
             if (!File.Exists(filePath))
-            {
-                mutex.ReleaseMutex();
-                mutex.Dispose();
-                return null;
-            }
+                return new InstallerLanguageHandoff(null, filePath, consumingPath, mutex);
 
             try
             {
                 File.Move(filePath, consumingPath);
                 var language = ReadLanguage(consumingPath);
                 if (TryResolveSavedLanguage(language) is not null)
-                    return new InstallerLanguageHandoff(language!, filePath, consumingPath, mutex);
+                    return new InstallerLanguageHandoff(language, filePath, consumingPath, mutex);
 
                 RestoreHandoffFile(consumingPath, filePath);
             }
@@ -83,9 +79,7 @@ public static class SupportedLanguageResolver
                 RestoreHandoffFile(consumingPath, filePath);
             }
 
-            mutex.ReleaseMutex();
-            mutex.Dispose();
-            return null;
+            return new InstallerLanguageHandoff(null, filePath, consumingPath, mutex);
         }
         catch
         {
@@ -155,7 +149,7 @@ public static class SupportedLanguageResolver
         private readonly Mutex _mutex;
         private bool _completed;
 
-        internal InstallerLanguageHandoff(string language, string filePath, string consumingPath, Mutex mutex)
+        internal InstallerLanguageHandoff(string? language, string filePath, string consumingPath, Mutex mutex)
         {
             Language = language;
             _filePath = filePath;
@@ -163,7 +157,7 @@ public static class SupportedLanguageResolver
             _mutex = mutex;
         }
 
-        public string Language { get; }
+        public string? Language { get; }
 
         public void Complete()
         {

--- a/StudyDocumentManager/Services/SupportedLanguageResolver.cs
+++ b/StudyDocumentManager/Services/SupportedLanguageResolver.cs
@@ -43,19 +43,10 @@ public static class SupportedLanguageResolver
         if (!File.Exists(filePath))
             return null;
 
+        var consumingPath = filePath + ".consuming";
         try
         {
-            var language = File.ReadAllLines(filePath)
-                .Select(line => line.Trim())
-                .SkipWhile(line => !line.Equals("[Installer]", StringComparison.OrdinalIgnoreCase))
-                .Skip(1)
-                .Select(line => line.Split('=', 2))
-                .Where(parts => parts.Length == 2
-                    && parts[0].Trim().Equals("Language", StringComparison.OrdinalIgnoreCase))
-                .Select(parts => parts[1].Trim())
-                .FirstOrDefault();
-            File.Delete(filePath);
-            return language;
+            File.Move(filePath, consumingPath);
         }
         catch (IOException)
         {
@@ -64,6 +55,63 @@ public static class SupportedLanguageResolver
         catch (UnauthorizedAccessException)
         {
             return null;
+        }
+
+        try
+        {
+            var language = File.ReadAllLines(consumingPath)
+                .Select(line => line.Trim())
+                .SkipWhile(line => !line.Equals("[Installer]", StringComparison.OrdinalIgnoreCase))
+                .Skip(1)
+                .Select(line => line.Split('=', 2))
+                .Where(parts => parts.Length == 2
+                    && parts[0].Trim().Equals("Language", StringComparison.OrdinalIgnoreCase))
+                .Select(parts => parts[1].Trim())
+                .FirstOrDefault();
+
+            if (string.IsNullOrWhiteSpace(language))
+            {
+                RestoreHandoffFile(consumingPath, filePath);
+                return null;
+            }
+
+            try
+            {
+                File.Delete(consumingPath);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+
+            return language;
+        }
+        catch (IOException)
+        {
+            RestoreHandoffFile(consumingPath, filePath);
+            return null;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            RestoreHandoffFile(consumingPath, filePath);
+            return null;
+        }
+    }
+
+    private static void RestoreHandoffFile(string consumingPath, string filePath)
+    {
+        try
+        {
+            if (File.Exists(consumingPath) && !File.Exists(filePath))
+                File.Move(consumingPath, filePath);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
         }
     }
 

--- a/StudyDocumentManager/Services/SupportedLanguageResolver.cs
+++ b/StudyDocumentManager/Services/SupportedLanguageResolver.cs
@@ -32,7 +32,9 @@ public static class SupportedLanguageResolver
                 ? new SupportedLanguageResolution(installed, UsedSavedLanguage: false)
                 : new SupportedLanguageResolution(FromCulture(culture), UsedSavedLanguage: false);
 
-    public static InstallerLanguageHandoff? TryClaimInstallerLanguage(string? localAppData = null)
+    public static InstallerLanguageHandoff? TryClaimInstallerLanguage(
+        string? localAppData = null,
+        TimeSpan? mutexTimeout = null)
     {
         localAppData ??= Environment.GetFolderPath(
             Environment.SpecialFolder.LocalApplicationData,
@@ -45,7 +47,7 @@ public static class SupportedLanguageResolver
         {
             try
             {
-                if (!mutex.WaitOne(TimeSpan.FromSeconds(5)))
+                if (!mutex.WaitOne(mutexTimeout ?? TimeSpan.FromSeconds(5)))
                 {
                     mutex.Dispose();
                     return null;

--- a/StudyDocumentManager/Services/SupportedLanguageResolver.cs
+++ b/StudyDocumentManager/Services/SupportedLanguageResolver.cs
@@ -64,6 +64,7 @@ public static class SupportedLanguageResolver
                 .Select(line => line.Trim())
                 .SkipWhile(line => !line.Equals("[Installer]", StringComparison.OrdinalIgnoreCase))
                 .Skip(1)
+                .TakeWhile(line => !line.StartsWith("[", StringComparison.Ordinal))
                 .Select(line => line.Split('=', 2))
                 .Where(parts => parts.Length == 2
                     && parts[0].Trim().Equals("Language", StringComparison.OrdinalIgnoreCase))
@@ -105,8 +106,16 @@ public static class SupportedLanguageResolver
     {
         try
         {
-            if (File.Exists(consumingPath) && !File.Exists(filePath))
-                File.Move(consumingPath, filePath);
+            if (!File.Exists(consumingPath))
+                return;
+
+            if (File.Exists(filePath))
+            {
+                File.Delete(consumingPath);
+                return;
+            }
+
+            File.Move(consumingPath, filePath);
         }
         catch (IOException)
         {
@@ -117,19 +126,7 @@ public static class SupportedLanguageResolver
     }
 
     private static void RestoreHandoffFile(string consumingPath, string filePath)
-    {
-        try
-        {
-            if (File.Exists(consumingPath) && !File.Exists(filePath))
-                File.Move(consumingPath, filePath);
-        }
-        catch (IOException)
-        {
-        }
-        catch (UnauthorizedAccessException)
-        {
-        }
-    }
+        => RecoverStaleHandoffFile(consumingPath, filePath);
 
     private static SupportedLanguage? TryResolveSavedLanguage(string? savedLanguage)
     {

--- a/StudyDocumentManager/Services/SupportedLanguageResolver.cs
+++ b/StudyDocumentManager/Services/SupportedLanguageResolver.cs
@@ -40,10 +40,11 @@ public static class SupportedLanguageResolver
             return null;
 
         var filePath = Path.Combine(localAppData, "StudyDocumentManager", InstallerLanguageFileName);
+        var consumingPath = filePath + ".consuming";
+        RecoverStaleHandoffFile(consumingPath, filePath);
         if (!File.Exists(filePath))
             return null;
 
-        var consumingPath = filePath + ".consuming";
         try
         {
             File.Move(filePath, consumingPath);
@@ -69,7 +70,7 @@ public static class SupportedLanguageResolver
                 .Select(parts => parts[1].Trim())
                 .FirstOrDefault();
 
-            if (string.IsNullOrWhiteSpace(language))
+            if (TryResolveSavedLanguage(language) is null)
             {
                 RestoreHandoffFile(consumingPath, filePath);
                 return null;
@@ -97,6 +98,21 @@ public static class SupportedLanguageResolver
         {
             RestoreHandoffFile(consumingPath, filePath);
             return null;
+        }
+    }
+
+    private static void RecoverStaleHandoffFile(string consumingPath, string filePath)
+    {
+        try
+        {
+            if (File.Exists(consumingPath) && !File.Exists(filePath))
+                File.Move(consumingPath, filePath);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
         }
     }
 

--- a/StudyDocumentManager/Services/SupportedLanguageResolver.cs
+++ b/StudyDocumentManager/Services/SupportedLanguageResolver.cs
@@ -31,9 +31,9 @@ public static class SupportedLanguageResolver
                 ? new SupportedLanguageResolution(installed, UsedSavedLanguage: false)
                 : new SupportedLanguageResolution(FromCulture(culture), UsedSavedLanguage: false);
 
-    public static string? ReadInstallerLanguage()
+    public static string? ReadInstallerLanguage(string? localAppData = null)
     {
-        var localAppData = Environment.GetFolderPath(
+        localAppData ??= Environment.GetFolderPath(
             Environment.SpecialFolder.LocalApplicationData,
             Environment.SpecialFolderOption.DoNotVerify);
         if (string.IsNullOrWhiteSpace(localAppData))

--- a/StudyDocumentManager/Services/SupportedLanguageResolver.cs
+++ b/StudyDocumentManager/Services/SupportedLanguageResolver.cs
@@ -163,7 +163,7 @@ public static class SupportedLanguageResolver
 
         public void Complete()
         {
-            if (_completed)
+            if (_completed || Language is null)
                 return;
 
             try

--- a/setup.iss
+++ b/setup.iss
@@ -56,6 +56,9 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 [Files]
 Source: "{#PublishDir}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs; Excludes: "*.pdb"
 
+[INI]
+Filename: "{localappdata}\StudyDocumentManager\installer-language.ini"; Section: "Installer"; Key: "Language"; String: "{language}"
+
 [Icons]
 Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
 Name: "{group}\{cm:UninstallProgram,{#MyAppName}}"; Filename: "{uninstallexe}"


### PR DESCRIPTION
## Summary
インストーラーで最終選択された言語をアプリの初期言語へ安全に引き継ぎます。既存の有効な app 言語設定は reinstall / upgrade でも維持し、起動時の言語解決を単一化します。

## Target branch
`development`

## Type
- [x] Bug fix

## Implementation checklist
- [x] Implement #34 — インストーラー選択言語をアプリの初期言語へ安全に引き継ぐ

## Verification checklist
- [x] Self-review of the diff completed
- [x] Project compile-check passes
- [x] Tests added or updated for behavior changes
- [x] Installer lifecycle verification passes
- [x] No secrets, tokens, or private config in the diff
- [x] Human-clean commit and discussion history confirmed
- [x] Issue sub-task checklist fully ticked
- [x] CI green

## Test plan
- Release build: 0 warning / 0 error
- Full Release tests: 906/906
- Resolver / handoff focused tests: 17/17
- Inno Setup 6.7.0 compile: success
- Isolated installer install/uninstall smoke: success
- `/LANG=english` handoff: `[Installer] Language=english` confirmed
- `git diff --check`: clean
- GitNexus detect_changes: 6 files, medium risk, expected startup-language scope

## References
Closes #34