### PR TITLE
保存検索・状態・一括編集・Undo を追加する

### DIFF
--- a/StudyDocumentManager.Core/Entities/BulkEditChanges.cs
+++ b/StudyDocumentManager.Core/Entities/BulkEditChanges.cs
@@ -1,0 +1,18 @@
+namespace StudyDocumentManager.Core.Entities;
+
+public sealed class BulkEditChanges
+{
+    public string? Subject { get; set; }
+    public string? Type { get; set; }
+    public string? Tags { get; set; }
+    public bool? IsImportant { get; set; }
+    public DateTime? Deadline { get; set; }
+    public string? Status { get; set; }
+
+    // membership add, not a document column
+    public int? AddToCollectionId { get; set; }
+
+    public bool HasAnyChange =>
+        Subject != null || Type != null || Tags != null || IsImportant != null ||
+        Deadline != null || Status != null || AddToCollectionId != null;
+}

--- a/StudyDocumentManager.Core/Entities/BulkEditOutcome.cs
+++ b/StudyDocumentManager.Core/Entities/BulkEditOutcome.cs
@@ -1,0 +1,12 @@
+namespace StudyDocumentManager.Core.Entities;
+
+public sealed record BulkItemResult(int DocumentId, bool Success);
+
+public sealed class BulkEditOutcome
+{
+    public int Requested { get; init; }
+    public int Succeeded { get; init; }
+    public IReadOnlyList<BulkItemResult> Items { get; init; } = Array.Empty<BulkItemResult>();
+
+    public IReadOnlyList<int> FailedIds => Items.Where(i => !i.Success).Select(i => i.DocumentId).ToList();
+}

--- a/StudyDocumentManager.Core/Entities/DocumentStatus.cs
+++ b/StudyDocumentManager.Core/Entities/DocumentStatus.cs
@@ -1,0 +1,26 @@
+using System.Linq;
+
+namespace StudyDocumentManager.Core.Entities;
+
+public static class DocumentStatus
+{
+    public const string Unread = "unread";
+    public const string InProgress = "in-progress";
+    public const string Read = "read";
+    public const string NeedsAction = "needs-action";
+    public const string Completed = "completed";
+    public const string Archived = "archived";
+
+    public static readonly IReadOnlyList<string> All =
+    [
+        Unread,
+        InProgress,
+        Read,
+        NeedsAction,
+        Completed,
+        Archived
+    ];
+
+    public static bool IsValid(string? value)
+        => !string.IsNullOrEmpty(value) && All.Contains(value);
+}

--- a/StudyDocumentManager.Core/Entities/SavedSearch.cs
+++ b/StudyDocumentManager.Core/Entities/SavedSearch.cs
@@ -1,0 +1,9 @@
+namespace StudyDocumentManager.Core.Entities;
+
+public class SavedSearch
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string CriteriaJson { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; }
+}

--- a/StudyDocumentManager.Core/Entities/SavedSearchCriteria.cs
+++ b/StudyDocumentManager.Core/Entities/SavedSearchCriteria.cs
@@ -1,0 +1,43 @@
+using System.Text.Json;
+
+namespace StudyDocumentManager.Core.Entities;
+
+public sealed class SavedSearchCriteria
+{
+    public string Kind { get; set; } = SavedSearchKinds.Standard;
+    public string? Keyword { get; set; }
+    public string? Subject { get; set; }
+    public string? Type { get; set; }
+    public DateTime? FromDate { get; set; }
+    public DateTime? ToDate { get; set; }
+    public double? MinSize { get; set; }
+    public double? MaxSize { get; set; }
+    public bool? IsImportant { get; set; }
+    public int RecentDays { get; set; } = 7;
+    public int DeadlineDays { get; set; } = 7;
+
+    public string ToJson() => JsonSerializer.Serialize(this);
+
+    public static SavedSearchCriteria? FromJson(string json)
+    {
+        try
+        {
+            return JsonSerializer.Deserialize<SavedSearchCriteria>(json);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+}
+
+public static class SavedSearchKinds
+{
+    public const string Standard = "standard";
+    public const string Uncategorized = "uncategorized";
+    public const string MissingMetadata = "missing-metadata";
+    public const string MissingFile = "missing-file";
+    public const string RecentlyAdded = "recently-added";
+    public const string Important = "important";
+    public const string DueSoon = "due-soon";
+}

--- a/StudyDocumentManager.Core/Entities/StudyDocument.cs
+++ b/StudyDocumentManager.Core/Entities/StudyDocument.cs
@@ -18,6 +18,7 @@ public class StudyDocument
     public bool IsImportant { get; set; }
     public string Tags { get; set; } = string.Empty;
     public DateTime? Deadline { get; set; }
+    public string Status { get; set; } = DocumentStatus.Unread;
 
     public StudyDocument()
     {

--- a/StudyDocumentManager.Core/Interfaces/IBulkOperationRepository.cs
+++ b/StudyDocumentManager.Core/Interfaces/IBulkOperationRepository.cs
@@ -1,3 +1,5 @@
+using StudyDocumentManager.Core.Entities;
+
 namespace StudyDocumentManager.Core.Interfaces;
 
 public interface IBulkOperationRepository
@@ -5,4 +7,10 @@ public interface IBulkOperationRepository
     int BulkSoftDelete(List<int> ids);
     int BulkUpdateSubject(List<int> ids, string subject);
     int BulkToggleImportant(List<int> ids, bool important);
+
+    int BulkUpdateStatus(List<int> ids, string status)
+        => throw new NotSupportedException($"{nameof(BulkUpdateStatus)} is not implemented by this repository.");
+
+    BulkEditOutcome BulkEditMetadata(IReadOnlyList<int> documentIds, BulkEditChanges changes)
+        => throw new NotSupportedException($"{nameof(BulkEditMetadata)} is not implemented by this repository.");
 }

--- a/StudyDocumentManager.Core/Interfaces/IDocumentRepository.cs
+++ b/StudyDocumentManager.Core/Interfaces/IDocumentRepository.cs
@@ -15,6 +15,16 @@ public interface IDocumentRepository
         string keyword, string subject, string type,
         DateTime? fromDate, DateTime? toDate,
         double? minSize, double? maxSize, bool? isImportant);
+
+    List<StudyDocument> SearchAdvancedWithStatus(
+        string? keyword, string? subject, string? type,
+        DateTime? fromDate, DateTime? toDate,
+        double? minSize, double? maxSize, bool? isImportant, string? status)
+        => throw new NotSupportedException($"{nameof(SearchAdvancedWithStatus)} is not implemented by this repository.");
+
+    Dictionary<string, int> GetStatusCounts()
+        => throw new NotSupportedException($"{nameof(GetStatusCounts)} is not implemented by this repository.");
+
     bool Add(StudyDocument document);
 
     bool AddWithCatalogs(StudyDocument document);
@@ -26,6 +36,12 @@ public interface IDocumentRepository
     List<string> GetDistinctTags();
     List<StudyDocument> GetUpcomingDeadlines(int days);
     List<StudyDocument> GetOverdueDocuments();
+
+    List<StudyDocument> GetUncategorizedDocuments()
+        => throw new NotSupportedException($"{nameof(GetUncategorizedDocuments)} is not implemented by this repository.");
+
+    List<StudyDocument> GetDocumentsWithMissingMetadata()
+        => throw new NotSupportedException($"{nameof(GetDocumentsWithMissingMetadata)} is not implemented by this repository.");
 
     void EnsureSubjectExists(string subject);
     void EnsureTypeExists(string type);

--- a/StudyDocumentManager.Core/Interfaces/IRecycleBinRepository.cs
+++ b/StudyDocumentManager.Core/Interfaces/IRecycleBinRepository.cs
@@ -9,4 +9,7 @@ public interface IRecycleBinRepository
     bool PermanentDeleteDocument(int id);
     int EmptyRecycleBin();
     int GetDeletedDocumentCount();
+
+    int RestoreDocuments(IReadOnlyList<int> ids)
+        => throw new NotSupportedException($"{nameof(RestoreDocuments)} is not implemented by this repository.");
 }

--- a/StudyDocumentManager.Core/Interfaces/ISavedSearchRepository.cs
+++ b/StudyDocumentManager.Core/Interfaces/ISavedSearchRepository.cs
@@ -1,0 +1,13 @@
+using StudyDocumentManager.Core.Entities;
+
+namespace StudyDocumentManager.Core.Interfaces;
+
+public interface ISavedSearchRepository
+{
+    List<SavedSearch> GetAll();
+    SavedSearch? GetById(int id);
+    bool NameExists(string name);
+    int Add(SavedSearch savedSearch);
+    bool Update(SavedSearch savedSearch);
+    bool Delete(int id);
+}

--- a/StudyDocumentManager.Core/Interfaces/IUndoRepository.cs
+++ b/StudyDocumentManager.Core/Interfaces/IUndoRepository.cs
@@ -1,0 +1,10 @@
+using StudyDocumentManager.Core.Entities;
+
+namespace StudyDocumentManager.Core.Interfaces;
+
+public interface IUndoRepository
+{
+    void ApplyMetadataUndo(
+        IReadOnlyList<StudyDocument> originals,
+        IReadOnlyList<(int CollectionId, int DocumentId)> addedCollectionMemberships);
+}

--- a/StudyDocumentManager.Data/Helpers/DatabaseHelper.cs
+++ b/StudyDocumentManager.Data/Helpers/DatabaseHelper.cs
@@ -373,6 +373,8 @@ public class DatabaseHelper
         {
             foreach (var original in originals)
             {
+                if (!DocumentRowExists(connection, transaction, original.Id))
+                    continue;
                 if (!UpdateDocumentCore(connection, transaction, original))
                     throw new InvalidOperationException("Undo document restoration failed.");
             }
@@ -384,8 +386,7 @@ public class DatabaseHelper
                 command.CommandText = "DELETE FROM collection_items WHERE collection_id = @collectionId AND document_id = @documentId";
                 command.Parameters.AddWithValue("@collectionId", membership.CollectionId);
                 command.Parameters.AddWithValue("@documentId", membership.DocumentId);
-                if (command.ExecuteNonQuery() == 0)
-                    throw new InvalidOperationException("Undo collection membership removal failed.");
+                command.ExecuteNonQuery();
             }
 
             transaction.Commit();
@@ -395,6 +396,15 @@ public class DatabaseHelper
             transaction.Rollback();
             throw;
         }
+    }
+
+    private static bool DocumentRowExists(SqliteConnection connection, SqliteTransaction transaction, int id)
+    {
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = "SELECT COUNT(*) FROM documents WHERE id = @id";
+        command.Parameters.AddWithValue("@id", id);
+        return Convert.ToInt32(command.ExecuteScalar()) > 0;
     }
 
     public bool DeleteDocument(int id)
@@ -543,12 +553,6 @@ public class DatabaseHelper
         {
             if (RestoreDocumentCore(conn, transaction, id))
                 restored++;
-        }
-
-        if (restored != distinctIds.Count)
-        {
-            transaction.Rollback();
-            throw new InvalidOperationException("Undo restore did not restore every document.");
         }
 
         transaction.Commit();
@@ -1742,22 +1746,44 @@ private static void ValidateDocumentPathIndex(SqliteConnection connection, bool 
 
         try
         {
+            var targetCollectionMissing = false;
+            if (changes.AddToCollectionId is int requestedCollectionId)
+            {
+                using var collectionCheck = conn.CreateCommand();
+                collectionCheck.Transaction = transaction;
+                collectionCheck.CommandText = "SELECT COUNT(*) FROM collections WHERE id = @collectionId";
+                collectionCheck.Parameters.AddWithValue("@collectionId", requestedCollectionId);
+                targetCollectionMissing = Convert.ToInt32(collectionCheck.ExecuteScalar()) == 0;
+            }
+
             foreach (var id in ids)
             {
                 var succeeded = false;
-                try
+                var statusAllowed = changes.Status is null || DocumentStatus.IsValid(changes.Status);
+                if (!targetCollectionMissing && statusAllowed)
                 {
-                    // whitelist check must precede the UPDATE so a rejected field-set never partially applies
-                    if (changes.Status is null || DocumentStatus.IsValid(changes.Status))
+                    try
                     {
-                        succeeded = ExecuteBulkEditMetadataUpdate(conn, transaction, id, changes);
-                        if (succeeded && changes.AddToCollectionId is int collectionId)
-                            InsertBulkEditCollectionLink(conn, transaction, collectionId, id);
+                        transaction.Save(BulkEditItemSavepoint);
+                        try
+                        {
+                            // whitelist check must precede the UPDATE so a rejected field-set never partially applies
+                            succeeded = ExecuteBulkEditMetadataUpdate(conn, transaction, id, changes);
+                            if (succeeded && changes.AddToCollectionId is int collectionId)
+                                InsertBulkEditCollectionLink(conn, transaction, collectionId, id);
+                            transaction.Release(BulkEditItemSavepoint);
+                        }
+                        catch
+                        {
+                            transaction.Rollback(BulkEditItemSavepoint);
+                            transaction.Release(BulkEditItemSavepoint);
+                            throw;
+                        }
                     }
-                }
-                catch (SqliteException)
-                {
-                    succeeded = false;
+                    catch (SqliteException)
+                    {
+                        succeeded = false;
+                    }
                 }
                 results.Add(new BulkItemResult(id, succeeded));
             }
@@ -1779,6 +1805,8 @@ private static void ValidateDocumentPathIndex(SqliteConnection connection, bool 
             Items = results
         };
     }
+
+    private const string BulkEditItemSavepoint = "bulk_edit_item";
 
     private static bool ExecuteBulkEditMetadataUpdate(
         SqliteConnection conn, SqliteTransaction transaction, int id, BulkEditChanges changes)

--- a/StudyDocumentManager.Data/Helpers/DatabaseHelper.cs
+++ b/StudyDocumentManager.Data/Helpers/DatabaseHelper.cs
@@ -316,34 +316,13 @@ public class DatabaseHelper
 
     public bool UpdateDocument(StudyDocument doc)
     {
-        const string query = """
-            UPDATE documents SET
-                name = @name, subject = @subject, type = @type, file_path = @file_path,
-                notes = @notes, file_size = @file_size, author = @author,
-                is_important = @is_important, tags = @tags, deadline = @deadline,
-                status = @status
-            WHERE id = @id
-            """;
-
         using var connection = OpenConnection();
         using var transaction = connection.BeginTransaction();
 
         try
         {
-            if (!string.IsNullOrWhiteSpace(doc.Subject))
-                InsertCatalogValue(connection, transaction, "categories", doc.Subject);
-
-            if (!string.IsNullOrWhiteSpace(doc.Type))
-                InsertCatalogValue(connection, transaction, "document_types", doc.Type);
-
-            using var command = connection.CreateCommand();
-            command.Transaction = transaction;
-            command.CommandText = query;
-            foreach (var parameter in BuildDocumentParameters(doc))
-                command.Parameters.Add(parameter);
-            command.Parameters.Add(new SqliteParameter("@id", doc.Id));
-
-            if (command.ExecuteNonQuery() == 0)
+            var updated = UpdateDocumentCore(connection, transaction, doc);
+            if (!updated)
             {
                 transaction.Rollback();
                 return false;
@@ -351,6 +330,65 @@ public class DatabaseHelper
 
             transaction.Commit();
             return true;
+        }
+        catch
+        {
+            transaction.Rollback();
+            throw;
+        }
+    }
+
+    private bool UpdateDocumentCore(SqliteConnection connection, SqliteTransaction transaction, StudyDocument doc)
+    {
+        if (!string.IsNullOrWhiteSpace(doc.Subject))
+            InsertCatalogValue(connection, transaction, "categories", doc.Subject);
+
+        if (!string.IsNullOrWhiteSpace(doc.Type))
+            InsertCatalogValue(connection, transaction, "document_types", doc.Type);
+
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = """
+            UPDATE documents SET
+                name = @name, subject = @subject, type = @type, file_path = @file_path,
+                notes = @notes, file_size = @file_size, author = @author,
+                is_important = @is_important, tags = @tags, deadline = @deadline,
+                status = @status
+            WHERE id = @id
+            """;
+        foreach (var parameter in BuildDocumentParameters(doc))
+            command.Parameters.Add(parameter);
+        command.Parameters.Add(new SqliteParameter("@id", doc.Id));
+        return command.ExecuteNonQuery() > 0;
+    }
+
+    public void ApplyMetadataUndo(
+        IReadOnlyList<StudyDocument> originals,
+        IReadOnlyList<(int CollectionId, int DocumentId)> addedCollectionMemberships)
+    {
+        using var connection = OpenConnection();
+        using var transaction = connection.BeginTransaction();
+
+        try
+        {
+            foreach (var original in originals)
+            {
+                if (!UpdateDocumentCore(connection, transaction, original))
+                    throw new InvalidOperationException("Undo document restoration failed.");
+            }
+
+            foreach (var membership in addedCollectionMemberships)
+            {
+                using var command = connection.CreateCommand();
+                command.Transaction = transaction;
+                command.CommandText = "DELETE FROM collection_items WHERE collection_id = @collectionId AND document_id = @documentId";
+                command.Parameters.AddWithValue("@collectionId", membership.CollectionId);
+                command.Parameters.AddWithValue("@documentId", membership.DocumentId);
+                if (command.ExecuteNonQuery() == 0)
+                    throw new InvalidOperationException("Undo collection membership removal failed.");
+            }
+
+            transaction.Commit();
         }
         catch
         {

--- a/StudyDocumentManager.Data/Helpers/DatabaseHelper.cs
+++ b/StudyDocumentManager.Data/Helpers/DatabaseHelper.cs
@@ -496,14 +496,21 @@ public class DatabaseHelper
         if (ids is null || ids.Count == 0)
             return 0;
 
+        var distinctIds = ids.Distinct().ToList();
         using var conn = OpenConnection();
         using var transaction = conn.BeginTransaction();
 
         var restored = 0;
-        foreach (var id in ids.Distinct())
+        foreach (var id in distinctIds)
         {
             if (RestoreDocumentCore(conn, transaction, id))
                 restored++;
+        }
+
+        if (restored != distinctIds.Count)
+        {
+            transaction.Rollback();
+            throw new InvalidOperationException("Undo restore did not restore every document.");
         }
 
         transaction.Commit();

--- a/StudyDocumentManager.Data/Helpers/DatabaseHelper.cs
+++ b/StudyDocumentManager.Data/Helpers/DatabaseHelper.cs
@@ -170,6 +170,12 @@ public class DatabaseHelper
         string? keyword, string? subject, string? type,
         DateTime? fromDate, DateTime? toDate,
         double? minSize, double? maxSize, bool? isImportant)
+        => SearchDocumentsAdvanced(keyword, subject, type, fromDate, toDate, minSize, maxSize, isImportant, null);
+
+    public List<StudyDocument> SearchDocumentsAdvanced(
+        string? keyword, string? subject, string? type,
+        DateTime? fromDate, DateTime? toDate,
+        double? minSize, double? maxSize, bool? isImportant, string? status)
     {
         var query = "SELECT * FROM documents WHERE (is_deleted IS NULL OR is_deleted = 0)";
         var parameters = new List<SqliteParameter>();
@@ -221,25 +227,58 @@ public class DatabaseHelper
             query += " AND is_important = 1";
         }
 
+        if (!string.IsNullOrEmpty(status))
+        {
+            query += " AND (status = @status)";
+            parameters.Add(new SqliteParameter("@status", status));
+        }
+
         query += " ORDER BY created_at DESC";
         return ExecuteReader(query, parameters.ToArray());
+    }
+
+    public Dictionary<string, int> GetStatusCounts()
+    {
+        const string query = "SELECT status, COUNT(*) FROM documents WHERE (is_deleted IS NULL OR is_deleted = 0) AND status IS NOT NULL GROUP BY status";
+        var counts = new Dictionary<string, int>();
+        using var conn = OpenConnection();
+        using var cmd = new SqliteCommand(query, conn);
+        using var reader = cmd.ExecuteReader();
+
+        while (reader.Read())
+            counts[reader.GetString(0)] = Convert.ToInt32(reader.GetValue(1));
+
+        return counts;
     }
 
     public bool InsertDocument(StudyDocument doc)
     {
         const string query = """
-            INSERT INTO documents (name, subject, type, file_path, notes, file_size, author, is_important, tags, deadline)
-            VALUES (@name, @subject, @type, @file_path, @notes, @file_size, @author, @is_important, @tags, @deadline)
+            INSERT INTO documents (name, subject, type, file_path, notes, file_size, author, is_important, tags, deadline, status)
+            VALUES (@name, @subject, @type, @file_path, @notes, @file_size, @author, @is_important, @tags, @deadline, @status);
+            SELECT last_insert_rowid();
             """;
-        return ExecuteNonQuery(query, BuildDocumentParameters(doc)) > 0;
+
+        using var conn = OpenConnection();
+        using var cmd = new SqliteCommand(query, conn);
+
+        foreach (var parameter in BuildDocumentParameters(doc))
+            cmd.Parameters.Add(parameter);
+
+        var result = cmd.ExecuteScalar();
+        if (result == null)
+            return false;
+
+        doc.Id = Convert.ToInt32(result);
+        return true;
     }
 
 
     public bool InsertDocumentWithCatalogs(StudyDocument document)
     {
         const string query = """
-            INSERT INTO documents (name, subject, type, file_path, notes, file_size, author, is_important, tags, deadline)
-            VALUES (@name, @subject, @type, @file_path, @notes, @file_size, @author, @is_important, @tags, @deadline)
+            INSERT INTO documents (name, subject, type, file_path, notes, file_size, author, is_important, tags, deadline, status)
+            VALUES (@name, @subject, @type, @file_path, @notes, @file_size, @author, @is_important, @tags, @deadline, @status)
             """;
 
         using var connection = OpenConnection();
@@ -281,7 +320,8 @@ public class DatabaseHelper
             UPDATE documents SET
                 name = @name, subject = @subject, type = @type, file_path = @file_path,
                 notes = @notes, file_size = @file_size, author = @author,
-                is_important = @is_important, tags = @tags, deadline = @deadline
+                is_important = @is_important, tags = @tags, deadline = @deadline,
+                status = @status
             WHERE id = @id
             """;
 
@@ -389,6 +429,28 @@ public class DatabaseHelper
         return ExecuteReader(query);
     }
 
+    public List<StudyDocument> GetUncategorizedDocuments()
+    {
+        const string query = """
+            SELECT * FROM documents
+            WHERE (is_deleted IS NULL OR is_deleted = 0)
+            AND (subject IS NULL OR subject = '')
+            ORDER BY created_at DESC
+            """;
+        return ExecuteReader(query);
+    }
+
+    public List<StudyDocument> GetDocumentsWithMissingMetadata()
+    {
+        const string query = """
+            SELECT * FROM documents
+            WHERE (is_deleted IS NULL OR is_deleted = 0)
+            AND ((subject IS NULL OR subject = '') OR (type IS NULL OR type = '') OR (tags IS NULL OR tags = ''))
+            ORDER BY created_at DESC
+            """;
+        return ExecuteReader(query);
+    }
+
     public DashboardStats GetDashboardStatistics()
     {
         var stats = new DashboardStats();
@@ -419,7 +481,38 @@ public class DatabaseHelper
         using var conn = OpenConnection();
         using var transaction = conn.BeginTransaction();
 
-        using var documentCommand = conn.CreateCommand();
+        if (!RestoreDocumentCore(conn, transaction, id))
+        {
+            transaction.Rollback();
+            return false;
+        }
+
+        transaction.Commit();
+        return true;
+    }
+
+    public int RestoreDocuments(IReadOnlyList<int> ids)
+    {
+        if (ids is null || ids.Count == 0)
+            return 0;
+
+        using var conn = OpenConnection();
+        using var transaction = conn.BeginTransaction();
+
+        var restored = 0;
+        foreach (var id in ids.Distinct())
+        {
+            if (RestoreDocumentCore(conn, transaction, id))
+                restored++;
+        }
+
+        transaction.Commit();
+        return restored;
+    }
+
+    private static bool RestoreDocumentCore(SqliteConnection connection, SqliteTransaction transaction, int id)
+    {
+        using var documentCommand = connection.CreateCommand();
         documentCommand.Transaction = transaction;
         documentCommand.CommandText = "SELECT subject, type FROM documents WHERE id = @id AND is_deleted = 1";
         documentCommand.Parameters.AddWithValue("@id", id);
@@ -433,25 +526,16 @@ public class DatabaseHelper
         reader.Close();
 
         if (!string.IsNullOrWhiteSpace(subject))
-            InsertCatalogValue(conn, transaction, "categories", subject);
+            InsertCatalogValue(connection, transaction, "categories", subject);
 
         if (!string.IsNullOrWhiteSpace(type))
-            InsertCatalogValue(conn, transaction, "document_types", type);
+            InsertCatalogValue(connection, transaction, "document_types", type);
 
-        using var restoreCommand = conn.CreateCommand();
+        using var restoreCommand = connection.CreateCommand();
         restoreCommand.Transaction = transaction;
         restoreCommand.CommandText = "UPDATE documents SET is_deleted = 0, deleted_at = NULL WHERE id = @id AND is_deleted = 1";
         restoreCommand.Parameters.AddWithValue("@id", id);
-        var restored = restoreCommand.ExecuteNonQuery() > 0;
-
-        if (!restored)
-        {
-            transaction.Rollback();
-            return false;
-        }
-
-        transaction.Commit();
-        return true;
+        return restoreCommand.ExecuteNonQuery() > 0;
     }
 
     public bool PermanentDeleteDocument(int id)
@@ -720,10 +804,13 @@ public class DatabaseHelper
         while (tableReader.Read())
             actualTables.Add(tableReader.GetString(0));
 
-        if (!actualTables.SetEquals(requiredTables))
+        var hasSavedSearches = actualTables.Contains("saved_searches");
+        var expectedTables = hasSavedSearches ? [.. requiredTables, "saved_searches"] : requiredTables;
+
+        if (!actualTables.SetEquals(expectedTables))
             throw new InvalidOperationException("Backup database tables are not supported.");
 
-        ValidateRequiredColumns(connection, "documents", ["id", "name", "subject", "type", "file_path", "notes", "created_at", "file_size", "author", "is_important", "tags", "deadline", "is_deleted", "deleted_at"]);
+        ValidateRequiredColumns(connection, "documents", ["id", "name", "subject", "type", "file_path", "notes", "created_at", "file_size", "author", "is_important", "tags", "deadline", "is_deleted", "deleted_at", "status"], ["status"]);
         ValidateRequiredColumns(connection, "collections", ["id", "name", "description", "created_at"]);
         ValidateRequiredColumns(connection, "collection_items", ["id", "collection_id", "document_id", "added_at"]);
         ValidateRequiredColumns(connection, "personal_notes", ["id", "document_id", "content", "created_at", "updated_at"]);
@@ -732,6 +819,8 @@ public class DatabaseHelper
         ValidateRequiredColumns(connection, "categories", ["id", "name", "created_at"]);
         ValidateRequiredColumns(connection, "document_types", ["id", "name", "created_at"]);
         ValidateRequiredColumns(connection, "app_settings", ["key", "value"]);
+        if (hasSavedSearches)
+            ValidateRequiredColumns(connection, "saved_searches", ["id", "name", "criteria_json", "created_at"]);
 
         ValidateCascadeForeignKeys(connection, "collection_items", [("collection_id", "collections", "id"), ("document_id", "documents", "id")]);
         ValidateCascadeForeignKeys(connection, "personal_notes", [("document_id", "documents", "id")]);
@@ -742,12 +831,13 @@ public class DatabaseHelper
         ValidateUniqueConstraint(connection, "document_relations", ["doc_id_1", "doc_id_2"]);
         ValidateDocumentPathIndex(connection, requireDocumentPathIndex);
 
-        foreach (var tableName in requiredTables)
+        foreach (var tableName in expectedTables)
             ValidateIndexesAndTriggers(connection, tableName, allowLegacyDocumentPathIndexes: !requireDocumentPathIndex);
 
         using var schemaVersionCommand = connection.CreateCommand();
         schemaVersionCommand.CommandText = "SELECT value FROM app_settings WHERE key = 'schema_version'";
-        if (!string.Equals(schemaVersionCommand.ExecuteScalar()?.ToString(), "3", StringComparison.Ordinal))
+        var schemaVersion = schemaVersionCommand.ExecuteScalar()?.ToString();
+        if (!string.Equals(schemaVersion, "3", StringComparison.Ordinal) && !string.Equals(schemaVersion, "4", StringComparison.Ordinal))
             throw new InvalidOperationException("Backup database schema version is not supported.");
 
         using (var documentCommand = connection.CreateCommand())
@@ -787,6 +877,9 @@ public class DatabaseHelper
     }
 
     private static void ValidateRequiredColumns(SqliteConnection connection, string tableName, IReadOnlyCollection<string> requiredColumns)
+        => ValidateRequiredColumns(connection, tableName, requiredColumns, []);
+
+    private static void ValidateRequiredColumns(SqliteConnection connection, string tableName, IReadOnlyCollection<string> requiredColumns, IReadOnlyCollection<string> optionalColumns)
     {
         using var command = connection.CreateCommand();
         command.CommandText = $"PRAGMA table_info({tableName})";
@@ -795,7 +888,12 @@ public class DatabaseHelper
         while (reader.Read())
             actualColumns.Add(reader.GetString(1));
 
-        if (!actualColumns.SetEquals(requiredColumns))
+        var unsupportedColumns = actualColumns.Where(column => !requiredColumns.Contains(column, StringComparer.Ordinal)).ToList();
+        if (unsupportedColumns.Count > 0)
+            throw new InvalidOperationException($"Backup database table '{tableName}' is not supported.");
+
+        var missingRequiredColumns = requiredColumns.Except(optionalColumns, StringComparer.Ordinal).Except(actualColumns, StringComparer.Ordinal).ToList();
+        if (missingRequiredColumns.Count > 0)
             throw new InvalidOperationException($"Backup database table '{tableName}' is not supported.");
     }
 
@@ -981,8 +1079,21 @@ private static void ValidateDocumentPathIndex(SqliteConnection connection, bool 
             Author = reader["author"]?.ToString() ?? string.Empty,
             IsImportant = reader["is_important"] is not DBNull && Convert.ToInt32(reader["is_important"]) == 1,
             Tags = reader["tags"]?.ToString() ?? string.Empty,
-            Deadline = reader["deadline"] is DBNull ? null : DateTime.Parse(reader["deadline"].ToString()!)
+            Deadline = reader["deadline"] is DBNull ? null : DateTime.Parse(reader["deadline"].ToString()!),
+            Status = ReadStatus(reader)
         };
+    }
+
+    private static string ReadStatus(SqliteDataReader reader)
+    {
+        for (var i = 0; i < reader.FieldCount; i++)
+        {
+            if (!string.Equals(reader.GetName(i), "status", StringComparison.Ordinal))
+                continue;
+            return reader.IsDBNull(i) ? DocumentStatus.Unread : reader.GetString(i);
+        }
+
+        return DocumentStatus.Unread;
     }
 
     private SqliteParameter[] BuildDocumentParameters(StudyDocument doc)
@@ -998,7 +1109,8 @@ private static void ValidateDocumentPathIndex(SqliteConnection connection, bool 
             new SqliteParameter("@author", string.IsNullOrEmpty(doc.Author) ? DBNull.Value : doc.Author),
             new SqliteParameter("@is_important", doc.IsImportant ? 1 : 0),
             new SqliteParameter("@tags", string.IsNullOrEmpty(doc.Tags) ? DBNull.Value : doc.Tags),
-            new SqliteParameter("@deadline", doc.Deadline.HasValue ? doc.Deadline.Value.ToString("yyyy-MM-dd HH:mm:ss") : DBNull.Value)
+            new SqliteParameter("@deadline", doc.Deadline.HasValue ? doc.Deadline.Value.ToString("yyyy-MM-dd HH:mm:ss") : DBNull.Value),
+            new SqliteParameter("@status", DocumentStatus.IsValid(doc.Status) ? doc.Status : DocumentStatus.Unread)
         ];
     }
 
@@ -1555,6 +1667,150 @@ private static void ValidateDocumentPathIndex(SqliteConnection connection, bool 
         return cmd.ExecuteNonQuery();
     }
 
+    public int BulkUpdateStatus(List<int> ids, string status)
+    {
+        if (ids == null || ids.Count == 0) return 0;
+        if (!DocumentStatus.IsValid(status)) return 0;
+        using var conn = OpenConnection();
+        var paramNames = new List<string>();
+        using var cmd = conn.CreateCommand();
+        for (int i = 0; i < ids.Count; i++)
+        {
+            paramNames.Add($"@id{i}");
+            cmd.Parameters.AddWithValue($"@id{i}", ids[i]);
+        }
+        cmd.Parameters.AddWithValue("@status", status);
+        cmd.CommandText = $"UPDATE documents SET status = @status WHERE id IN ({string.Join(",", paramNames)}) AND (is_deleted IS NULL OR is_deleted = 0)";
+        return cmd.ExecuteNonQuery();
+    }
+
+    public BulkEditOutcome BulkEditMetadata(IReadOnlyList<int> documentIds, BulkEditChanges changes)
+    {
+        var ids = documentIds ?? Array.Empty<int>();
+        var requested = ids.Count;
+        if (requested == 0 || changes is null || !changes.HasAnyChange)
+            return new BulkEditOutcome { Requested = requested };
+
+        var results = new List<BulkItemResult>(requested);
+        using var conn = OpenConnection();
+        using var transaction = conn.BeginTransaction();
+
+        try
+        {
+            foreach (var id in ids)
+            {
+                var succeeded = false;
+                try
+                {
+                    // whitelist check must precede the UPDATE so a rejected field-set never partially applies
+                    if (changes.Status is null || DocumentStatus.IsValid(changes.Status))
+                    {
+                        succeeded = ExecuteBulkEditMetadataUpdate(conn, transaction, id, changes);
+                        if (succeeded && changes.AddToCollectionId is int collectionId)
+                            InsertBulkEditCollectionLink(conn, transaction, collectionId, id);
+                    }
+                }
+                catch (SqliteException)
+                {
+                    succeeded = false;
+                }
+                results.Add(new BulkItemResult(id, succeeded));
+            }
+
+            SeedBulkEditCatalogValues(conn, transaction, changes, results);
+
+            transaction.Commit();
+        }
+        catch
+        {
+            transaction.Rollback();
+            throw;
+        }
+
+        return new BulkEditOutcome
+        {
+            Requested = requested,
+            Succeeded = results.Count(r => r.Success),
+            Items = results
+        };
+    }
+
+    private static bool ExecuteBulkEditMetadataUpdate(
+        SqliteConnection conn, SqliteTransaction transaction, int id, BulkEditChanges changes)
+    {
+        var sets = new List<string>();
+        using var cmd = conn.CreateCommand();
+        cmd.Transaction = transaction;
+
+        if (changes.Subject is not null)
+        {
+            sets.Add("subject = @subject");
+            cmd.Parameters.AddWithValue("@subject", string.IsNullOrEmpty(changes.Subject) ? DBNull.Value : changes.Subject);
+        }
+        if (changes.Type is not null)
+        {
+            sets.Add("type = @type");
+            cmd.Parameters.AddWithValue("@type", string.IsNullOrEmpty(changes.Type) ? DBNull.Value : changes.Type);
+        }
+        if (changes.Tags is not null)
+        {
+            sets.Add("tags = @tags");
+            cmd.Parameters.AddWithValue("@tags", string.IsNullOrEmpty(changes.Tags) ? DBNull.Value : changes.Tags);
+        }
+        if (changes.IsImportant is not null)
+        {
+            sets.Add("is_important = @is_important");
+            cmd.Parameters.AddWithValue("@is_important", changes.IsImportant.Value ? 1 : 0);
+        }
+        if (changes.Deadline is not null)
+        {
+            sets.Add("deadline = @deadline");
+            cmd.Parameters.AddWithValue("@deadline", changes.Deadline.Value.ToString("yyyy-MM-dd HH:mm:ss"));
+        }
+        if (changes.Status is not null)
+        {
+            sets.Add("status = @status");
+            cmd.Parameters.AddWithValue("@status", changes.Status);
+        }
+
+        if (sets.Count == 0)
+        {
+            using var existsCommand = conn.CreateCommand();
+            existsCommand.Transaction = transaction;
+            existsCommand.CommandText = "SELECT COUNT(*) FROM documents WHERE id = @id AND (is_deleted IS NULL OR is_deleted = 0)";
+            existsCommand.Parameters.AddWithValue("@id", id);
+            return Convert.ToInt32(existsCommand.ExecuteScalar()) == 1;
+        }
+
+        cmd.CommandText = $"UPDATE documents SET {string.Join(", ", sets)} WHERE id = @id AND (is_deleted IS NULL OR is_deleted = 0)";
+        cmd.Parameters.AddWithValue("@id", id);
+        return cmd.ExecuteNonQuery() == 1;
+    }
+
+    private static void InsertBulkEditCollectionLink(
+        SqliteConnection conn, SqliteTransaction transaction, int collectionId, int documentId)
+    {
+        using var cmd = conn.CreateCommand();
+        cmd.Transaction = transaction;
+        cmd.CommandText = "INSERT OR IGNORE INTO collection_items (collection_id, document_id) VALUES (@collectionId, @documentId)";
+        cmd.Parameters.AddWithValue("@collectionId", collectionId);
+        cmd.Parameters.AddWithValue("@documentId", documentId);
+        cmd.ExecuteNonQuery();
+    }
+
+    private static void SeedBulkEditCatalogValues(
+        SqliteConnection conn, SqliteTransaction transaction, BulkEditChanges changes, IReadOnlyList<BulkItemResult> results)
+    {
+        if (!results.Any(r => r.Success))
+            return;
+
+        if (!string.IsNullOrWhiteSpace(changes.Subject))
+            InsertCatalogValue(conn, transaction, "categories", changes.Subject);
+
+        if (!string.IsNullOrWhiteSpace(changes.Type))
+            InsertCatalogValue(conn, transaction, "document_types", changes.Type);
+    }
+
 
 
     public int EmptyRecycleBin()
@@ -1716,6 +1972,86 @@ private static void ValidateDocumentPathIndex(SqliteConnection connection, bool 
         cmd.Parameters.AddWithValue("@key", key);
         cmd.Parameters.AddWithValue("@value", value);
         cmd.ExecuteNonQuery();
+    }
+
+    public List<SavedSearch> GetSavedSearches()
+    {
+        const string query = "SELECT * FROM saved_searches ORDER BY name COLLATE NOCASE";
+        var results = new List<SavedSearch>();
+        using var conn = OpenConnection();
+        using var cmd = new SqliteCommand(query, conn);
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read())
+            results.Add(MapToSavedSearch(reader));
+        return results;
+    }
+
+    public SavedSearch? GetSavedSearchById(int id)
+    {
+        const string query = "SELECT * FROM saved_searches WHERE id = @id";
+        using var conn = OpenConnection();
+        using var cmd = new SqliteCommand(query, conn);
+        cmd.Parameters.AddWithValue("@id", id);
+        using var reader = cmd.ExecuteReader();
+        return reader.Read() ? MapToSavedSearch(reader) : null;
+    }
+
+    public bool SavedSearchNameExists(string name)
+    {
+        const string query = "SELECT COUNT(*) FROM saved_searches WHERE name = @name COLLATE NOCASE";
+        using var conn = OpenConnection();
+        using var cmd = new SqliteCommand(query, conn);
+        cmd.Parameters.AddWithValue("@name", name);
+        return Convert.ToInt32(cmd.ExecuteScalar()) > 0;
+    }
+
+    public int InsertSavedSearch(SavedSearch savedSearch)
+    {
+        const string query = """
+            INSERT INTO saved_searches (name, criteria_json)
+            VALUES (@name, @criteria_json);
+            SELECT last_insert_rowid();
+            """;
+        using var conn = OpenConnection();
+        using var cmd = new SqliteCommand(query, conn);
+        cmd.Parameters.AddWithValue("@name", savedSearch.Name);
+        cmd.Parameters.AddWithValue("@criteria_json", savedSearch.CriteriaJson);
+        var result = cmd.ExecuteScalar();
+        return result != null ? Convert.ToInt32(result) : 0;
+    }
+
+    public bool UpdateSavedSearch(SavedSearch savedSearch)
+    {
+        const string query = """
+            UPDATE saved_searches SET name = @name, criteria_json = @criteria_json
+            WHERE id = @id
+            """;
+        using var conn = OpenConnection();
+        using var cmd = new SqliteCommand(query, conn);
+        cmd.Parameters.AddWithValue("@id", savedSearch.Id);
+        cmd.Parameters.AddWithValue("@name", savedSearch.Name);
+        cmd.Parameters.AddWithValue("@criteria_json", savedSearch.CriteriaJson);
+        return cmd.ExecuteNonQuery() > 0;
+    }
+
+    public bool DeleteSavedSearch(int id)
+    {
+        const string query = "DELETE FROM saved_searches WHERE id = @id";
+        using var conn = OpenConnection();
+        using var cmd = new SqliteCommand(query, conn);
+        cmd.Parameters.AddWithValue("@id", id);
+        return cmd.ExecuteNonQuery() > 0;
+    }
+
+    private static SavedSearch MapToSavedSearch(SqliteDataReader reader)
+    {
+        return new SavedSearch
+        {
+            Id = reader.GetInt32(reader.GetOrdinal("id")),
+            Name = reader["name"]?.ToString() ?? string.Empty,
+            CriteriaJson = reader["criteria_json"]?.ToString() ?? string.Empty,
+            CreatedAt = reader["created_at"] is DBNull ? DateTime.Now : DateTime.Parse(reader["created_at"].ToString()!)
+        };
     }
 
 }

--- a/StudyDocumentManager.Data/Helpers/DatabaseMigrator.cs
+++ b/StudyDocumentManager.Data/Helpers/DatabaseMigrator.cs
@@ -29,7 +29,8 @@ public static class DatabaseMigrator
                 tags TEXT,
                 deadline DATETIME,
                 is_deleted INTEGER DEFAULT 0,
-                deleted_at DATETIME
+                deleted_at DATETIME,
+                status TEXT NOT NULL DEFAULT 'unread'
             );
 
             CREATE TABLE IF NOT EXISTS collections (
@@ -93,6 +94,13 @@ public static class DatabaseMigrator
                 value TEXT
             );
 
+            CREATE TABLE IF NOT EXISTS saved_searches (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL UNIQUE COLLATE NOCASE,
+                criteria_json TEXT NOT NULL,
+                created_at DATETIME DEFAULT (datetime('now', 'localtime'))
+            );
+
             CREATE INDEX IF NOT EXISTS idx_documents_subject ON documents(subject);
             CREATE INDEX IF NOT EXISTS idx_documents_type ON documents(type);
             CREATE INDEX IF NOT EXISTS idx_documents_created_at ON documents(created_at);
@@ -116,6 +124,7 @@ public static class DatabaseMigrator
             ExecuteSql(conn, transaction, createTablesQuery);
             MigrateAddColumn(conn, transaction, "documents", "is_deleted", "INTEGER DEFAULT 0");
             MigrateAddColumn(conn, transaction, "documents", "deleted_at", "DATETIME");
+            MigrateAddColumn(conn, transaction, "documents", "status", "TEXT NOT NULL DEFAULT 'unread'");
             ExecuteSql(conn, transaction, "PRAGMA defer_foreign_keys = ON");
 
             if (preflight.RebuildDocuments)
@@ -136,6 +145,7 @@ public static class DatabaseMigrator
         MigrateSeedCategories(conn);
         MigrateNormalizeFileTypes(conn);
         MigrateNeutralizeLabels(conn);
+        MigrateWriteSchemaVersion4(conn);
     }
 
     private sealed record MigrationPreflight(IReadOnlyList<string> TablesToRebuild, bool RebuildDocuments);
@@ -147,7 +157,7 @@ public static class DatabaseMigrator
     {
         if (TableExists(connection, "documents"))
         {
-            RequireColumns(connection, "documents", ["id", "name", "subject", "type", "file_path", "notes", "created_at", "file_size", "author", "is_important", "tags", "deadline", "is_deleted", "deleted_at"], ["is_deleted", "deleted_at"]);
+            RequireColumns(connection, "documents", ["id", "name", "subject", "type", "file_path", "notes", "created_at", "file_size", "author", "is_important", "tags", "deadline", "is_deleted", "deleted_at", "status"], ["is_deleted", "deleted_at", "status"]);
             EnsureNoUnsupportedIndexesOrTriggers(connection, "documents");
         }
 
@@ -155,6 +165,7 @@ public static class DatabaseMigrator
         ValidateKnownTable(connection, "categories", ["id", "name", "created_at"]);
         ValidateKnownTable(connection, "document_types", ["id", "name", "created_at"]);
         ValidateKnownTable(connection, "app_settings", ["key", "value"]);
+        ValidateKnownTable(connection, "saved_searches", ["id", "name", "criteria_json", "created_at"]);
     }
 
     private static void MigrateLegacyVietnameseSchema(SqliteConnection connection, string createTablesQuery)
@@ -197,6 +208,7 @@ public static class DatabaseMigrator
         {
             "documents", "collections", "collection_items", "personal_notes", "recent_files",
             "document_relations", "categories", "document_types", "app_settings",
+            "saved_searches",
             "tai_lieu", "danh_muc", "loai_tai_lieu"
         };
         var unsupportedTables = tables.Where(table => !supportedTables.Contains(table)).ToList();
@@ -353,18 +365,19 @@ public static class DatabaseMigrator
         var supportedTables = new HashSet<string>(StringComparer.Ordinal)
         {
             "documents", "collections", "collection_items", "personal_notes", "recent_files",
-            "document_relations", "categories", "document_types", "app_settings"
+            "document_relations", "categories", "document_types", "app_settings", "saved_searches"
         };
         var unsupportedTables = tables.Where(table => !supportedTables.Contains(table)).ToList();
         if (unsupportedTables.Count > 0)
             throw new InvalidOperationException($"Unsupported database tables: {string.Join(", ", unsupportedTables)}.");
 
-        RequireColumns(connection, "documents", ["id", "name", "subject", "type", "file_path", "notes", "created_at", "file_size", "author", "is_important", "tags", "deadline", "is_deleted", "deleted_at"], ["is_deleted", "deleted_at"]);
+        RequireColumns(connection, "documents", ["id", "name", "subject", "type", "file_path", "notes", "created_at", "file_size", "author", "is_important", "tags", "deadline", "is_deleted", "deleted_at", "status"], ["is_deleted", "deleted_at", "status"]);
         var rebuildDocuments = ValidateDocumentIndexesAndTriggers(connection);
         ValidateKnownTable(connection, "collections", ["id", "name", "description", "created_at"]);
         ValidateKnownTable(connection, "categories", ["id", "name", "created_at"]);
         ValidateKnownTable(connection, "document_types", ["id", "name", "created_at"]);
         ValidateKnownTable(connection, "app_settings", ["key", "value"]);
+        ValidateKnownTable(connection, "saved_searches", ["id", "name", "criteria_json", "created_at"]);
 
         var tablesToRebuild = new List<string>();
         ValidateChildTable(connection, "collection_items", ["id", "collection_id", "document_id", "added_at"],
@@ -571,8 +584,8 @@ public static class DatabaseMigrator
 
     private static void RebuildDocumentsTable(SqliteConnection connection, SqliteTransaction transaction)
     {
-        ExecuteSql(connection, transaction, "CREATE TABLE documents_rebuild (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, subject TEXT, type TEXT, file_path TEXT, notes TEXT, created_at DATETIME DEFAULT (datetime('now', 'localtime')), file_size REAL, author TEXT, is_important INTEGER DEFAULT 0, tags TEXT, deadline DATETIME, is_deleted INTEGER DEFAULT 0, deleted_at DATETIME)");
-        ExecuteSql(connection, transaction, "INSERT INTO documents_rebuild (id, name, subject, type, file_path, notes, created_at, file_size, author, is_important, tags, deadline, is_deleted, deleted_at) SELECT id, name, subject, type, file_path, notes, created_at, file_size, author, is_important, tags, deadline, is_deleted, deleted_at FROM documents");
+        ExecuteSql(connection, transaction, "CREATE TABLE documents_rebuild (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, subject TEXT, type TEXT, file_path TEXT, notes TEXT, created_at DATETIME DEFAULT (datetime('now', 'localtime')), file_size REAL, author TEXT, is_important INTEGER DEFAULT 0, tags TEXT, deadline DATETIME, is_deleted INTEGER DEFAULT 0, deleted_at DATETIME, status TEXT NOT NULL DEFAULT 'unread')");
+        ExecuteSql(connection, transaction, "INSERT INTO documents_rebuild (id, name, subject, type, file_path, notes, created_at, file_size, author, is_important, tags, deadline, is_deleted, deleted_at, status) SELECT id, name, subject, type, file_path, notes, created_at, file_size, author, is_important, tags, deadline, is_deleted, deleted_at, status FROM documents");
         ExecuteSql(connection, transaction, "DROP TABLE documents");
         ExecuteSql(connection, transaction, "ALTER TABLE documents_rebuild RENAME TO documents");
     }
@@ -937,5 +950,17 @@ public static class DatabaseMigrator
             tx.Rollback();
             throw;
         }
+    }
+
+    private static void MigrateWriteSchemaVersion4(SqliteConnection conn)
+    {
+        using var checkCmd = conn.CreateCommand();
+        checkCmd.CommandText = "SELECT value FROM app_settings WHERE key = 'schema_version'";
+        var currentVersion = checkCmd.ExecuteScalar()?.ToString();
+        if (int.TryParse(currentVersion, out var ver) && ver >= 4)
+            return;
+
+        using var cmd = new SqliteCommand("INSERT OR REPLACE INTO app_settings (key, value) VALUES ('schema_version', '4')", conn);
+        cmd.ExecuteNonQuery();
     }
 }

--- a/StudyDocumentManager.Data/Repositories/DocumentRepository.cs
+++ b/StudyDocumentManager.Data/Repositories/DocumentRepository.cs
@@ -27,6 +27,14 @@ public class DocumentRepository : IDocumentRepository, IRecycleBinRepository, IB
         double? minSize, double? maxSize, bool? isImportant)
         => _db.SearchDocumentsAdvanced(keyword, subject, type, fromDate, toDate, minSize, maxSize, isImportant);
 
+    public List<StudyDocument> SearchAdvancedWithStatus(
+        string? keyword, string? subject, string? type,
+        DateTime? fromDate, DateTime? toDate,
+        double? minSize, double? maxSize, bool? isImportant, string? status)
+        => _db.SearchDocumentsAdvanced(keyword, subject, type, fromDate, toDate, minSize, maxSize, isImportant, status);
+
+    public Dictionary<string, int> GetStatusCounts() => _db.GetStatusCounts();
+
     public bool Add(StudyDocument document) => _db.InsertDocument(document);
 
 
@@ -46,6 +54,10 @@ public class DocumentRepository : IDocumentRepository, IRecycleBinRepository, IB
 
     public List<StudyDocument> GetOverdueDocuments() => _db.GetOverdueDocuments();
 
+    public List<StudyDocument> GetUncategorizedDocuments() => _db.GetUncategorizedDocuments();
+
+    public List<StudyDocument> GetDocumentsWithMissingMetadata() => _db.GetDocumentsWithMissingMetadata();
+
     public void EnsureSubjectExists(string subject)
     {
         if (!string.IsNullOrWhiteSpace(subject))
@@ -63,6 +75,8 @@ public class DocumentRepository : IDocumentRepository, IRecycleBinRepository, IB
 
     public bool RestoreDocument(int id) => _db.RestoreDocument(id);
 
+    public int RestoreDocuments(IReadOnlyList<int> ids) => _db.RestoreDocuments(ids);
+
     public bool PermanentDeleteDocument(int id) => _db.PermanentDeleteDocument(id);
 
     public int EmptyRecycleBin() => _db.EmptyRecycleBin();
@@ -75,6 +89,11 @@ public class DocumentRepository : IDocumentRepository, IRecycleBinRepository, IB
     public int BulkUpdateSubject(List<int> ids, string subject) => _db.BulkUpdateSubject(ids, subject);
 
     public int BulkToggleImportant(List<int> ids, bool important) => _db.BulkToggleImportant(ids, important);
+
+    public int BulkUpdateStatus(List<int> ids, string status) => _db.BulkUpdateStatus(ids, status);
+
+    public BulkEditOutcome BulkEditMetadata(IReadOnlyList<int> documentIds, BulkEditChanges changes)
+        => _db.BulkEditMetadata(documentIds, changes);
 
     // ——— File integrity ———————————————————————————————————————
     public bool UpdateDocumentPath(int id, string newPath) => _db.UpdateDocumentPath(id, newPath);

--- a/StudyDocumentManager.Data/Repositories/DocumentRepository.cs
+++ b/StudyDocumentManager.Data/Repositories/DocumentRepository.cs
@@ -7,7 +7,7 @@ namespace StudyDocumentManager.Data.Repositories;
 /// <summary>
 /// Implements all document-related repository interfaces using DatabaseHelper.
 /// </summary>
-public class DocumentRepository : IDocumentRepository, IRecycleBinRepository, IBulkOperationRepository, IFileIntegrityRepository
+public class DocumentRepository : IDocumentRepository, IRecycleBinRepository, IBulkOperationRepository, IFileIntegrityRepository, IUndoRepository
 {
     private readonly DatabaseHelper _db;
 
@@ -41,6 +41,11 @@ public class DocumentRepository : IDocumentRepository, IRecycleBinRepository, IB
     public bool AddWithCatalogs(StudyDocument document) => _db.InsertDocumentWithCatalogs(document);
 
     public bool Update(StudyDocument document) => _db.UpdateDocument(document);
+
+    public void ApplyMetadataUndo(
+        IReadOnlyList<StudyDocument> originals,
+        IReadOnlyList<(int CollectionId, int DocumentId)> addedCollectionMemberships)
+        => _db.ApplyMetadataUndo(originals, addedCollectionMemberships);
 
     public bool Delete(int id) => _db.DeleteDocument(id);
 

--- a/StudyDocumentManager.Data/Repositories/SavedSearchRepository.cs
+++ b/StudyDocumentManager.Data/Repositories/SavedSearchRepository.cs
@@ -1,0 +1,24 @@
+using StudyDocumentManager.Core.Entities;
+using StudyDocumentManager.Core.Interfaces;
+using StudyDocumentManager.Data.Helpers;
+
+namespace StudyDocumentManager.Data.Repositories;
+
+public class SavedSearchRepository : ISavedSearchRepository
+{
+    private readonly DatabaseHelper _db;
+
+    public SavedSearchRepository(DatabaseHelper db) => _db = db;
+
+    public List<SavedSearch> GetAll() => _db.GetSavedSearches();
+
+    public SavedSearch? GetById(int id) => _db.GetSavedSearchById(id);
+
+    public bool NameExists(string name) => _db.SavedSearchNameExists(name);
+
+    public int Add(SavedSearch savedSearch) => _db.InsertSavedSearch(savedSearch);
+
+    public bool Update(SavedSearch savedSearch) => _db.UpdateSavedSearch(savedSearch);
+
+    public bool Delete(int id) => _db.DeleteSavedSearch(id);
+}

--- a/StudyDocumentManager.Tests/BulkEditDataTests.cs
+++ b/StudyDocumentManager.Tests/BulkEditDataTests.cs
@@ -1,0 +1,245 @@
+using Microsoft.Data.Sqlite;
+using StudyDocumentManager.Core.Entities;
+using StudyDocumentManager.Data.Repositories;
+using Xunit;
+
+namespace StudyDocumentManager.Tests;
+
+public class BulkEditDataTests : DatabaseTestBase
+{
+    [Fact]
+    public void BulkEditMetadata_MixedFieldsOnMultipleDocs_AllSucceedAndPersist()
+    {
+        var docs = new[]
+        {
+            new StudyDocument { Name = "Doc A" },
+            new StudyDocument { Name = "Doc B" },
+            new StudyDocument { Name = "Doc C" }
+        };
+        foreach (var doc in docs)
+            Assert.True(Repo.Add(doc));
+
+        var changes = new BulkEditChanges
+        {
+            Subject = "Physics",
+            Type = "Lecture Note",
+            Tags = "bulk;edit",
+            IsImportant = true,
+            Status = DocumentStatus.Completed
+        };
+
+        var outcome = Repo.BulkEditMetadata(docs.Select(d => d.Id).ToList(), changes);
+
+        Assert.Equal(3, outcome.Requested);
+        Assert.Equal(3, outcome.Succeeded);
+        Assert.Empty(outcome.FailedIds);
+        foreach (var doc in docs)
+        {
+            var loaded = Repo.GetById(doc.Id)!;
+            Assert.Equal("Physics", loaded.Subject);
+            Assert.Equal("Lecture Note", loaded.Type);
+            Assert.Equal("bulk;edit", loaded.Tags);
+            Assert.True(loaded.IsImportant);
+            Assert.Equal(DocumentStatus.Completed, loaded.Status);
+        }
+    }
+
+    [Fact]
+    public void BulkEditMetadata_MissingAndSoftDeletedIds_FailPerItemWhileValidDocsUpdate()
+    {
+        var activeA = new StudyDocument { Name = "Active A" };
+        var activeB = new StudyDocument { Name = "Active B" };
+        var softDeleted = new StudyDocument { Name = "Soft deleted" };
+        Assert.True(Repo.Add(activeA));
+        Assert.True(Repo.Add(activeB));
+        Assert.True(Repo.Add(softDeleted));
+        Assert.True(Repo.Delete(softDeleted.Id));
+
+        const int missingId = 987654321;
+        var outcome = Repo.BulkEditMetadata(
+            [missingId, activeA.Id, softDeleted.Id, activeB.Id],
+            new BulkEditChanges { Subject = "History", Status = DocumentStatus.Read });
+
+        Assert.Equal(4, outcome.Requested);
+        Assert.Equal(2, outcome.Succeeded);
+        Assert.Equal([missingId, softDeleted.Id], outcome.FailedIds);
+        Assert.False(outcome.Items.Single(r => r.DocumentId == missingId).Success);
+        Assert.True(outcome.Items.Single(r => r.DocumentId == activeA.Id).Success);
+
+        Assert.Equal("History", Repo.GetById(activeA.Id)!.Subject);
+        Assert.Equal("History", Repo.GetById(activeB.Id)!.Subject);
+        var untouched = Repo.GetById(softDeleted.Id)!;
+        Assert.Equal(string.Empty, untouched.Subject);
+        Assert.Equal(DocumentStatus.Unread, untouched.Status);
+    }
+
+    [Fact]
+    public void BulkEditMetadata_EmptyIdList_ReturnsZeroOutcomeWithoutWrites()
+    {
+        var doc = new StudyDocument { Name = "Idle document" };
+        Assert.True(Repo.Add(doc));
+
+        var outcome = Repo.BulkEditMetadata([], new BulkEditChanges { Subject = "Ignored" });
+
+        Assert.Equal(0, outcome.Requested);
+        Assert.Equal(0, outcome.Succeeded);
+        Assert.Empty(outcome.Items);
+        Assert.Equal("Idle document", Repo.GetById(doc.Id)!.Name);
+    }
+
+    [Fact]
+    public void BulkEditMetadata_NoFieldSet_ReturnsRequestedOnlyWithoutException()
+    {
+        var doc = new StudyDocument { Name = "Untouched", Subject = "Original" };
+        Assert.True(Repo.Add(doc));
+
+        var outcome = Repo.BulkEditMetadata([doc.Id], new BulkEditChanges());
+
+        Assert.Equal(1, outcome.Requested);
+        Assert.Equal(0, outcome.Succeeded);
+        Assert.Empty(outcome.Items);
+        var loaded = Repo.GetById(doc.Id)!;
+        Assert.Equal("Original", loaded.Subject);
+        Assert.Equal(DocumentStatus.Unread, loaded.Status);
+    }
+
+    [Fact]
+    public void BulkEditMetadata_BogusStatusWithOtherFieldsSet_FailsItemBeforeAnyWrite()
+    {
+        var doc = new StudyDocument { Name = "Guarded", Subject = "Old subject" };
+        Assert.True(Repo.Add(doc));
+
+        var outcome = Repo.BulkEditMetadata(
+            [doc.Id],
+            new BulkEditChanges { Subject = "New subject", IsImportant = true, Status = "bogus" });
+
+        Assert.Equal(1, outcome.Requested);
+        Assert.Equal(0, outcome.Succeeded);
+        Assert.Equal([doc.Id], outcome.FailedIds);
+
+        var loaded = Repo.GetById(doc.Id)!;
+        Assert.Equal("Old subject", loaded.Subject);
+        Assert.False(loaded.IsImportant);
+    }
+
+    [Fact]
+    public void BulkEditMetadata_DeadlineAndImportant_RoundtripTypesThroughGetById()
+    {
+        var doc = new StudyDocument { Name = "Dated document", IsImportant = true };
+        Assert.True(Repo.Add(doc));
+        var deadline = new DateTime(2030, 12, 31, 13, 45, 30);
+
+        var outcome = Repo.BulkEditMetadata(
+            [doc.Id],
+            new BulkEditChanges { Deadline = deadline, IsImportant = false });
+
+        Assert.Equal(1, outcome.Succeeded);
+        var loaded = Repo.GetById(doc.Id)!;
+        Assert.NotNull(loaded.Deadline);
+        Assert.Equal(deadline, loaded.Deadline.Value);
+        Assert.False(loaded.IsImportant);
+    }
+
+    [Fact]
+    public void BulkEditMetadata_AddToCollection_LinksSucceededIdsOnlyAndIsIdempotent()
+    {
+        var activeA = new StudyDocument { Name = "Link A" };
+        var activeB = new StudyDocument { Name = "Link B" };
+        var softDeleted = new StudyDocument { Name = "Link C" };
+        Assert.True(Repo.Add(activeA));
+        Assert.True(Repo.Add(activeB));
+        Assert.True(Repo.Add(softDeleted));
+        Assert.True(Repo.Delete(softDeleted.Id));
+
+        var collectionId = Db.CreateCollection("Bulk target");
+        var changes = new BulkEditChanges { Status = DocumentStatus.Archived, AddToCollectionId = collectionId };
+
+        var firstRun = Repo.BulkEditMetadata([activeA.Id, softDeleted.Id, activeB.Id], changes);
+
+        Assert.Equal(2, firstRun.Succeeded);
+        Assert.Equal(1, CountLinks(collectionId, activeA.Id));
+        Assert.Equal(1, CountLinks(collectionId, activeB.Id));
+        Assert.Equal(0, CountLinks(collectionId, softDeleted.Id));
+
+        Repo.BulkEditMetadata([activeA.Id, activeB.Id], changes);
+
+        Assert.Equal(1, CountLinks(collectionId, activeA.Id));
+        Assert.Equal(1, CountLinks(collectionId, activeB.Id));
+    }
+
+    [Fact]
+    public void BulkEditMetadata_MembershipOnlyChange_LinksActiveDocsOnly()
+    {
+        var doc = new StudyDocument { Name = "Solo" };
+        var deletedDoc = new StudyDocument { Name = "Gone" };
+        Assert.True(Repo.Add(doc));
+        Assert.True(Repo.Add(deletedDoc));
+        Assert.True(Repo.Delete(deletedDoc.Id));
+
+        var collectionId = Db.CreateCollection("Only link");
+
+        var outcome = Repo.BulkEditMetadata(
+            [doc.Id, deletedDoc.Id],
+            new BulkEditChanges { AddToCollectionId = collectionId });
+
+        Assert.Equal(2, outcome.Requested);
+        Assert.Equal(1, outcome.Succeeded);
+        Assert.Equal([deletedDoc.Id], outcome.FailedIds);
+        Assert.Equal(1, CountLinks(collectionId, doc.Id));
+        Assert.Equal(0, CountLinks(collectionId, deletedDoc.Id));
+    }
+
+    [Fact]
+    public void BulkEditMetadata_NewSubjectValue_SeedsCategoryCatalog()
+    {
+        var categoryRepo = new CategoryRepository(Db);
+        var doc = new StudyDocument { Name = "Catalog source" };
+        Assert.True(Repo.Add(doc));
+
+        Repo.BulkEditMetadata([doc.Id], new BulkEditChanges { Subject = "Brand New Subject" });
+
+        Assert.Contains("Brand New Subject", categoryRepo.GetAllSubjects());
+    }
+
+    [Fact]
+    public void BulkEditMetadata_PartialFailureLeavesDatabaseConsistent()
+    {
+        var active = new StudyDocument { Name = "Consistent active", Subject = "Before" };
+        var softDeleted = new StudyDocument { Name = "Consistent deleted", Subject = "Before" };
+        Assert.True(Repo.Add(active));
+        Assert.True(Repo.Add(softDeleted));
+        Assert.True(Repo.Delete(softDeleted.Id));
+
+        var outcome = Repo.BulkEditMetadata(
+            [999999999, active.Id, softDeleted.Id],
+            new BulkEditChanges { Subject = "After", Type = "Essay" });
+
+        Assert.Equal(3, outcome.Requested);
+        Assert.Equal(1, outcome.Succeeded);
+        Assert.Single(Repo.GetAll());
+        Assert.Contains(softDeleted.Id, Repo.GetDeletedDocuments().Select(d => d.Id));
+        Assert.Equal("After", Repo.GetById(active.Id)!.Subject);
+        Assert.Equal("Before", Repo.GetById(softDeleted.Id)!.Subject);
+        using (var connection = new SqliteConnection(Db.ConnectionString))
+        {
+            connection.Open();
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "PRAGMA foreign_key_check";
+            Assert.False(cmd.ExecuteReader().Read());
+        }
+    }
+
+    private int CountLinks(int collectionId, int documentId)
+    {
+        using var connection = new SqliteConnection(Db.ConnectionString);
+        connection.Open();
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = """
+            SELECT COUNT(*) FROM collection_items
+            WHERE collection_id = @collectionId AND document_id = @documentId
+            """;
+        cmd.Parameters.AddWithValue("@collectionId", collectionId);
+        cmd.Parameters.AddWithValue("@documentId", documentId);
+        return Convert.ToInt32(cmd.ExecuteScalar());
+    }
+}

--- a/StudyDocumentManager.Tests/BulkEditDataTests.cs
+++ b/StudyDocumentManager.Tests/BulkEditDataTests.cs
@@ -229,6 +229,60 @@ public class BulkEditDataTests : DatabaseTestBase
         }
     }
 
+    [Fact]
+    public void BulkEditMetadata_NonexistentTargetCollection_FailsAllItemsWithoutAnyWrite()
+    {
+        var docA = new StudyDocument { Name = "Doc A", Subject = "Before", Status = DocumentStatus.Unread };
+        var docB = new StudyDocument { Name = "Doc B", Subject = "Before", Status = DocumentStatus.Unread };
+        Assert.True(Repo.Add(docA));
+        Assert.True(Repo.Add(docB));
+
+        const int missingCollectionId = 987654321;
+        var outcome = Repo.BulkEditMetadata(
+            [docA.Id, docB.Id],
+            new BulkEditChanges { Subject = "Physics", Status = DocumentStatus.Read, AddToCollectionId = missingCollectionId });
+
+        Assert.Equal(2, outcome.Requested);
+        Assert.Equal(0, outcome.Succeeded);
+        Assert.Equal([docA.Id, docB.Id], outcome.FailedIds);
+
+        foreach (var doc in new[] { docA, docB })
+        {
+            var loaded = Repo.GetById(doc.Id)!;
+            Assert.Equal("Before", loaded.Subject);
+            Assert.Equal(DocumentStatus.Unread, loaded.Status);
+            Assert.Equal(0, CountLinks(missingCollectionId, doc.Id));
+        }
+        Assert.DoesNotContain("Physics", new CategoryRepository(Db).GetAllSubjects());
+    }
+
+    [Fact]
+    public void BulkEditMetadata_CollectionLinkWithSoftDeletedId_FailedItemKeepsMetadataUntouched()
+    {
+        var active = new StudyDocument { Name = "Active", Subject = "Before" };
+        var softDeleted = new StudyDocument { Name = "Deleted", Subject = "Before", Status = DocumentStatus.Unread };
+        Assert.True(Repo.Add(active));
+        Assert.True(Repo.Add(softDeleted));
+        Assert.True(Repo.Delete(softDeleted.Id));
+
+        var collectionId = Db.CreateCollection("Atomic target");
+        var changes = new BulkEditChanges { Subject = "Physics", AddToCollectionId = collectionId };
+
+        var outcome = Repo.BulkEditMetadata([active.Id, softDeleted.Id], changes);
+
+        Assert.Equal(2, outcome.Requested);
+        Assert.Equal(1, outcome.Succeeded);
+        Assert.Equal([softDeleted.Id], outcome.FailedIds);
+        Assert.Equal("Physics", Repo.GetById(active.Id)!.Subject);
+        Assert.Equal("Before", Repo.GetById(softDeleted.Id)!.Subject);
+        Assert.Equal(0, CountLinks(collectionId, softDeleted.Id));
+
+        Repo.BulkEditMetadata([active.Id, softDeleted.Id], changes);
+
+        Assert.Equal(1, CountLinks(collectionId, active.Id));
+        Assert.Equal(0, CountLinks(collectionId, softDeleted.Id));
+    }
+
     private int CountLinks(int collectionId, int documentId)
     {
         using var connection = new SqliteConnection(Db.ConnectionString);

--- a/StudyDocumentManager.Tests/BulkEditUiTests.cs
+++ b/StudyDocumentManager.Tests/BulkEditUiTests.cs
@@ -1,0 +1,350 @@
+using StudyDocumentManager.Core;
+using StudyDocumentManager.Core.DTOs;
+using StudyDocumentManager.Core.Entities;
+using StudyDocumentManager.Core.Interfaces;
+using StudyDocumentManager.Data.Repositories;
+using StudyDocumentManager.Models;
+using StudyDocumentManager.Services;
+using Xunit;
+
+namespace StudyDocumentManager.Tests;
+
+public class BulkEditUiTests : DatabaseTestBase
+{
+    private BulkDeleteModel CreateModel(
+        BulkEditMetadataStub bulkRepo,
+        RecordingPreviewDialogService? previewDialog = null,
+        UndoService? undo = null,
+        BulkEditDialogStub? dialogStub = null)
+    {
+        var documentRepo = new DocumentRepository(Db);
+        return new BulkDeleteModel(
+            documentRepo,
+            bulkRepo,
+            new CategoryRepository(Db),
+            dialogStub ?? new BulkEditDialogStub(),
+            new BulkEditNavigationStub(),
+            new BulkEditLocalizationStub(),
+            previewDialog ?? new RecordingPreviewDialogService(),
+            new CollectionRepository(Db),
+            undo ?? new UndoService());
+    }
+
+    [Fact]
+    public async Task Apply_NoSelection_GatedAndNothingMutated()
+    {
+        var documentRepo = new DocumentRepository(Db);
+        var bulkRepo = new BulkEditMetadataStub(documentRepo);
+        var dialog = new RecordingPreviewDialogService();
+        Repo.Add(new StudyDocument { Name = "Alpha", Subject = "Math", Type = "PDF" });
+        var model = CreateModel(bulkRepo, dialog);
+        model.Initialize();
+
+        model.EnableSubject = true;
+        model.NewSubject = "Physics";
+        Assert.False(model.ApplyBulkEditCommand.CanExecute(null));
+
+        await model.ApplyBulkEditCommand.ExecuteAsync(null);
+
+        Assert.Equal(0, bulkRepo.CallCount);
+        Assert.Empty(dialog.PreviewCalls);
+        Assert.All(documentRepo.GetAll(), d => Assert.Equal("Math", d.Subject));
+    }
+
+    [Fact]
+    public void Apply_SelectionWithEnabledField_CanExecute()
+    {
+        var bulkRepo = new BulkEditMetadataStub(new DocumentRepository(Db));
+        Repo.Add(new StudyDocument { Name = "Alpha", Subject = "Math", Type = "PDF" });
+        var model = CreateModel(bulkRepo);
+        model.Initialize();
+        model.Documents[0].IsSelected = true;
+
+        Assert.False(model.HasAnyEnabledChange);
+        Assert.False(model.ApplyBulkEditCommand.CanExecute(null));
+
+        model.EnableStatus = true;
+        Assert.True(model.HasAnyEnabledChange);
+        Assert.True(model.ApplyBulkEditCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public async Task Apply_HappyPath_UpdatesDb_UndoRestoresAllPriorFields()
+    {
+        var documentRepo = new DocumentRepository(Db);
+        var bulkRepo = new BulkEditMetadataStub(documentRepo);
+        var dialog = new RecordingPreviewDialogService { PreviewResult = true };
+        var undo = new UndoService();
+
+        Repo.Add(new StudyDocument { Name = "Alpha", Subject = "Math", Type = "PDF", Status = DocumentStatus.Unread, Tags = "", IsImportant = false });
+        Repo.Add(new StudyDocument { Name = "Beta", Subject = "Chemistry", Type = "DOCX", Status = DocumentStatus.Read, Tags = "chem", IsImportant = true });
+        Repo.Add(new StudyDocument { Name = "Gamma", Subject = "History", Type = "PDF", Status = DocumentStatus.InProgress, Tags = "hist", IsImportant = false });
+        var ids = documentRepo.GetAll().Select(d => d.Id).ToList();
+
+        var originals = documentRepo.GetAll().ToDictionary(d => d.Id, Clone);
+
+        var model = CreateModel(bulkRepo, dialog, undo);
+        model.Initialize();
+        foreach (var row in model.Documents)
+            row.IsSelected = true;
+        model.EnableSubject = true;
+        model.NewSubject = "Physics";
+        model.EnableTags = true;
+        model.NewTags = "bulk";
+        model.EnableStatus = true;
+        model.NewStatus = DocumentStatus.Completed;
+
+        await model.ApplyBulkEditCommand.ExecuteAsync(null);
+
+        foreach (var id in ids)
+        {
+            var updated = documentRepo.GetById(id)!;
+            Assert.Equal("Physics", updated.Subject);
+            Assert.Equal("bulk", updated.Tags);
+            Assert.Equal(DocumentStatus.Completed, updated.Status);
+        }
+        Assert.True(undo.CanUndo);
+
+        await model.UndoLastCommand.ExecuteAsync(null);
+
+        foreach (var (id, original) in originals)
+        {
+            var restored = documentRepo.GetById(id)!;
+            Assert.Equal(original.Subject, restored.Subject);
+            Assert.Equal(original.Tags, restored.Tags);
+            Assert.Equal(original.Status, restored.Status);
+            Assert.Equal(original.IsImportant, restored.IsImportant);
+        }
+        Assert.False(model.UndoLastCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public async Task Apply_PartialFailure_ReportsFailedNames_StillOffersUndo()
+    {
+        var documentRepo = new DocumentRepository(Db);
+        var bulkRepo = new BulkEditMetadataStub(documentRepo);
+        var dialog = new RecordingPreviewDialogService { PreviewResult = true };
+        var dialogStub = new BulkEditDialogStub();
+
+        Repo.Add(new StudyDocument { Name = "Alpha", Subject = "Math", Type = "PDF", Status = DocumentStatus.Unread });
+        Repo.Add(new StudyDocument { Name = "Beta", Subject = "Math", Type = "PDF", Status = DocumentStatus.Read });
+        Repo.Add(new StudyDocument { Name = "Gamma", Subject = "Math", Type = "PDF", Status = DocumentStatus.InProgress });
+        var (id1, id2, id3) = GetIdsByRow();
+
+        bulkRepo.FailIds.Add(id2);
+
+        var model = CreateModel(bulkRepo, dialog, dialogStub: dialogStub);
+        model.Initialize();
+        foreach (var row in model.Documents)
+            row.IsSelected = true;
+        model.EnableStatus = true;
+        model.NewStatus = DocumentStatus.Archived;
+
+        await model.ApplyBulkEditCommand.ExecuteAsync(null);
+
+        Assert.Single(dialogStub.Errors);
+        Assert.Contains("BE_Result_Partial", dialogStub.Errors[0]);
+        Assert.Contains("BE_FailedItemsHeader", dialogStub.Errors[0]);
+        Assert.Contains("Beta", dialogStub.Errors[0]);
+
+        Assert.Equal(DocumentStatus.Archived, documentRepo.GetById(id1)!.Status);
+        Assert.Equal(DocumentStatus.Read, documentRepo.GetById(id2)!.Status);
+        Assert.Equal(DocumentStatus.Archived, documentRepo.GetById(id3)!.Status);
+
+        Assert.True(model.UndoLastCommand.CanExecute(null));
+        await model.UndoLastCommand.ExecuteAsync(null);
+        Assert.Equal(DocumentStatus.Unread, documentRepo.GetById(id1)!.Status);
+        Assert.Equal(DocumentStatus.Read, documentRepo.GetById(id2)!.Status);
+        Assert.Equal(DocumentStatus.InProgress, documentRepo.GetById(id3)!.Status);
+    }
+
+    [Fact]
+    public async Task Preview_PayloadContainsOnlyEnabledFields()
+    {
+        var documentRepo = new DocumentRepository(Db);
+        var bulkRepo = new BulkEditMetadataStub(documentRepo);
+        var dialog = new RecordingPreviewDialogService { PreviewResult = false };
+
+        Repo.Add(new StudyDocument { Name = "Alpha", Subject = "Math", Type = "PDF" });
+        Repo.Add(new StudyDocument { Name = "Beta", Subject = "Math", Type = "PDF" });
+        Repo.Add(new StudyDocument { Name = "Gamma", Subject = "Math", Type = "PDF" });
+
+        var model = CreateModel(bulkRepo, dialog);
+        model.Initialize();
+        foreach (var row in model.Documents)
+            row.IsSelected = true;
+        model.EnableSubject = true;
+        model.NewSubject = "Physics";
+
+        await model.ApplyBulkEditCommand.ExecuteAsync(null);
+
+        var call = Assert.Single(dialog.PreviewCalls);
+        Assert.Equal(3, call.AffectedCount);
+        var pair = Assert.Single(call.Changes);
+        Assert.Equal("BE_Field_Subject", pair.FieldLabel);
+        Assert.Equal("Physics", pair.NewValue);
+        Assert.All(documentRepo.GetAll(), d => Assert.Equal("Math", d.Subject));
+    }
+
+    [Fact]
+    public void UndoService_PushBeyondCap_EvictsOldest()
+    {
+        var undo = new UndoService();
+        for (var i = 1; i <= 11; i++)
+        {
+            undo.Push(new UndoEntry
+            {
+                DescriptionKey = "BE_UndoDescription",
+                DescriptionArgs = [i],
+                Originals = [new StudyDocument { Id = i }],
+                CreatedAt = DateTime.Now
+            });
+        }
+
+        Assert.True(undo.CanUndo);
+        Assert.Equal(11, undo.Peek()!.Originals[0].Id);
+
+        for (var expected = 11; expected >= 2; expected--)
+            Assert.Equal(expected, undo.Pop()!.Originals[0].Id);
+
+        Assert.False(undo.CanUndo);
+        Assert.Null(undo.Peek());
+        Assert.Null(undo.Pop());
+    }
+
+    private static StudyDocument Clone(StudyDocument source) => new()
+    {
+        Id = source.Id,
+        Name = source.Name,
+        Subject = source.Subject,
+        Type = source.Type,
+        FilePath = source.FilePath,
+        Notes = source.Notes,
+        CreatedAt = source.CreatedAt,
+        FileSize = source.FileSize,
+        Author = source.Author,
+        IsImportant = source.IsImportant,
+        Tags = source.Tags,
+        Deadline = source.Deadline,
+        Status = source.Status
+    };
+
+    private (int First, int Second, int Third) GetIdsByRow()
+    {
+        var ids = Repo.GetAll().OrderBy(d => d.Id).Select(d => d.Id).ToList();
+        return (ids[0], ids[1], ids[2]);
+    }
+
+    private sealed class BulkEditMetadataStub(DocumentRepository repository) : IBulkOperationRepository
+    {
+        public HashSet<int> FailIds { get; } = [];
+        public int CallCount { get; private set; }
+
+        public BulkEditOutcome BulkEditMetadata(IReadOnlyList<int> documentIds, BulkEditChanges changes)
+        {
+            CallCount++;
+            var items = new List<BulkItemResult>();
+            foreach (var id in documentIds)
+            {
+                if (FailIds.Contains(id))
+                {
+                    items.Add(new BulkItemResult(id, false));
+                    continue;
+                }
+
+                var document = repository.GetById(id);
+                if (document == null)
+                {
+                    items.Add(new BulkItemResult(id, false));
+                    continue;
+                }
+
+                if (changes.Subject != null) document.Subject = changes.Subject;
+                if (changes.Type != null) document.Type = changes.Type;
+                if (changes.Tags != null) document.Tags = changes.Tags;
+                if (changes.IsImportant.HasValue) document.IsImportant = changes.IsImportant.Value;
+                if (changes.Deadline.HasValue) document.Deadline = changes.Deadline;
+                if (changes.Status != null) document.Status = changes.Status;
+
+                items.Add(new BulkItemResult(id, repository.Update(document)));
+            }
+
+            return new BulkEditOutcome
+            {
+                Requested = documentIds.Count,
+                Succeeded = items.Count(i => i.Success),
+                Items = items
+            };
+        }
+
+        public int BulkSoftDelete(List<int> ids) => repository.BulkSoftDelete(ids);
+        public int BulkUpdateSubject(List<int> ids, string subject) => repository.BulkUpdateSubject(ids, subject);
+        public int BulkToggleImportant(List<int> ids, bool important) => repository.BulkToggleImportant(ids, important);
+        public int BulkUpdateStatus(List<int> ids, string status) => repository.BulkUpdateStatus(ids, status);
+    }
+
+    private sealed class RecordingPreviewDialogService : ICustomDialogService
+    {
+        public bool PreviewResult { get; set; }
+        public List<(int AffectedCount, List<(string FieldLabel, string NewValue)> Changes)> PreviewCalls { get; } = [];
+
+        public Task<bool> ShowBulkEditPreviewAsync(int affectedCount, IReadOnlyList<(string FieldLabel, string NewValue)> changes)
+        {
+            PreviewCalls.Add((affectedCount, [.. changes]));
+            return Task.FromResult(PreviewResult);
+        }
+
+        public Task<string?> ShowChangeCategoryAsync(string documentName, IList<string> existingCategories, string currentCategory)
+            => Task.FromResult<string?>(null);
+
+        public Task<int> ShowSelectCollectionAsync(string documentName, IList<(int Id, string Name, int DocCount)> collections)
+            => Task.FromResult(-1);
+
+        public Task<List<StudyDocument>?> ShowDocumentPickerAsync(
+            string collectionName, IEnumerable<StudyDocument> allDocuments, IEnumerable<int> alreadyInCollection)
+            => Task.FromResult<List<StudyDocument>?>(null);
+
+        public Task<AddDocumentDraft?> ShowAddDocumentAsync(string filePath, IList<string> subjects, IList<string> types)
+            => Task.FromResult<AddDocumentDraft?>(null);
+    }
+
+    private sealed class BulkEditDialogStub : IDialogService
+    {
+        public List<string> Errors { get; } = [];
+        public List<string> Messages { get; } = [];
+
+        public Task ShowMessageAsync(string title, string message)
+        {
+            Messages.Add(message);
+            return Task.CompletedTask;
+        }
+
+        public Task ShowErrorAsync(string title, string message)
+        {
+            Errors.Add(message);
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> ShowConfirmAsync(string title, string message) => Task.FromResult(true);
+        public Task<bool> ShowConfirmAsync(string title, string message, string confirmText, bool isDanger = false) => Task.FromResult(true);
+        public Task<string?> ShowInputAsync(string title, string label, string defaultValue = "", string watermark = "")
+            => Task.FromResult<string?>(null);
+    }
+
+    private sealed class BulkEditNavigationStub : INavigationService
+    {
+        public bool CanGoBack => false;
+        public void NavigateTo(string viewKey) { }
+        public void NavigateTo(string viewKey, object? parameter) { }
+        public void GoBack() { }
+    }
+
+    private sealed class BulkEditLocalizationStub : ILocalizationService
+    {
+        public string this[string key] => key;
+        public SupportedLanguage CurrentLanguage => SupportedLanguage.Japanese;
+        public void SetLanguage(SupportedLanguage language) { }
+        public IReadOnlyList<SupportedLanguage> AvailableLanguages { get; } = [];
+        public event EventHandler? LanguageChanged { add { } remove { } }
+    }
+}

--- a/StudyDocumentManager.Tests/BulkEditUiTests.cs
+++ b/StudyDocumentManager.Tests/BulkEditUiTests.cs
@@ -1,7 +1,15 @@
+using Avalonia;
+using Avalonia.Automation;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
 using StudyDocumentManager.Core;
 using StudyDocumentManager.Core.DTOs;
 using StudyDocumentManager.Core.Entities;
 using StudyDocumentManager.Core.Interfaces;
+using StudyDocumentManager.Data.Helpers;
 using StudyDocumentManager.Data.Repositories;
 using StudyDocumentManager.Models;
 using StudyDocumentManager.Services;
@@ -342,6 +350,131 @@ public class BulkEditUiTests : DatabaseTestBase
     }
 
     private sealed class BulkEditLocalizationStub : ILocalizationService
+    {
+        public string this[string key] => key;
+        public SupportedLanguage CurrentLanguage => SupportedLanguage.Japanese;
+        public void SetLanguage(SupportedLanguage language) { }
+        public IReadOnlyList<SupportedLanguage> AvailableLanguages { get; } = [];
+        public event EventHandler? LanguageChanged { add { } remove { } }
+    }
+}
+
+public sealed class BulkDeleteApplyButtonBindingTests : IDisposable
+{
+    private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"sdm_test_{Guid.NewGuid():N}.db");
+    private readonly DatabaseHelper _db;
+    private readonly DocumentRepository _repo;
+
+    public BulkDeleteApplyButtonBindingTests()
+    {
+        _db = new DatabaseHelper();
+        _db.SetDatabasePath(_dbPath);
+        _db.InitializeDatabase();
+        _repo = new DocumentRepository(_db);
+    }
+
+    [AvaloniaFact]
+    public void ApplyButton_BindsApplyBulkEditCommand_AndExecutesWhenSelectionAndChangesValid()
+    {
+        Application.Current!.Resources["Loc"] = new LocalizationService();
+        _repo.Add(new StudyDocument { Name = "Alpha", Subject = "Math", Type = "PDF" });
+
+        var model = new BulkDeleteModel(
+            _repo,
+            _repo,
+            new CategoryRepository(_db),
+            new ApplyDialogStub(),
+            new ApplyNavigationStub(),
+            new ApplyLocalizationStub(),
+            new ApplyPreviewDialogs { PreviewResult = true },
+            new CollectionRepository(_db),
+            new UndoService());
+
+        var view = new Views.BulkDelete { DataContext = model };
+        var window = new Window { Content = view };
+
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.NotEmpty(model.Documents);
+            var expander = view.GetVisualDescendants().OfType<Expander>().Single();
+            expander.IsExpanded = true;
+            Dispatcher.UIThread.RunJobs();
+
+            foreach (var row in model.Documents)
+                row.IsSelected = true;
+            model.EnableSubject = true;
+            model.NewSubject = "Physics";
+            Dispatcher.UIThread.RunJobs();
+
+            var button = Assert.Single(view.GetVisualDescendants().OfType<Button>(),
+                b => AutomationProperties.GetAutomationId(b) == "BulkEdit_Apply");
+
+            Assert.Same(model.ApplyBulkEditCommand, button.Command);
+            Assert.True(button.IsEnabled);
+            Assert.True(button.Command!.CanExecute(null));
+
+            button.Command.Execute(null);
+            Dispatcher.UIThread.RunJobs();
+            AvaloniaHeadlessPlatform.ForceRenderTimerTick();
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.All(_repo.GetAll(), d => Assert.Equal("Physics", d.Subject));
+            Assert.True(model.UndoLastCommand.CanExecute(null));
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    public void Dispose()
+    {
+        _db.CloseAllConnections();
+        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); }
+        catch { }
+    }
+
+    private sealed class ApplyDialogStub : IDialogService
+    {
+        public Task ShowMessageAsync(string title, string message) => Task.CompletedTask;
+        public Task ShowErrorAsync(string title, string message) => Task.CompletedTask;
+        public Task<bool> ShowConfirmAsync(string title, string message) => Task.FromResult(true);
+        public Task<bool> ShowConfirmAsync(string title, string message, string confirmText, bool isDanger = false) => Task.FromResult(true);
+        public Task<string?> ShowInputAsync(string title, string label, string defaultValue = "", string watermark = "") => Task.FromResult<string?>(null);
+    }
+
+    private sealed class ApplyPreviewDialogs : ICustomDialogService
+    {
+        public bool PreviewResult { get; set; }
+
+        public Task<bool> ShowBulkEditPreviewAsync(int affectedCount, IReadOnlyList<(string FieldLabel, string NewValue)> changes)
+            => Task.FromResult(PreviewResult);
+
+        public Task<string?> ShowChangeCategoryAsync(string documentName, IList<string> existingCategories, string currentCategory)
+            => Task.FromResult<string?>(null);
+
+        public Task<int> ShowSelectCollectionAsync(string documentName, IList<(int Id, string Name, int DocCount)> collections)
+            => Task.FromResult(-1);
+
+        public Task<List<StudyDocument>?> ShowDocumentPickerAsync(string collectionName, IEnumerable<StudyDocument> allDocuments, IEnumerable<int> alreadyInCollection)
+            => Task.FromResult<List<StudyDocument>?>(null);
+
+        public Task<AddDocumentDraft?> ShowAddDocumentAsync(string filePath, IList<string> subjects, IList<string> types)
+            => Task.FromResult<AddDocumentDraft?>(null);
+    }
+
+    private sealed class ApplyNavigationStub : INavigationService
+    {
+        public bool CanGoBack => false;
+        public void NavigateTo(string viewKey) { }
+        public void NavigateTo(string viewKey, object? parameter) { }
+        public void GoBack() { }
+    }
+
+    private sealed class ApplyLocalizationStub : ILocalizationService
     {
         public string this[string key] => key;
         public SupportedLanguage CurrentLanguage => SupportedLanguage.Japanese;

--- a/StudyDocumentManager.Tests/BulkEditUiTests.cs
+++ b/StudyDocumentManager.Tests/BulkEditUiTests.cs
@@ -152,9 +152,11 @@ public class BulkEditUiTests : DatabaseTestBase
         Assert.Equal(DocumentStatus.Archived, documentRepo.GetById(id3)!.Status);
 
         Assert.True(model.UndoLastCommand.CanExecute(null));
+        Assert.True(documentRepo.Delete(id2));
+        Assert.True(documentRepo.PermanentDeleteDocument(id2));
         await model.UndoLastCommand.ExecuteAsync(null);
         Assert.Equal(DocumentStatus.Unread, documentRepo.GetById(id1)!.Status);
-        Assert.Equal(DocumentStatus.Read, documentRepo.GetById(id2)!.Status);
+        Assert.Null(documentRepo.GetById(id2));
         Assert.Equal(DocumentStatus.InProgress, documentRepo.GetById(id3)!.Status);
     }
 

--- a/StudyDocumentManager.Tests/DocumentStatusDataTests.cs
+++ b/StudyDocumentManager.Tests/DocumentStatusDataTests.cs
@@ -1,0 +1,265 @@
+using Microsoft.Data.Sqlite;
+using StudyDocumentManager.Core.Entities;
+using StudyDocumentManager.Data.Helpers;
+using StudyDocumentManager.Data.Repositories;
+using Xunit;
+
+namespace StudyDocumentManager.Tests;
+
+public class DocumentStatusDataTests : DatabaseTestBase
+{
+    [Fact]
+    public void InitializeDatabase_FreshDb_DocumentsTableHasStatusColumnDefaultingToUnread()
+    {
+        using var connection = new SqliteConnection(Db.ConnectionString);
+        connection.Open();
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "PRAGMA table_info(documents)";
+        using var reader = cmd.ExecuteReader();
+
+        var hasStatusColumn = false;
+        while (reader.Read())
+        {
+            if (!string.Equals(reader.GetString(1), "status", StringComparison.Ordinal))
+                continue;
+
+            hasStatusColumn = true;
+            Assert.Equal("TEXT", reader.GetString(2));
+            Assert.Equal(1, reader.GetInt32(3));
+            Assert.Equal("'unread'", reader.GetString(4));
+        }
+
+        Assert.True(hasStatusColumn);
+    }
+
+    [Fact]
+    public void Add_NewDocumentWithoutTouchingStatus_PersistsUnread()
+    {
+        var doc = new StudyDocument { Name = "Fresh document" };
+
+        Assert.True(Repo.Add(doc));
+
+        var loaded = Repo.GetById(doc.Id);
+        Assert.NotNull(loaded);
+        Assert.Equal(DocumentStatus.Unread, loaded.Status);
+    }
+
+    [Fact]
+    public void Add_WithCompletedStatus_RoundtripsThroughGetById()
+    {
+        var doc = new StudyDocument { Name = "Roundtrip document", Status = DocumentStatus.Completed };
+
+        Assert.True(Repo.Add(doc));
+
+        var loaded = Repo.GetById(doc.Id);
+        Assert.NotNull(loaded);
+        Assert.Equal(DocumentStatus.Completed, loaded.Status);
+    }
+
+    [Fact]
+    public void Update_ChangedStatus_Persists()
+    {
+        var doc = new StudyDocument { Name = "Editable document" };
+        Assert.True(Repo.Add(doc));
+
+        var loaded = Repo.GetById(doc.Id);
+        Assert.NotNull(loaded);
+        loaded.Status = DocumentStatus.InProgress;
+
+        Assert.True(Repo.Update(loaded));
+        Assert.Equal(DocumentStatus.InProgress, Repo.GetById(doc.Id)!.Status);
+    }
+
+    [Fact]
+    public void InitializeDatabase_LegacySchemaWithoutStatusColumn_BackfillsUnreadAndKeepsActiveQuery()
+    {
+        var legacyPath = Path.Combine(Path.GetTempPath(), $"sdm_status_upgrade_{Guid.NewGuid():N}.db");
+        try
+        {
+            CreateV3StyleDatabaseWithoutStatusColumn(legacyPath);
+
+            var database = new DatabaseHelper();
+            database.SetDatabasePath(legacyPath);
+            database.InitializeDatabase();
+
+            using var connection = new SqliteConnection(database.ConnectionString);
+            connection.Open();
+
+            Assert.Equal(1L, Scalar(connection, "SELECT COUNT(*) FROM pragma_table_info('documents') WHERE name = 'status'"));
+            Assert.Equal(DocumentStatus.Unread, ScalarString(connection, "SELECT status FROM documents WHERE id = 1"));
+            Assert.Equal(DocumentStatus.Unread, ScalarString(connection, "SELECT status FROM documents WHERE id = 2"));
+
+            var repository = new DocumentRepository(database);
+            var active = Assert.Single(repository.GetAll());
+            Assert.Equal("Upgrade active", active.Name);
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            if (File.Exists(legacyPath))
+                File.Delete(legacyPath);
+        }
+    }
+
+    [Fact]
+    public void InitializeDatabase_CalledTwice_IsIdempotentAndKeepsCustomStatus()
+    {
+        var doc = new StudyDocument { Name = "Persistent document", Status = DocumentStatus.NeedsAction };
+        Assert.True(Repo.Add(doc));
+
+        Db.InitializeDatabase();
+        Db.InitializeDatabase();
+
+        Assert.Single(Repo.GetAll());
+        var loaded = Repo.GetById(doc.Id);
+        Assert.NotNull(loaded);
+        Assert.Equal(DocumentStatus.NeedsAction, loaded.Status);
+    }
+
+    [Fact]
+    public void SearchAdvancedWithStatus_KeywordPlusStatus_NarrowsResults()
+    {
+        var readDoc = new StudyDocument { Name = "Alpha report", Status = DocumentStatus.Read };
+        var completedDoc = new StudyDocument { Name = "Alpha memo", Status = DocumentStatus.Completed };
+        Assert.True(Repo.Add(readDoc));
+        Assert.True(Repo.Add(completedDoc));
+
+        var combined = Repo.SearchAdvancedWithStatus("Alpha", "", "", null, null, null, null, null, DocumentStatus.Read);
+
+        var narrowed = Assert.Single(combined);
+        Assert.Equal(readDoc.Id, narrowed.Id);
+
+        var keywordOnly = Repo.SearchAdvancedWithStatus("Alpha", "", "", null, null, null, null, null, null);
+        Assert.Equal(2, keywordOnly.Count);
+    }
+
+    [Fact]
+    public void SearchAdvancedWithStatus_NullStatus_MatchesPlainSearchAdvanced()
+    {
+        var first = new StudyDocument { Name = "Shared report", Status = DocumentStatus.Archived };
+        var second = new StudyDocument { Name = "Other notes", Status = DocumentStatus.Unread };
+        Assert.True(Repo.Add(first));
+        Assert.True(Repo.Add(second));
+
+        var viaPlain = Repo.SearchAdvanced("", "", "", null, null, null, null, null);
+        var viaStatus = Repo.SearchAdvancedWithStatus("", "", "", null, null, null, null, null, null);
+
+        Assert.Equal(viaPlain.Select(d => d.Id), viaStatus.Select(d => d.Id));
+        Assert.Equal(viaPlain.Select(d => d.Status), viaStatus.Select(d => d.Status));
+    }
+
+    [Fact]
+    public void GetStatusCounts_ExcludesSoftDeleted_GroupsActiveOnly()
+    {
+        var readKept = new StudyDocument { Name = "Read kept", Status = DocumentStatus.Read };
+        var completed = new StudyDocument { Name = "Completed doc", Status = DocumentStatus.Completed };
+        var readDeleted = new StudyDocument { Name = "Read deleted", Status = DocumentStatus.Read };
+        Assert.True(Repo.Add(readKept));
+        Assert.True(Repo.Add(completed));
+        Assert.True(Repo.Add(readDeleted));
+        Assert.True(Repo.Delete(readDeleted.Id));
+
+        var counts = Repo.GetStatusCounts();
+
+        Assert.Equal(
+            new Dictionary<string, int>
+            {
+                [DocumentStatus.Read] = 1,
+                [DocumentStatus.Completed] = 1
+            },
+            counts);
+    }
+
+    [Fact]
+    public void BulkUpdateStatus_ActiveIdsUpdated_SoftDeletedSkipped()
+    {
+        var activeA = new StudyDocument { Name = "Bulk A" };
+        var activeB = new StudyDocument { Name = "Bulk B" };
+        var softDeleted = new StudyDocument { Name = "Bulk C" };
+        Assert.True(Repo.Add(activeA));
+        Assert.True(Repo.Add(activeB));
+        Assert.True(Repo.Add(softDeleted));
+        Assert.True(Repo.Delete(softDeleted.Id));
+
+        var affected = Repo.BulkUpdateStatus([activeA.Id, activeB.Id, softDeleted.Id], DocumentStatus.Completed);
+
+        Assert.Equal(2, affected);
+        Assert.Equal(DocumentStatus.Completed, Repo.GetById(activeA.Id)!.Status);
+        Assert.Equal(DocumentStatus.Completed, Repo.GetById(activeB.Id)!.Status);
+        Assert.Equal(DocumentStatus.Unread, Repo.GetById(softDeleted.Id)!.Status);
+    }
+
+    [Fact]
+    public void BulkUpdateStatus_InvalidStatus_AffectsZeroRows()
+    {
+        var doc = new StudyDocument { Name = "Guarded document", Status = DocumentStatus.Read };
+        Assert.True(Repo.Add(doc));
+
+        var affected = Repo.BulkUpdateStatus([doc.Id], "bogus");
+
+        Assert.Equal(0, affected);
+        Assert.Equal(DocumentStatus.Read, Repo.GetById(doc.Id)!.Status);
+    }
+
+    [Fact]
+    public void Add_InvalidOrMissingStatus_IsCoercedToUnreadOnWrite()
+    {
+        var bogus = new StudyDocument { Name = "Bogus status document", Status = "bogus" };
+        var nullStatus = new StudyDocument { Name = "Null status document", Status = null! };
+
+        Assert.True(Repo.Add(bogus));
+        Assert.True(Repo.Add(nullStatus));
+
+        Assert.Equal(DocumentStatus.Unread, Repo.GetById(bogus.Id)!.Status);
+        Assert.Equal(DocumentStatus.Unread, Repo.GetById(nullStatus.Id)!.Status);
+    }
+
+    private static void CreateV3StyleDatabaseWithoutStatusColumn(string databasePath)
+    {
+        using var connection = new SqliteConnection($"Data Source={databasePath};Foreign Keys=True");
+        connection.Open();
+        Execute(connection, """
+            CREATE TABLE documents (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                subject TEXT,
+                type TEXT,
+                file_path TEXT,
+                notes TEXT,
+                created_at DATETIME,
+                file_size REAL,
+                author TEXT,
+                is_important INTEGER DEFAULT 0,
+                tags TEXT,
+                deadline DATETIME,
+                is_deleted INTEGER DEFAULT 0,
+                deleted_at DATETIME
+            );
+            INSERT INTO documents (id, name, created_at, is_deleted, deleted_at) VALUES (1, 'Upgrade active', '2026-05-01 10:00:00', 0, NULL);
+            INSERT INTO documents (id, name, created_at, is_deleted, deleted_at) VALUES (2, 'Upgrade deleted', '2026-05-02 10:00:00', 1, '2026-05-03 10:00:00');
+            CREATE TABLE app_settings (key TEXT PRIMARY KEY, value TEXT);
+            INSERT INTO app_settings (key, value) VALUES ('schema_version', '3');
+            """);
+    }
+
+    private static void Execute(SqliteConnection connection, string sql)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        command.ExecuteNonQuery();
+    }
+
+    private static long Scalar(SqliteConnection connection, string sql)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        return Convert.ToInt64(command.ExecuteScalar());
+    }
+
+    private static string ScalarString(SqliteConnection connection, string sql)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        return Assert.IsType<string>(command.ExecuteScalar());
+    }
+}

--- a/StudyDocumentManager.Tests/DocumentStatusUiTests.cs
+++ b/StudyDocumentManager.Tests/DocumentStatusUiTests.cs
@@ -1,0 +1,294 @@
+using StudyDocumentManager.Core;
+using StudyDocumentManager.Core.DTOs;
+using StudyDocumentManager.Core.Entities;
+using StudyDocumentManager.Core.Interfaces;
+using StudyDocumentManager.Data.Repositories;
+using StudyDocumentManager.Models;
+using StudyDocumentManager.Services;
+using Xunit;
+
+namespace StudyDocumentManager.Tests;
+
+public sealed class DocumentStatusUiTests : DatabaseTestBase
+{
+    private readonly CategoryRepository _categoryRepo;
+
+    public DocumentStatusUiTests()
+    {
+        _categoryRepo = new CategoryRepository(Db);
+    }
+
+    private int SeedDoc(string name, string subject, string status)
+    {
+        var doc = new StudyDocument
+        {
+            Name = name,
+            Subject = subject,
+            Type = "PDF",
+            FilePath = $"C:\\seed\\{name}.pdf",
+            Status = status
+        };
+        Assert.True(Repo.Add(doc));
+        return doc.Id;
+    }
+
+    private DashboardModel CreateDashboard(
+        RecordingDialogService? dialog = null,
+        RecordingNavigationService? navigation = null)
+    {
+        var repository = new DocumentRepository(Db);
+        return new DashboardModel(
+            repository,
+            repository,
+            _categoryRepo,
+            new CollectionRepository(Db),
+            new StubRecentFileRepository(),
+            dialog ?? new RecordingDialogService(),
+            new StubFileDialogService(),
+            new StubCustomDialogService(),
+            navigation ?? new RecordingNavigationService(),
+            new StubClipboardService(),
+            new StubProcessLauncherService(),
+            new StubExportService(),
+            new StubBackupService(),
+            new StubLocalizationService());
+    }
+
+    private AddEditModel CreateAddEdit()
+        => new(
+            new DocumentRepository(Db),
+            _categoryRepo,
+            new RecordingDialogService(),
+            new StubFileDialogService(),
+            new RecordingNavigationService(),
+            new StubLocalizationService());
+
+    private ReportModel CreateReport()
+        => new(new ReportRepository(Db), Repo, new StubLocalizationService());
+
+    [Fact]
+    public void Dashboard_StatusFilter_NarrowsResultsAndSentinelRestoresAll()
+    {
+        SeedDoc("Alpha A", "Math", DocumentStatus.Unread);
+        SeedDoc("Alpha B", "Math", DocumentStatus.Read);
+        SeedDoc("Beta C", "Physics", DocumentStatus.Read);
+        var model = CreateDashboard();
+        model.Initialize();
+
+        model.SearchKeyword = "Alpha";
+        model.SelectedStatus = DocumentStatus.Read;
+
+        var narrowed = model.Documents.Select(d => d.Name).ToList();
+        Assert.Equal(["Alpha B"], narrowed);
+
+        model.SelectedStatus = DashboardModel.FILTER_ALL_STATUS_KEY;
+
+        Assert.Equal(["Alpha A", "Alpha B"], [.. model.Documents.Select(d => d.Name)]);
+        Assert.Equal(0, model.ActiveFilterCount);
+    }
+
+    [Fact]
+    public void Dashboard_RefreshCommand_ResetsStatusToSentinelAndReloadsAll()
+    {
+        SeedDoc("One", "Math", DocumentStatus.Unread);
+        SeedDoc("Two", "Math", DocumentStatus.Read);
+        SeedDoc("Three", "Physics", DocumentStatus.Archived);
+        var model = CreateDashboard();
+        model.Initialize();
+
+        model.SelectedStatus = DocumentStatus.Archived;
+        Assert.Equal(["Three"], [.. model.Documents.Select(d => d.Name)]);
+        Assert.Equal(1, model.ActiveFilterCount);
+
+        model.RefreshCommand.Execute(null);
+
+        Assert.Equal(DashboardModel.FILTER_ALL_STATUS_KEY, model.SelectedStatus);
+        Assert.Equal(0, model.ActiveFilterCount);
+        Assert.Equal(3, model.Documents.Count);
+    }
+
+    [Fact]
+    public void Dashboard_StatusOptions_ListSentinelPlusSixCanonicalKinds()
+    {
+        var model = CreateDashboard();
+
+        Assert.Equal(DashboardModel.FILTER_ALL_STATUS_KEY, model.StatusOptions[0].Value);
+        Assert.Equal(DocumentStatus.All, [.. model.StatusOptions.Skip(1).Select(o => o.Value)]);
+        Assert.All(model.StatusOptions, o => Assert.False(string.IsNullOrWhiteSpace(o.Display)));
+    }
+
+    [Fact]
+    public void AddEdit_LoadDocument_MapsStoredStatusIntoPickerState()
+    {
+        var id = SeedDoc("Stored", "Math", DocumentStatus.NeedsAction);
+        var model = CreateAddEdit();
+
+        model.LoadDocument(id);
+
+        Assert.True(model.IsEditing);
+        Assert.Equal(DocumentStatus.NeedsAction, model.SelectedStatus);
+        Assert.Equal(DocumentStatus.All, [.. model.StatusOptions.Select(o => o.Value)]);
+    }
+
+    [Fact]
+    public async Task AddEdit_Save_PersistsSelectedStatus()
+    {
+        var model = CreateAddEdit();
+        model.Name = "Fresh";
+        model.SelectedStatus = DocumentStatus.Completed;
+
+        await model.SaveCommand.ExecuteAsync(null);
+
+        var saved = Assert.Single(Repo.GetAll());
+        Assert.Equal(DocumentStatus.Completed, saved.Status);
+        Assert.False(model.HasStatusValidationError);
+    }
+
+    [Fact]
+    public async Task AddEdit_Save_InvalidSelection_BlocksSaveWithErrorFlag()
+    {
+        var model = CreateAddEdit();
+        model.Name = "Broken";
+        model.SelectedStatus = "bogus-status";
+
+        await model.SaveCommand.ExecuteAsync(null);
+
+        Assert.True(model.HasStatusValidationError);
+        Assert.Equal("DS_Error_InvalidStatus", model.StatusValidationMessage);
+        Assert.Empty(Repo.GetAll());
+    }
+
+    [Fact]
+    public async Task AddEdit_Save_ValidSelectionAfterInvalid_ClearsError()
+    {
+        var model = CreateAddEdit();
+        model.Name = "Recover";
+        model.SelectedStatus = "bogus-status";
+        await model.SaveCommand.ExecuteAsync(null);
+        Assert.True(model.HasStatusValidationError);
+
+        model.SelectedStatus = DocumentStatus.InProgress;
+
+        Assert.False(model.HasStatusValidationError);
+        Assert.Equal(string.Empty, model.StatusValidationMessage);
+    }
+
+    [Fact]
+    public void Report_StatusCounts_MergesAllSixKindsInCanonicalOrderWithZerosFilled()
+    {
+        SeedDoc("A", "Math", DocumentStatus.Unread);
+        SeedDoc("B", "Math", DocumentStatus.Unread);
+        SeedDoc("C", "Physics", DocumentStatus.Read);
+        var model = CreateReport();
+
+        Assert.Equal(DocumentStatus.All, [.. model.ByStatusData.Select(i => i.Kind)]);
+        Assert.Equal(2, model.ByStatusData.Single(i => i.Kind == DocumentStatus.Unread).Value);
+        Assert.Equal(1, model.ByStatusData.Single(i => i.Kind == DocumentStatus.Read).Value);
+        Assert.All(
+            model.ByStatusData.Where(i => i.Kind is not (DocumentStatus.Unread or DocumentStatus.Read)),
+            i => Assert.Equal(0, i.Value));
+        Assert.All(model.ByStatusData, i => Assert.False(string.IsNullOrWhiteSpace(i.Label)));
+    }
+
+    [Fact]
+    public void Report_DeletedDocuments_AreExcludedFromStatusCounts()
+    {
+        var id = SeedDoc("Gone", "Math", DocumentStatus.InProgress);
+        Assert.True(Repo.Delete(id));
+
+        var model = CreateReport();
+
+        Assert.All(model.ByStatusData, i => Assert.Equal(0, i.Value));
+    }
+
+    private sealed class RecordingDialogService : IDialogService
+    {
+        public bool ConfirmResult { get; set; }
+        public List<string> Messages { get; } = [];
+
+        public Task ShowMessageAsync(string title, string message)
+        {
+            Messages.Add(message);
+            return Task.CompletedTask;
+        }
+
+        public Task ShowErrorAsync(string title, string message) => Task.CompletedTask;
+        public Task<bool> ShowConfirmAsync(string title, string message) => Task.FromResult(ConfirmResult);
+        public Task<bool> ShowConfirmAsync(string title, string message, string confirmText, bool isDanger = false)
+            => Task.FromResult(ConfirmResult);
+        public Task<string?> ShowInputAsync(string title, string label, string defaultValue = "", string watermark = "")
+            => Task.FromResult<string?>(null);
+    }
+
+    private sealed class RecordingNavigationService : INavigationService
+    {
+        public List<(string Route, object? Parameter)> RoutesWithParameter { get; } = [];
+        public bool CanGoBack => false;
+        public void NavigateTo(string viewKey) => RoutesWithParameter.Add((viewKey, null));
+        public void NavigateTo(string viewKey, object? parameter) => RoutesWithParameter.Add((viewKey, parameter));
+        public void GoBack() { }
+    }
+
+    private sealed class StubRecentFileRepository : IRecentFileRepository
+    {
+        public List<(int Id, string Name, string? Subject, string? Type, string? FilePath, DateTime OpenedAt)> GetAll() => [];
+        public bool Add(int documentId) => true;
+        public void Clear() { }
+    }
+
+    private sealed class StubFileDialogService : IFileDialogService
+    {
+        public Task<string?> ShowOpenFileAsync(string title, string? filter = null) => Task.FromResult<string?>(null);
+        public Task<string?> ShowOpenFolderAsync(string title) => Task.FromResult<string?>(null);
+        public Task<string?> ShowSaveFileAsync(string title, string defaultFileName, string? filter = null)
+            => Task.FromResult<string?>(null);
+    }
+
+    private sealed class StubCustomDialogService : ICustomDialogService
+    {
+        public Task<string?> ShowChangeCategoryAsync(string documentName, IList<string> existingCategories, string currentCategory)
+            => Task.FromResult<string?>(null);
+        public Task<int> ShowSelectCollectionAsync(string documentName, IList<(int Id, string Name, int DocCount)> collections)
+            => Task.FromResult(-1);
+        public Task<List<StudyDocument>?> ShowDocumentPickerAsync(
+            string collectionName, IEnumerable<StudyDocument> allDocuments, IEnumerable<int> alreadyInCollection)
+            => Task.FromResult<List<StudyDocument>?>(null);
+        public Task<AddDocumentDraft?> ShowAddDocumentAsync(string filePath, IList<string> subjects, IList<string> types)
+            => Task.FromResult<AddDocumentDraft?>(null);
+    }
+
+    private sealed class StubClipboardService : IClipboardService
+    {
+        public Task SetTextAsync(string text) => Task.CompletedTask;
+    }
+
+    private sealed class StubProcessLauncherService : IProcessLauncherService
+    {
+        public void OpenFile(string filePath) { }
+        public void RevealInExplorer(string filePath) { }
+        public void OpenUrl(string url) { }
+    }
+
+    private sealed class StubExportService : IExportService
+    {
+        public Task<ExportResult> ExportCsvAsync(IReadOnlyList<StudyDocument> documents, string? suggestedFileName)
+            => Task.FromResult(new ExportResult(true));
+    }
+
+    private sealed class StubBackupService : IBackupService
+    {
+        public Task<(bool Success, string? Path, string? Error)> BackupAsync()
+            => Task.FromResult<(bool, string?, string?)>((true, null, null));
+        public Task<(bool Success, string? Error)> RestoreAsync()
+            => Task.FromResult<(bool, string?)>((true, null));
+    }
+
+    private sealed class StubLocalizationService : ILocalizationService
+    {
+        public string this[string key] => key;
+        public SupportedLanguage CurrentLanguage => SupportedLanguage.Japanese;
+        public void SetLanguage(SupportedLanguage language) { }
+        public IReadOnlyList<SupportedLanguage> AvailableLanguages { get; } = [];
+        public event EventHandler? LanguageChanged { add { } remove { } }
+    }
+}

--- a/StudyDocumentManager.Tests/SavedSearchRepositoryTests.cs
+++ b/StudyDocumentManager.Tests/SavedSearchRepositoryTests.cs
@@ -1,0 +1,246 @@
+using Microsoft.Data.Sqlite;
+using StudyDocumentManager.Core.Entities;
+using StudyDocumentManager.Data.Repositories;
+using Xunit;
+
+namespace StudyDocumentManager.Tests;
+
+public class SavedSearchRepositoryTests : DatabaseTestBase
+{
+    private readonly SavedSearchRepository SearchRepo;
+
+    public SavedSearchRepositoryTests()
+    {
+        SearchRepo = new SavedSearchRepository(Db);
+    }
+
+    [Fact]
+    public void Add_GetById_PreservesNameCriteriaJsonAndCreatedAt()
+    {
+        var criteria = new SavedSearchCriteria
+        {
+            Kind = SavedSearchKinds.Standard,
+            Keyword = "量子レポート",
+            MinSize = 1.5,
+            IsImportant = true,
+            RecentDays = 14
+        };
+        var json = criteria.ToJson();
+
+        var id = SearchRepo.Add(new SavedSearch { Name = "Physics reports", CriteriaJson = json });
+
+        Assert.True(id > 0);
+        var loaded = SearchRepo.GetById(id);
+
+        Assert.NotNull(loaded);
+        Assert.Equal("Physics reports", loaded!.Name);
+        Assert.Equal(json, loaded.CriteriaJson);
+        Assert.True((DateTime.Now - loaded.CreatedAt).Duration() < TimeSpan.FromMinutes(1));
+    }
+
+    [Fact]
+    public void GetAll_OrdersNamesCaseInsensitively()
+    {
+        SearchRepo.Add(new SavedSearch { Name = "Bravo" });
+        SearchRepo.Add(new SavedSearch { Name = "alpha" });
+        SearchRepo.Add(new SavedSearch { Name = "Charlie" });
+
+        var names = SearchRepo.GetAll().Select(search => search.Name).ToList();
+
+        Assert.Equal(["alpha", "Bravo", "Charlie"], names);
+    }
+
+    [Fact]
+    public void NameExists_MatchesExistingNamesCaseInsensitively()
+    {
+        SearchRepo.Add(new SavedSearch { Name = "Report" });
+
+        Assert.True(SearchRepo.NameExists("Report"));
+        Assert.True(SearchRepo.NameExists("report"));
+        Assert.True(SearchRepo.NameExists("REPORT"));
+        Assert.False(SearchRepo.NameExists("missing"));
+    }
+
+    [Fact]
+    public void Update_ChangesNameAndJson_AndReturnsFalseForUnknownId()
+    {
+        var id = SearchRepo.Add(new SavedSearch { Name = "Old name", CriteriaJson = "{\"Kind\":\"standard\"}" });
+
+        Assert.True(SearchRepo.Update(new SavedSearch { Id = id, Name = "New name", CriteriaJson = "{\"Kind\":\"due-soon\"}" }));
+
+        var updated = SearchRepo.GetById(id);
+        Assert.NotNull(updated);
+        Assert.Equal("New name", updated!.Name);
+        Assert.Equal("{\"Kind\":\"due-soon\"}", updated.CriteriaJson);
+
+        Assert.False(SearchRepo.Update(new SavedSearch { Id = id + 1000, Name = "Ghost", CriteriaJson = "{}" }));
+    }
+
+    [Fact]
+    public void Delete_RemovesRow_AndReturnsFalseForUnknownId()
+    {
+        var id = SearchRepo.Add(new SavedSearch { Name = "Temporary", CriteriaJson = "{}" });
+
+        Assert.True(SearchRepo.Delete(id));
+        Assert.Null(SearchRepo.GetById(id));
+        Assert.False(SearchRepo.Delete(id + 1000));
+    }
+
+    [Fact]
+    public void DoubleInitializeDatabase_PreservesSavedSearchRows()
+    {
+        var id = SearchRepo.Add(new SavedSearch { Name = "Stable search", CriteriaJson = "{\"Kind\":\"standard\"}" });
+
+        Db.InitializeDatabase();
+
+        var loaded = SearchRepo.GetById(id);
+        Assert.NotNull(loaded);
+        Assert.Equal("Stable search", loaded!.Name);
+        Assert.Single(SearchRepo.GetAll());
+    }
+
+    [Fact]
+    public void InitializeDatabase_CreatesSavedSearchesTable()
+    {
+        using var connection = new SqliteConnection($"Data Source={DbPath};Pooling=False");
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'saved_searches'";
+        Assert.Equal(1L, Convert.ToInt64(command.ExecuteScalar()));
+    }
+
+    [Fact]
+    public void GetUncategorizedDocuments_ReturnsOnlyActiveDocumentsWithoutSubject()
+    {
+        Repo.Add(new StudyDocument { Name = "Categorized", Subject = "Math" });
+        Repo.Add(new StudyDocument { Name = "Empty subject active", Subject = "" });
+        Repo.Add(new StudyDocument { Name = "Deleted uncategorized" });
+        var deletedId = Repo.GetAll().Single(document => document.Name == "Deleted uncategorized").Id;
+        Repo.Delete(deletedId);
+
+        var results = Repo.GetUncategorizedDocuments();
+
+        Assert.Single(results);
+        Assert.DoesNotContain(results, document => document.Name == "Categorized");
+        Assert.DoesNotContain(results, document => document.Name == "Deleted uncategorized");
+        Assert.Contains(results, document => document.Name == "Empty subject active");
+    }
+
+    [Fact]
+    public void GetDocumentsWithMissingMetadata_ReturnsActiveDocumentsMissingAnyField()
+    {
+        Repo.Add(new StudyDocument { Name = "No subject" });
+        Repo.Add(new StudyDocument { Name = "No type", Subject = "Math" });
+        Repo.Add(new StudyDocument { Name = "No tags", Subject = "Math", Type = "PDF" });
+        Repo.Add(new StudyDocument { Name = "Complete", Subject = "Math", Type = "PDF", Tags = "exam" });
+
+        var results = Repo.GetDocumentsWithMissingMetadata();
+
+        Assert.Equal(3, results.Count);
+        Assert.DoesNotContain(results, document => document.Name == "Complete");
+        Assert.Contains(results, document => document.Name == "No subject");
+        Assert.Contains(results, document => document.Name == "No type");
+        Assert.Contains(results, document => document.Name == "No tags");
+    }
+
+    [Fact]
+    public void BackupValidator_AcceptsSchemaVersion4Candidate()
+    {
+        var id = SearchRepo.Add(new SavedSearch { Name = "Backup proof", CriteriaJson = "{\"Keyword\":\"backup\"}" });
+        var candidatePath = CreateTemporaryPath("v4.db");
+
+        try
+        {
+            Assert.True(Db.BackupDatabase(candidatePath));
+            Assert.True(Db.CanRestoreDatabase(candidatePath));
+
+            Assert.True(Db.RestoreDatabase(candidatePath));
+            Assert.NotNull(SearchRepo.GetById(id));
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            DeleteFile(candidatePath);
+        }
+    }
+
+    [Fact]
+    public void RestoreDatabase_LegacyVersion3CandidateWithoutSavedSearchesTable_IsAccepted()
+    {
+        var candidatePath = CreateTemporaryPath("legacy-v3.db");
+
+        try
+        {
+            Assert.True(Db.BackupDatabase(candidatePath));
+            using (var connection = new SqliteConnection($"Data Source={candidatePath};Pooling=False"))
+            {
+                connection.Open();
+                using var command = connection.CreateCommand();
+                command.CommandText = "DROP TABLE saved_searches; UPDATE app_settings SET value = '3' WHERE key = 'schema_version';";
+                command.ExecuteNonQuery();
+            }
+
+            Assert.True(Db.CanRestoreDatabase(candidatePath));
+            Assert.True(Db.RestoreDatabase(candidatePath));
+            Assert.Empty(SearchRepo.GetAll());
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            DeleteFile(candidatePath);
+        }
+    }
+
+    private static string CreateTemporaryPath(string suffix)
+        => Path.Combine(Path.GetTempPath(), $"sdm_{Guid.NewGuid():N}_{suffix}");
+
+    private static void DeleteFile(string path)
+    {
+        if (File.Exists(path))
+            File.Delete(path);
+    }
+}
+
+public class SavedSearchCriteriaTests
+{
+    [Fact]
+    public void ToJson_FromJson_RoundTripsAllValues()
+    {
+        var original = new SavedSearchCriteria
+        {
+            Kind = SavedSearchKinds.RecentlyAdded,
+            Keyword = "k",
+            Subject = "Math",
+            Type = "PDF",
+            FromDate = new DateTime(2026, 1, 2),
+            ToDate = new DateTime(2026, 2, 3),
+            MinSize = 0.5,
+            MaxSize = 10.25,
+            IsImportant = true,
+            RecentDays = 30,
+            DeadlineDays = 14
+        };
+
+        var restored = SavedSearchCriteria.FromJson(original.ToJson());
+
+        Assert.NotNull(restored);
+        Assert.Equivalent(original, restored);
+    }
+
+    [Fact]
+    public void FromJson_InvalidJson_ReturnsNull()
+    {
+        Assert.Null(SavedSearchCriteria.FromJson("not-json"));
+        Assert.Null(SavedSearchCriteria.FromJson(""));
+    }
+
+    [Fact]
+    public void NewCriteria_HasDefaultKindAndWindows()
+    {
+        var criteria = new SavedSearchCriteria();
+
+        Assert.Equal(SavedSearchKinds.Standard, criteria.Kind);
+        Assert.Equal(7, criteria.RecentDays);
+        Assert.Equal(7, criteria.DeadlineDays);
+    }
+}

--- a/StudyDocumentManager.Tests/SmartViewsModelTests.cs
+++ b/StudyDocumentManager.Tests/SmartViewsModelTests.cs
@@ -1,0 +1,347 @@
+using StudyDocumentManager.Core;
+using StudyDocumentManager.Core.DTOs;
+using StudyDocumentManager.Core.Entities;
+using StudyDocumentManager.Core.Interfaces;
+using StudyDocumentManager.Data.Repositories;
+using StudyDocumentManager.Models;
+using StudyDocumentManager.Services;
+using Xunit;
+
+namespace StudyDocumentManager.Tests;
+
+public class SmartViewsModelTests : DatabaseTestBase
+{
+    private SavedSearchRepository CreateSavedSearchRepo() => new(Db);
+
+    private SmartViewsModel CreateModel(
+        ISavedSearchRepository? savedSearchRepo = null,
+        RecordingDialogService? dialog = null,
+        RecordingNavigationService? navigation = null)
+    {
+        return new SmartViewsModel(
+            savedSearchRepo ?? CreateSavedSearchRepo(),
+            new CategoryRepository(Db),
+            dialog ?? new RecordingDialogService(),
+            navigation ?? new RecordingNavigationService(),
+            new StubLocalizationService());
+    }
+
+    private DashboardModel CreateDashboard(
+        RecordingDialogService? dialog = null,
+        RecordingNavigationService? navigation = null)
+    {
+        var repository = new DocumentRepository(Db);
+        return new DashboardModel(
+            repository,
+            repository,
+            new CategoryRepository(Db),
+            new CollectionRepository(Db),
+            new StubRecentFileRepository(),
+            dialog ?? new RecordingDialogService(),
+            new StubFileDialogService(),
+            new StubCustomDialogService(),
+            navigation ?? new RecordingNavigationService(),
+            new StubClipboardService(),
+            new StubProcessLauncherService(),
+            new StubExportService(),
+            new StubBackupService(),
+            new StubLocalizationService());
+    }
+
+    private static SavedSearchCriteria BuildCriteria(
+        string kind = SavedSearchKinds.Standard,
+        string? keyword = null,
+        bool important = false,
+        int recentDays = 7,
+        int deadlineDays = 7)
+        => new()
+        {
+            Kind = kind,
+            Keyword = keyword,
+            IsImportant = important ? true : null,
+            RecentDays = recentDays,
+            DeadlineDays = deadlineDays
+        };
+
+    [Fact]
+    public void Save_HappyPath_PersistsRowWithRoundtrippableCriteria()
+    {
+        var repo = CreateSavedSearchRepo();
+        var model = CreateModel(repo);
+
+        model.NewCommand.Execute(null);
+        model.EditorName = "  Calculus set  ";
+        model.EditorKeyword = "calculus";
+        model.EditorSubject = "Math";
+        model.EditorIsImportantOnly = true;
+        model.SaveCommand.Execute(null);
+
+        var all = repo.GetAll();
+        Assert.Single(all);
+        Assert.Equal("Calculus set", all[0].Name);
+
+        var restored = SavedSearchCriteria.FromJson(repo.GetById(all[0].Id)!.CriteriaJson);
+        Assert.NotNull(restored);
+        Assert.Equal(SavedSearchKinds.Standard, restored!.Kind);
+        Assert.Equal("calculus", restored.Keyword);
+        Assert.Equal("Math", restored.Subject);
+        Assert.True(restored.IsImportant);
+
+        Assert.Single(model.SavedViews);
+        Assert.False(model.IsEditing);
+        Assert.Equal("SV_Saved", model.StatusText);
+    }
+
+    [Fact]
+    public void Save_DuplicateName_BlockedWithStatusErrorAndNoNewRow()
+    {
+        var repo = CreateSavedSearchRepo();
+        repo.Add(new SavedSearch { Name = "Work", CriteriaJson = BuildCriteria().ToJson(), CreatedAt = DateTime.Now });
+        var model = CreateModel(repo);
+
+        model.NewCommand.Execute(null);
+        model.EditorName = "Work";
+        model.SaveCommand.Execute(null);
+
+        Assert.Single(repo.GetAll());
+        Assert.Equal("SV_NameExists", model.StatusText);
+        Assert.True(model.IsEditing);
+    }
+
+    [Fact]
+    public void Duplicate_CreatesSuffixedCopy_PreservingCriteriaJson()
+    {
+        var repo = CreateSavedSearchRepo();
+        var json = BuildCriteria(keyword: "physics").ToJson();
+        var sourceId = repo.Add(new SavedSearch { Name = "Set", CriteriaJson = json, CreatedAt = DateTime.Now });
+        var model = CreateModel(repo);
+        model.SelectedSavedSearch = model.SavedViews.First(v => v.Id == sourceId);
+
+        model.DuplicateCommand.Execute(null);
+
+        Assert.Equal(2, repo.GetAll().Count);
+        var copy = repo.GetAll().First(s => s.Id != sourceId);
+        Assert.Equal("Set (2)", copy.Name);
+        Assert.Equal(json, copy.CriteriaJson);
+        Assert.Equal(2, model.SavedViews.Count);
+    }
+
+    [Fact]
+    public async Task Delete_Confirmed_RemovesRowWithDangerConfirmation()
+    {
+        var repo = CreateSavedSearchRepo();
+        var dialog = new RecordingDialogService { ConfirmResult = true };
+        var id = repo.Add(new SavedSearch { Name = "Old", CriteriaJson = BuildCriteria().ToJson(), CreatedAt = DateTime.Now });
+        var model = CreateModel(repo, dialog: dialog);
+        model.SelectedSavedSearch = model.SavedViews.First(v => v.Id == id);
+
+        await model.DeleteCommand.ExecuteAsync(null);
+
+        Assert.Null(repo.GetById(id));
+        Assert.Empty(model.SavedViews);
+        Assert.Equal("SV_Deleted", model.StatusText);
+        Assert.True(dialog.LastConfirmWasDanger);
+    }
+
+    [Fact]
+    public async Task Delete_Dismissed_KeepsRow()
+    {
+        var repo = CreateSavedSearchRepo();
+        var dialog = new RecordingDialogService { ConfirmResult = false };
+        var id = repo.Add(new SavedSearch { Name = "Keep", CriteriaJson = BuildCriteria().ToJson(), CreatedAt = DateTime.Now });
+        var model = CreateModel(repo, dialog: dialog);
+        model.SelectedSavedSearch = model.SavedViews.First(v => v.Id == id);
+
+        await model.DeleteCommand.ExecuteAsync(null);
+
+        Assert.NotNull(repo.GetById(id));
+        Assert.Single(model.SavedViews);
+    }
+
+    [Fact]
+    public void Open_NavigatesToRunSmartViewWithSelectedId()
+    {
+        var repo = CreateSavedSearchRepo();
+        var navigation = new RecordingNavigationService();
+        var id = repo.Add(new SavedSearch { Name = "Run", CriteriaJson = BuildCriteria().ToJson(), CreatedAt = DateTime.Now });
+        var model = CreateModel(repo, navigation: navigation);
+        model.SelectedSavedSearch = model.SavedViews.First(v => v.Id == id);
+
+        model.OpenCommand.Execute(null);
+
+        Assert.Equal([("run-smartview", id)], navigation.RoutesWithParameter);
+    }
+
+    [Fact]
+    public void ApplySavedSearch_Standard_StoresPendingDuringDeferredInit_AppliesOnInitialize()
+    {
+        Repo.Add(new StudyDocument { Name = "Alpha calculus", Subject = "Math", Type = "PDF" });
+        Repo.Add(new StudyDocument { Name = "Beta physics", Subject = "Physics", Type = "PDF" });
+        var dashboard = CreateDashboard();
+
+        dashboard.ApplySavedSearch(BuildCriteria(keyword: "calculus"));
+
+        dashboard.Initialize();
+
+        Assert.Single(dashboard.Documents);
+        Assert.Equal("Alpha calculus", dashboard.Documents[0].Name);
+        Assert.Equal("calculus", dashboard.SearchKeyword);
+    }
+
+    [Fact]
+    public void ApplySavedSearch_DueSoon_SetsUpcomingDeadlineList()
+    {
+        Repo.Add(new StudyDocument { Name = "Near", Deadline = DateTime.Now.AddDays(3) });
+        Repo.Add(new StudyDocument { Name = "Far", Deadline = DateTime.Now.AddDays(30) });
+        var dashboard = CreateDashboard();
+
+        dashboard.ApplySavedSearch(BuildCriteria(kind: SavedSearchKinds.DueSoon, deadlineDays: 7));
+        dashboard.Initialize();
+
+        var names = dashboard.Documents.Select(d => d.Name).ToList();
+        Assert.Contains("Near", names);
+        Assert.DoesNotContain("Far", names);
+        Assert.Equal("Status_UpcomingDeadlines", dashboard.StatusText);
+    }
+
+    [Fact]
+    public void ApplySavedSearch_MissingFile_FiltersByDiskExistence_ClientSide()
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"sdm_sv_{Guid.NewGuid():N}.txt");
+        File.WriteAllBytes(tempFile, [1, 2, 3]);
+        try
+        {
+            Repo.Add(new StudyDocument { Name = "HasFile", FilePath = tempFile });
+            Repo.Add(new StudyDocument { Name = "LostFile", FilePath = @"Z:\definitely_missing_svt.pdf" });
+            Repo.Add(new StudyDocument { Name = "NoFilePath" });
+            var dashboard = CreateDashboard();
+
+            dashboard.ApplySavedSearch(BuildCriteria(kind: SavedSearchKinds.MissingFile));
+            dashboard.Initialize();
+
+            var names = dashboard.Documents.Select(d => d.Name).ToList();
+            Assert.Single(names);
+            Assert.Contains("LostFile", names);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void ApplySavedSearch_RecentlyAdded_EnablesDateFilterWithWindow()
+    {
+        Repo.Add(new StudyDocument { Name = "Fresh one" });
+        Repo.Add(new StudyDocument { Name = "Fresh two" });
+        var dashboard = CreateDashboard();
+
+        dashboard.ApplySavedSearch(BuildCriteria(kind: SavedSearchKinds.RecentlyAdded, recentDays: 7));
+        dashboard.Initialize();
+
+        Assert.True(dashboard.IsDateFilterEnabled);
+        Assert.NotNull(dashboard.FilterFromDate);
+        var from = dashboard.FilterFromDate!.Value.DateTime;
+        Assert.True(from <= DateTime.Now.AddDays(-6));
+        Assert.True(from >= DateTime.Now.AddDays(-8));
+        Assert.Equal(2, dashboard.Documents.Count);
+    }
+
+    [Fact]
+    public void FromJson_InvalidJson_ReturnsNull()
+    {
+        Assert.Null(SavedSearchCriteria.FromJson("{not valid json"));
+    }
+
+    private sealed class RecordingDialogService : IDialogService
+    {
+        public bool ConfirmResult { get; set; }
+        public bool LastConfirmWasDanger { get; private set; }
+
+        public Task ShowMessageAsync(string title, string message) => Task.CompletedTask;
+        public Task ShowErrorAsync(string title, string message) => Task.CompletedTask;
+        public Task<bool> ShowConfirmAsync(string title, string message) => ShowConfirmCore(false);
+        public Task<bool> ShowConfirmAsync(string title, string message, string confirmText, bool isDanger = false)
+            => ShowConfirmCore(isDanger);
+        public Task<string?> ShowInputAsync(string title, string label, string defaultValue = "", string watermark = "")
+            => Task.FromResult<string?>(null);
+
+        private Task<bool> ShowConfirmCore(bool isDanger)
+        {
+            LastConfirmWasDanger = isDanger;
+            return Task.FromResult(ConfirmResult);
+        }
+    }
+
+    private sealed class RecordingNavigationService : INavigationService
+    {
+        public List<(string Route, object? Parameter)> RoutesWithParameter { get; } = [];
+        public bool CanGoBack => false;
+        public void NavigateTo(string viewKey) => RoutesWithParameter.Add((viewKey, null));
+        public void NavigateTo(string viewKey, object? parameter) => RoutesWithParameter.Add((viewKey, parameter));
+        public void GoBack() { }
+    }
+
+    private sealed class StubRecentFileRepository : IRecentFileRepository
+    {
+        public List<(int Id, string Name, string? Subject, string? Type, string? FilePath, DateTime OpenedAt)> GetAll() => [];
+        public bool Add(int documentId) => true;
+        public void Clear() { }
+    }
+
+    private sealed class StubFileDialogService : IFileDialogService
+    {
+        public Task<string?> ShowOpenFileAsync(string title, string? filter = null) => Task.FromResult<string?>(null);
+        public Task<string?> ShowOpenFolderAsync(string title) => Task.FromResult<string?>(null);
+        public Task<string?> ShowSaveFileAsync(string title, string defaultFileName, string? filter = null)
+            => Task.FromResult<string?>(null);
+    }
+
+    private sealed class StubCustomDialogService : ICustomDialogService
+    {
+        public Task<string?> ShowChangeCategoryAsync(string documentName, IList<string> existingCategories, string currentCategory)
+            => Task.FromResult<string?>(null);
+        public Task<int> ShowSelectCollectionAsync(string documentName, IList<(int Id, string Name, int DocCount)> collections)
+            => Task.FromResult(-1);
+        public Task<List<StudyDocument>?> ShowDocumentPickerAsync(
+            string collectionName, IEnumerable<StudyDocument> allDocuments, IEnumerable<int> alreadyInCollection)
+            => Task.FromResult<List<StudyDocument>?>(null);
+        public Task<AddDocumentDraft?> ShowAddDocumentAsync(string filePath, IList<string> subjects, IList<string> types)
+            => Task.FromResult<AddDocumentDraft?>(null);
+    }
+
+    private sealed class StubClipboardService : IClipboardService
+    {
+        public Task SetTextAsync(string text) => Task.CompletedTask;
+    }
+
+    private sealed class StubProcessLauncherService : IProcessLauncherService
+    {
+        public void OpenFile(string filePath) { }
+        public void RevealInExplorer(string filePath) { }
+        public void OpenUrl(string url) { }
+    }
+
+    private sealed class StubExportService : IExportService
+    {
+        public Task<ExportResult> ExportCsvAsync(IReadOnlyList<StudyDocument> documents, string? suggestedFileName)
+            => Task.FromResult(new ExportResult(true));
+    }
+
+    private sealed class StubBackupService : IBackupService
+    {
+        public Task<(bool Success, string? Path, string? Error)> BackupAsync()
+            => Task.FromResult<(bool, string?, string?)>((true, null, null));
+        public Task<(bool Success, string? Error)> RestoreAsync()
+            => Task.FromResult<(bool, string?)>((true, null));
+    }
+
+    private sealed class StubLocalizationService : ILocalizationService
+    {
+        public string this[string key] => key;
+        public SupportedLanguage CurrentLanguage => SupportedLanguage.Japanese;
+        public void SetLanguage(SupportedLanguage language) { }
+        public IReadOnlyList<SupportedLanguage> AvailableLanguages { get; } = [];
+        public event EventHandler? LanguageChanged { add { } remove { } }
+    }
+}

--- a/StudyDocumentManager.Tests/UndoExtensionTests.cs
+++ b/StudyDocumentManager.Tests/UndoExtensionTests.cs
@@ -141,6 +141,28 @@ public class UndoApplierRoutingTests
     }
 
     [Fact]
+    public void ApplyLast_WhenMembershipRemovalFails_RestoresDocumentAndKeepsUndoEntry()
+    {
+        var undo = new UndoService();
+        var original = new StudyDocument { Id = 5, Name = "Before" };
+        undo.Push(new UndoEntry
+        {
+            DescriptionKey = "BE_UndoDescription",
+            Originals = [original],
+            AddedCollectionMemberships = [new CollectionMembership(42, 5)]
+        });
+
+        var documents = new RecordingDocuments();
+        var collections = new RecordingCollections { RemoveResult = false };
+        var applier = new UndoApplier(undo, documents, new RecordingRecycleBin(), collections);
+
+        Assert.Throws<InvalidOperationException>(applier.ApplyLast);
+        Assert.Equal(2, documents.Updated.Count);
+        Assert.Same(original, documents.Updated[0]);
+        Assert.True(undo.CanUndo);
+    }
+
+    [Fact]
     public void ApplyLast_EmptyStack_Throws()
     {
         var applier = new UndoApplier(new UndoService(), new RecordingDocuments(), new RecordingRecycleBin(), new RecordingCollections());
@@ -172,6 +194,7 @@ public class UndoApplierRoutingTests
         public List<(string Name, string? Description)> Created { get; } = [];
         public List<(int CollectionId, int DocumentId)> AddedDocs { get; } = [];
         public List<(int CollectionId, int DocumentId)> RemovedDocs { get; } = [];
+        public bool RemoveResult { get; init; } = true;
 
         public List<(int Id, string Name, string? Description, DateTime CreatedAt, int ItemCount)> GetAll() => [];
 
@@ -194,7 +217,7 @@ public class UndoApplierRoutingTests
         public bool RemoveDocument(int collectionId, int documentId)
         {
             RemovedDocs.Add((collectionId, documentId));
-            return true;
+            return RemoveResult;
         }
     }
 
@@ -204,7 +227,7 @@ public class UndoApplierRoutingTests
         public bool UpdateResult { get; init; } = true;
 
         public List<StudyDocument> GetAll() => [];
-        public StudyDocument? GetById(int id) => null;
+        public StudyDocument? GetById(int id) => new() { Id = id, Name = "After" };
         public List<StudyDocument> Search(string keyword) => [];
         public List<StudyDocument> Filter(string subject, string type) => [];
         public List<StudyDocument> SearchAdvanced(string keyword, string subject, string type, DateTime? fromDate, DateTime? toDate, double? minSize, double? maxSize, bool? isImportant) => [];

--- a/StudyDocumentManager.Tests/UndoExtensionTests.cs
+++ b/StudyDocumentManager.Tests/UndoExtensionTests.cs
@@ -148,7 +148,7 @@ public class UndoApplierRoutingTests
     }
 
     [Fact]
-    public void ApplyLast_WhenRestoreCountIsPartial_ThrowsAndKeepsUndoEntry()
+    public void ApplyLast_WhenRestoreCountIsPartial_ConsumesEntryAndThrowsPartial()
     {
         var undo = new UndoService();
         undo.Push(new UndoEntry { DescriptionKey = "UN_DeletedDocuments", DeletedIds = [7, 8] });
@@ -156,9 +156,11 @@ public class UndoApplierRoutingTests
         var recycleBin = new RecordingRecycleBin { RestoreCount = 1 };
         var applier = new UndoApplier(undo, new RecordingDocuments(), recycleBin, new RecordingCollections());
 
-        Assert.Throws<InvalidOperationException>(applier.ApplyLast);
+        var exception = Assert.Throws<UndoPartialRestoreException>(applier.ApplyLast);
+        Assert.Equal(1, exception.RestoredCount);
+        Assert.Equal(2, exception.RequestedCount);
         Assert.Single(recycleBin.RestoreCalls);
-        Assert.True(undo.CanUndo);
+        Assert.False(undo.CanUndo);
     }
 
     [Fact]
@@ -327,36 +329,82 @@ public class UndoApplierResilienceTests : DatabaseTestBase
     }
 
     [Fact]
-    public void ApplyLast_DeletedIdsEntryWithPermanentlyDeletedId_ThrowsKeepsEntryForRetryAndSurvivorRestored()
+    public void ApplyLast_PartialDeleteRestore_ConsumesNewestEntryAndUnclogsStack()
     {
-        var docA = new StudyDocument { Name = "A", Subject = "S1", Type = "PDF" };
+        var docA = new StudyDocument { Name = "A", Subject = "OldSubject", Type = "PDF" };
         var doomed = new StudyDocument { Name = "C", Subject = "S3", Type = "PDF" };
         Assert.True(Repo.Add(docA));
         Assert.True(Repo.Add(doomed));
-        Assert.Equal(2, Db.BulkSoftDelete([docA.Id, doomed.Id]));
-        Assert.True(Repo.PermanentDeleteDocument(doomed.Id));
 
-        var undo = new UndoService();
-        var entry = new UndoEntry
+        var olderMetadata = new UndoEntry
+        {
+            DescriptionKey = "BE_UndoDescription",
+            DescriptionArgs = [1],
+            Originals =
+            [
+                new StudyDocument { Id = docA.Id, Name = "A", Subject = "OldSubject", Type = "PDF" }
+            ],
+            CreatedAt = DateTime.Now
+        };
+        var newerDelete = new UndoEntry
         {
             DescriptionKey = "UN_DeletedDocuments",
             DescriptionArgs = [2],
             DeletedIds = [docA.Id, doomed.Id],
             CreatedAt = DateTime.Now
         };
-        undo.Push(entry);
+
+        var undo = new UndoService();
+        undo.Push(olderMetadata);
+        undo.Push(newerDelete);
+        Assert.Equal(1, Repo.BulkUpdateSubject([docA.Id], "ChangedSubject"));
+        Assert.Equal(2, Db.BulkSoftDelete([docA.Id, doomed.Id]));
+        Assert.True(Repo.PermanentDeleteDocument(doomed.Id));
 
         var applier = new UndoApplier(undo, Repo, Repo, new CollectionRepository(Db));
 
-        Assert.Throws<InvalidOperationException>(applier.ApplyLast);
+        var partial = Assert.Throws<UndoPartialRestoreException>(applier.ApplyLast);
+
+        Assert.Equal(1, partial.RestoredCount);
+        Assert.Equal(2, partial.RequestedCount);
         Assert.NotNull(Repo.GetById(docA.Id));
         Assert.Null(Repo.GetById(doomed.Id));
+        Assert.Same(olderMetadata, undo.Peek());
+        Assert.True(applier.CanUndo);
+
+        applier.ApplyLast();
+
+        Assert.Equal("OldSubject", Repo.GetById(docA.Id)!.Subject);
+        Assert.False(undo.CanUndo);
+    }
+
+    [Fact]
+    public void ApplyLast_AllDeletedIdsPermanentlyGone_KeepsEntryForRetry()
+    {
+        var doomed = new StudyDocument { Name = "Gone", Subject = "S3", Type = "PDF" };
+        Assert.True(Repo.Add(doomed));
+        Assert.Equal(1, Db.BulkSoftDelete([doomed.Id]));
+        Assert.True(Repo.PermanentDeleteDocument(doomed.Id));
+
+        var undo = new UndoService();
+        var entry = new UndoEntry
+        {
+            DescriptionKey = "UN_DeletedDocuments",
+            DescriptionArgs = [1],
+            DeletedIds = [doomed.Id],
+            CreatedAt = DateTime.Now
+        };
+        undo.Push(entry);
+        var applier = new UndoApplier(undo, Repo, Repo, new CollectionRepository(Db));
+
+        var failure = Record.Exception(applier.ApplyLast);
+
+        Assert.IsType<InvalidOperationException>(failure);
         Assert.Same(entry, undo.Peek());
         Assert.True(applier.CanUndo);
 
         Assert.Throws<InvalidOperationException>(applier.ApplyLast);
-        Assert.Null(Repo.GetById(doomed.Id));
-        Assert.NotNull(Repo.GetById(docA.Id));
+        Assert.Same(entry, undo.Peek());
     }
 
     [Fact]
@@ -785,6 +833,76 @@ public class BulkDeleteFallbackUndoTests : DatabaseTestBase
         public Task<bool> ShowConfirmAsync(string title, string message) => Task.FromResult(true);
         public Task<bool> ShowConfirmAsync(string title, string message, string confirmText, bool isDanger = false) => Task.FromResult(true);
         public Task<string?> ShowInputAsync(string title, string label, string defaultValue = "", string watermark = "") => Task.FromResult<string?>(null);
+    }
+}
+
+public class BulkDeleteModelPartialUndoTests : DatabaseTestBase
+{
+    [Fact]
+    public async Task UndoLast_ApplierPartialRestore_ReportsPartialWithoutErrorDialog()
+    {
+        var survivor = new StudyDocument { Name = "Keep", Subject = "Math", Type = "PDF" };
+        Assert.True(Repo.Add(survivor));
+        Assert.Equal(1, Db.BulkSoftDelete([survivor.Id]));
+
+        var undo = new UndoService();
+        undo.Push(new UndoEntry
+        {
+            DescriptionKey = "UN_DeletedDocuments",
+            DescriptionArgs = [2],
+            DeletedIds = [survivor.Id],
+            CreatedAt = DateTime.Now
+        });
+
+        var dialogs = new RecordingDialogs();
+        var applier = new PartialThrowingApplier(Repo, undo, [survivor.Id]);
+        var model = new BulkDeleteModel(Repo, Repo, new CategoryRepository(Db), dialogs, new StubNavigation(), new FormatLocalization(),
+            null, null, undo, applier, Repo);
+        model.Initialize();
+
+        await model.UndoLastCommand.ExecuteAsync(null);
+
+        Assert.Empty(dialogs.Errors);
+        Assert.Contains("BE_Result_Partial", model.StatusText);
+        Assert.DoesNotContain("UN_DeletedDocuments", model.StatusText);
+        Assert.Equal([survivor.Id], model.Documents.Select(d => d.Document.Id).ToList());
+        Assert.False(model.UndoLastCommand.CanExecute(null));
+    }
+
+    private sealed class PartialThrowingApplier(IRecycleBinRepository recycleBin, IUndoService undo, IReadOnlyList<int> restoreIds) : IUndoApplier
+    {
+        public bool CanUndo => undo.CanUndo;
+
+        public void ApplyLast()
+        {
+            recycleBin.RestoreDocuments(restoreIds);
+            undo.Pop();
+            throw new UndoPartialRestoreException(1, 2);
+        }
+    }
+
+    private sealed class RecordingDialogs : IDialogService
+    {
+        public List<string> Errors { get; } = [];
+
+        public Task ShowMessageAsync(string title, string message) => Task.CompletedTask;
+        public Task ShowErrorAsync(string title, string message)
+        {
+            Errors.Add(message);
+            return Task.CompletedTask;
+        }
+        public Task<bool> ShowConfirmAsync(string title, string message) => Task.FromResult(true);
+        public Task<bool> ShowConfirmAsync(string title, string message, string confirmText, bool isDanger = false) => Task.FromResult(true);
+        public Task<string?> ShowInputAsync(string title, string label, string defaultValue = "", string watermark = "") => Task.FromResult<string?>(null);
+    }
+
+    private sealed class FormatLocalization : ILocalizationService
+    {
+        public string this[string key] => $"{key}:{{0}}";
+        public SupportedLanguage CurrentLanguage => SupportedLanguage.Japanese;
+        public void SetLanguage(SupportedLanguage language) { }
+        public IReadOnlyList<SupportedLanguage> AvailableLanguages { get; } = Enum.GetValues<SupportedLanguage>();
+        public event EventHandler? LanguageChanged { add { } remove { } }
     }
 }
 

--- a/StudyDocumentManager.Tests/UndoExtensionTests.cs
+++ b/StudyDocumentManager.Tests/UndoExtensionTests.cs
@@ -1,0 +1,430 @@
+using StudyDocumentManager.Core;
+using StudyDocumentManager.Core.DTOs;
+using StudyDocumentManager.Core.Entities;
+using StudyDocumentManager.Core.Interfaces;
+using StudyDocumentManager.Data.Repositories;
+using StudyDocumentManager.Models;
+using StudyDocumentManager.Services;
+using Xunit;
+
+namespace StudyDocumentManager.Tests;
+
+public class UndoRestoreDocumentsTests : DatabaseTestBase
+{
+    [Fact]
+    public void RestoreDocuments_SoftDeletedDocs_RestoresAllAndReseedsCatalog()
+    {
+        var physicsA = new StudyDocument { Name = "A", Subject = "Physics", Type = "PDF" };
+        var physicsB = new StudyDocument { Name = "B", Subject = "Physics", Type = "PDF" };
+        var other = new StudyDocument { Name = "C", Subject = "Other", Type = "DOCX" };
+        Assert.True(Repo.Add(physicsA));
+        Assert.True(Repo.Add(physicsB));
+        Assert.True(Repo.Add(other));
+
+        Assert.True(new CategoryRepository(Db).DeleteDocumentsBySubject("Physics"));
+        Assert.Equal(1, Db.BulkSoftDelete([other.Id]));
+
+        Assert.Empty(Repo.GetAll());
+        Assert.DoesNotContain("Physics", Db.GetAllSubjects());
+
+        var restored = Repo.RestoreDocuments([physicsA.Id, physicsB.Id, other.Id]);
+
+        Assert.Equal(3, restored);
+        Assert.Equal(3, Repo.GetAll().Count);
+        Assert.Empty(Repo.GetDeletedDocuments());
+        Assert.Contains("Physics", Db.GetAllSubjects());
+    }
+}
+
+public class UndoApplierRoutingTests
+{
+    [Fact]
+    public void ApplyLast_DeletedIdsEntry_CallsRestoreDocumentsOnceWithExactIds()
+    {
+        var undo = new UndoService();
+        undo.Push(new UndoEntry { DescriptionKey = "UN_DeletedDocuments", DeletedIds = [7, 8, 9] });
+
+        var recycleBin = new RecordingRecycleBin();
+        var documents = new RecordingDocuments();
+        new UndoApplier(undo, documents, recycleBin, new RecordingCollections()).ApplyLast();
+
+        Assert.Single(recycleBin.RestoreCalls);
+        Assert.Equal(new[] { 7, 8, 9 }, recycleBin.RestoreCalls[0]);
+        Assert.Empty(documents.Updated);
+    }
+
+    [Fact]
+    public void ApplyLast_CollectionEntry_CreatesCollectionOnceAndReaddsAllMembers()
+    {
+        var undo = new UndoService();
+        undo.Push(new UndoEntry
+        {
+            DescriptionKey = "UN_CollectionRestorable",
+            Collection = new CollectionSnapshot("Study", "focus", [1, 2])
+        });
+
+        var collections = new RecordingCollections { NextId = 42 };
+        var recycleBin = new RecordingRecycleBin();
+        new UndoApplier(undo, new RecordingDocuments(), recycleBin, collections).ApplyLast();
+
+        Assert.Single(collections.Created);
+        Assert.Equal(("Study", "focus"), collections.Created[0]);
+        Assert.Equal(new List<(int CollectionId, int DocumentId)> { (42, 1), (42, 2) }, collections.AddedDocs);
+        Assert.Empty(recycleBin.RestoreCalls);
+    }
+
+    [Fact]
+    public void ApplyLast_MetadataEntry_UpdatesOriginals()
+    {
+        var undo = new UndoService();
+        var original = new StudyDocument { Id = 5, Name = "Alpha", Subject = "OldSubject" };
+        undo.Push(new UndoEntry
+        {
+            DescriptionKey = "BE_UndoDescription",
+            DescriptionArgs = [1],
+            Originals = [original]
+        });
+
+        var documents = new RecordingDocuments();
+        new UndoApplier(undo, documents, new RecordingRecycleBin(), new RecordingCollections()).ApplyLast();
+
+        Assert.Single(documents.Updated);
+        Assert.Same(original, documents.Updated[0]);
+    }
+
+    [Fact]
+    public void ApplyLast_EmptyStack_Throws()
+    {
+        var applier = new UndoApplier(new UndoService(), new RecordingDocuments(), new RecordingRecycleBin(), new RecordingCollections());
+
+        Assert.Throws<InvalidOperationException>(applier.ApplyLast);
+    }
+
+    private sealed class RecordingRecycleBin : IRecycleBinRepository
+    {
+        public List<IReadOnlyList<int>> RestoreCalls { get; } = [];
+
+        public int RestoreDocuments(IReadOnlyList<int> ids)
+        {
+            RestoreCalls.Add(ids);
+            return ids.Count;
+        }
+
+        public List<StudyDocument> GetDeletedDocuments() => [];
+        public bool RestoreDocument(int id) => true;
+        public bool PermanentDeleteDocument(int id) => true;
+        public int EmptyRecycleBin() => 0;
+        public int GetDeletedDocumentCount() => 0;
+    }
+
+    private sealed class RecordingCollections : ICollectionRepository
+    {
+        public int NextId { get; set; } = 42;
+        public List<(string Name, string? Description)> Created { get; } = [];
+        public List<(int CollectionId, int DocumentId)> AddedDocs { get; } = [];
+
+        public List<(int Id, string Name, string? Description, DateTime CreatedAt, int ItemCount)> GetAll() => [];
+
+        public int Create(string name, string? description = null)
+        {
+            Created.Add((name, description));
+            return NextId;
+        }
+
+        public bool Update(int id, string name, string? description = null) => true;
+        public bool Delete(int id) => true;
+        public List<StudyDocument> GetDocuments(int collectionId) => [];
+
+        public bool AddDocument(int collectionId, int documentId)
+        {
+            AddedDocs.Add((collectionId, documentId));
+            return true;
+        }
+
+        public bool RemoveDocument(int collectionId, int documentId) => true;
+    }
+
+    private sealed class RecordingDocuments : IDocumentRepository
+    {
+        public List<StudyDocument> Updated { get; } = [];
+
+        public List<StudyDocument> GetAll() => [];
+        public StudyDocument? GetById(int id) => null;
+        public List<StudyDocument> Search(string keyword) => [];
+        public List<StudyDocument> Filter(string subject, string type) => [];
+        public List<StudyDocument> SearchAdvanced(string keyword, string subject, string type, DateTime? fromDate, DateTime? toDate, double? minSize, double? maxSize, bool? isImportant) => [];
+        public bool Add(StudyDocument document) => true;
+        public bool AddWithCatalogs(StudyDocument document) => true;
+
+        public bool Update(StudyDocument document)
+        {
+            Updated.Add(document);
+            return true;
+        }
+
+        public bool Delete(int id) => true;
+        public List<string> GetDistinctSubjects() => [];
+        public List<string> GetDistinctTypes() => [];
+        public List<string> GetDistinctTags() => [];
+        public List<StudyDocument> GetUpcomingDeadlines(int days) => [];
+        public List<StudyDocument> GetOverdueDocuments() => [];
+        public void EnsureSubjectExists(string subject) { }
+        public void EnsureTypeExists(string type) { }
+    }
+}
+
+public class UndoCollectionIntegrationTests : DatabaseTestBase
+{
+    [Fact]
+    public void ApplyLast_CollectionDelete_RecreatesCollectionWithNewIdAndMembers()
+    {
+        var collections = new CollectionRepository(Db);
+        int originalId = collections.Create("Study", "focus");
+        var docA = new StudyDocument { Name = "A", Subject = "S", Type = "T" };
+        var docB = new StudyDocument { Name = "B", Subject = "S", Type = "T" };
+        Assert.True(Repo.Add(docA));
+        Assert.True(Repo.Add(docB));
+        Assert.True(collections.AddDocument(originalId, docA.Id));
+        Assert.True(collections.AddDocument(originalId, docB.Id));
+
+        var memberIds = new List<int> { docA.Id, docB.Id };
+        var undo = new UndoService();
+        undo.Push(new UndoEntry
+        {
+            DescriptionKey = "UN_CollectionRestorable",
+            DescriptionArgs = ["Study"],
+            Collection = new CollectionSnapshot("Study", "focus", memberIds),
+            CreatedAt = DateTime.Now
+        });
+        Assert.True(collections.Delete(originalId));
+        Assert.Empty(collections.GetAll());
+
+        new UndoApplier(undo, Repo, Repo, collections).ApplyLast();
+
+        var all = collections.GetAll();
+        Assert.Single(all);
+        Assert.NotEqual(originalId, all[0].Id);
+        Assert.Equal("Study", all[0].Name);
+        Assert.Equal("focus", all[0].Description);
+
+        var restoredMemberIds = collections.GetDocuments(all[0].Id).Select(d => d.Id).OrderBy(x => x).ToList();
+        Assert.Equal(memberIds.OrderBy(x => x), restoredMemberIds);
+    }
+}
+
+public class UndoCategoryCascadeTests : DatabaseTestBase
+{
+    [Fact]
+    public async Task DeleteSubject_WithPreviewConfirm_PushesUndoThatRestoresDocsAndCatalog()
+    {
+        var docA = new StudyDocument { Name = "Alpha", Subject = "Math101", Type = "PDF" };
+        var docB = new StudyDocument { Name = "Beta", Subject = "Math101", Type = "PDF" };
+        Assert.True(Repo.AddWithCatalogs(docA));
+        Assert.True(Repo.AddWithCatalogs(docB));
+
+        // AddWithCatalogs does not write back generated ids; read them from storage.
+        var seededIds = Repo.GetAll().Select(d => d.Id).OrderBy(x => x).ToList();
+        Assert.Equal(2, seededIds.Count);
+
+        var undo = new UndoService();
+        var applier = new UndoApplier(undo, Repo, Repo, new CollectionRepository(Db));
+        var dialogs = new PreviewConfirmTrueDialogs();
+        var model = new CategoryManagementModel(Repo, new CategoryRepository(Db), dialogs, new KeyLocalization(), dialogs, undo);
+
+        var target = model.Subjects.First(s => s.Name == "Math101");
+        model.SelectedSubjects = new List<CategoryItem> { target };
+
+        await model.DeleteSubjectCommand.ExecuteAsync(null);
+
+        Assert.Empty(Repo.GetAll());
+        Assert.DoesNotContain("Math101", Db.GetAllSubjects());
+        Assert.True(applier.CanUndo);
+
+        applier.ApplyLast();
+
+        Assert.Equal(
+            seededIds,
+            Repo.GetAll().Select(d => d.Id).OrderBy(x => x).ToList());
+        Assert.Contains("Math101", Db.GetAllSubjects());
+        Assert.False(applier.CanUndo);
+    }
+
+    private sealed class PreviewConfirmTrueDialogs : IDialogService, ICustomDialogService
+    {
+        public Task ShowMessageAsync(string title, string message) => Task.CompletedTask;
+        public Task ShowErrorAsync(string title, string message) => Task.CompletedTask;
+        public Task<bool> ShowConfirmAsync(string title, string message) => Task.FromResult(true);
+        public Task<bool> ShowConfirmAsync(string title, string message, string confirmText, bool isDanger = false) => Task.FromResult(true);
+        public Task<string?> ShowInputAsync(string title, string label, string defaultValue = "", string watermark = "") => Task.FromResult<string?>(null);
+
+        public Task<bool> ShowAffectedItemsPreviewAsync(string title, int totalCount, IReadOnlyList<string> itemNames, string reversibilityNote)
+            => Task.FromResult(true);
+
+        public Task<string?> ShowChangeCategoryAsync(string documentName, IList<string> existingCategories, string currentCategory)
+            => Task.FromResult<string?>(null);
+
+        public Task<int> ShowSelectCollectionAsync(string documentName, IList<(int Id, string Name, int DocCount)> collections)
+            => Task.FromResult(-1);
+
+        public Task<List<StudyDocument>?> ShowDocumentPickerAsync(string collectionName, IEnumerable<StudyDocument> allDocuments, IEnumerable<int> alreadyInCollection)
+            => Task.FromResult<List<StudyDocument>?>(null);
+
+        public Task<AddDocumentDraft?> ShowAddDocumentAsync(string filePath, IList<string> subjects, IList<string> types)
+            => Task.FromResult<AddDocumentDraft?>(null);
+    }
+}
+
+public class MainWindowModelUndoStateTests
+{
+    [Fact]
+    public void CanUndo_TransitionsOnPushAndApply()
+    {
+        var undo = new UndoService();
+        var applier = new UndoApplier(undo, new RoutingFakes.RecordingDocuments(), new RoutingFakes.RecordingRecycleBin(), new RoutingFakes.RecordingCollections());
+        var model = CreateModel(applier, undo);
+
+        Assert.False(model.CanUndo);
+
+        undo.Push(new UndoEntry { DescriptionKey = "UN_DeletedDocuments", DeletedIds = [1] });
+        Assert.True(model.CanUndo);
+
+        applier.ApplyLast();
+        Assert.False(model.CanUndo);
+    }
+
+    private static MainWindowModel CreateModel(IUndoApplier applier, IUndoService undo)
+    {
+        var loc = new KeyLocalization();
+        var dashboard = new DashboardModel(null!, null!, null!, null!, null!, new StubDialogService(), null!, null!, null!, null!, null!, null!, null!, loc);
+        return new MainWindowModel(dashboard, new StubNavigation(), new StubDialogService(), null!, null!,
+            new StubLifecycle(), loc, new StubSettings(), new StubUpdate(), applier, undo);
+    }
+}
+
+public class BulkDeleteLegacyUndoRegressionTests : DatabaseTestBase
+{
+    [Fact]
+    public async Task MetadataBulkEdit_UndoWithoutApplier_StillRestoresOriginals()
+    {
+        var doc = new StudyDocument { Name = "Alpha", Subject = "Math", Type = "PDF" };
+        Assert.True(Repo.Add(doc));
+
+        var undo = new UndoService();
+        var dialog = new StubDialogService { ConfirmResult = true };
+        var model = new BulkDeleteModel(Repo, Repo, new CategoryRepository(Db), dialog, new StubNavigation(), new KeyLocalization(),
+            null, null, undo);
+        model.Initialize();
+        foreach (var row in model.Documents)
+            row.IsSelected = true;
+        model.EnableSubject = true;
+        model.NewSubject = "Physics";
+
+        await model.ApplyBulkEditCommand.ExecuteAsync(null);
+        Assert.Equal("Physics", Repo.GetById(doc.Id)!.Subject);
+        Assert.True(model.UndoLastCommand.CanExecute(null));
+
+        await model.UndoLastCommand.ExecuteAsync(null);
+
+        Assert.Equal("Math", Repo.GetById(doc.Id)!.Subject);
+        Assert.False(model.UndoLastCommand.CanExecute(null));
+    }
+}
+
+internal static class RoutingFakes
+{
+    public sealed class RecordingRecycleBin : IRecycleBinRepository
+    {
+        public List<IReadOnlyList<int>> RestoreCalls { get; } = [];
+
+        public int RestoreDocuments(IReadOnlyList<int> ids)
+        {
+            RestoreCalls.Add(ids);
+            return ids.Count;
+        }
+
+        public List<StudyDocument> GetDeletedDocuments() => [];
+        public bool RestoreDocument(int id) => true;
+        public bool PermanentDeleteDocument(int id) => true;
+        public int EmptyRecycleBin() => 0;
+        public int GetDeletedDocumentCount() => 0;
+    }
+
+    public sealed class RecordingCollections : ICollectionRepository
+    {
+        public int NextId { get; set; } = 42;
+
+        public List<(int Id, string Name, string? Description, DateTime CreatedAt, int ItemCount)> GetAll() => [];
+        public int Create(string name, string? description = null) => NextId;
+        public bool Update(int id, string name, string? description = null) => true;
+        public bool Delete(int id) => true;
+        public List<StudyDocument> GetDocuments(int collectionId) => [];
+        public bool AddDocument(int collectionId, int documentId) => true;
+        public bool RemoveDocument(int collectionId, int documentId) => true;
+    }
+
+    public sealed class RecordingDocuments : IDocumentRepository
+    {
+        public List<StudyDocument> GetAll() => [];
+        public StudyDocument? GetById(int id) => null;
+        public List<StudyDocument> Search(string keyword) => [];
+        public List<StudyDocument> Filter(string subject, string type) => [];
+        public List<StudyDocument> SearchAdvanced(string keyword, string subject, string type, DateTime? fromDate, DateTime? toDate, double? minSize, double? maxSize, bool? isImportant) => [];
+        public bool Add(StudyDocument document) => true;
+        public bool AddWithCatalogs(StudyDocument document) => true;
+        public bool Update(StudyDocument document) => true;
+        public bool Delete(int id) => true;
+        public List<string> GetDistinctSubjects() => [];
+        public List<string> GetDistinctTypes() => [];
+        public List<string> GetDistinctTags() => [];
+        public List<StudyDocument> GetUpcomingDeadlines(int days) => [];
+        public List<StudyDocument> GetOverdueDocuments() => [];
+        public void EnsureSubjectExists(string subject) { }
+        public void EnsureTypeExists(string type) { }
+    }
+}
+
+file sealed class StubDialogService : IDialogService
+{
+    public bool ConfirmResult { get; init; }
+
+    public Task ShowMessageAsync(string title, string message) => Task.CompletedTask;
+    public Task ShowErrorAsync(string title, string message) => Task.CompletedTask;
+    public Task<bool> ShowConfirmAsync(string title, string message) => Task.FromResult(ConfirmResult);
+    public Task<bool> ShowConfirmAsync(string title, string message, string confirmText, bool isDanger = false) => Task.FromResult(ConfirmResult);
+    public Task<string?> ShowInputAsync(string title, string label, string defaultValue = "", string watermark = "") => Task.FromResult<string?>(null);
+}
+
+file sealed class StubNavigation : INavigationService
+{
+    public bool CanGoBack => false;
+    public void NavigateTo(string viewKey) { }
+    public void NavigateTo(string viewKey, object? parameter) { }
+    public void GoBack() { }
+}
+
+file sealed class StubLifecycle : IApplicationLifecycleService
+{
+    public void Shutdown() { }
+}
+
+file sealed class StubSettings : ISettingsService
+{
+    public string? GetSetting(string key) => null;
+    public void SetSetting(string key, string value) { }
+}
+
+file sealed class StubUpdate : IUpdateService
+{
+    public Task<UpdateInfo?> CheckForUpdateAsync() => Task.FromResult<UpdateInfo?>(null);
+    public Task CheckSilentlyAsync() => Task.CompletedTask;
+    public Task HandleUpdateAsync(UpdateInfo update) => Task.CompletedTask;
+}
+
+file sealed class KeyLocalization : ILocalizationService
+{
+    public string this[string key] => key;
+    public SupportedLanguage CurrentLanguage => SupportedLanguage.Japanese;
+    public void SetLanguage(SupportedLanguage language) { }
+    public IReadOnlyList<SupportedLanguage> AvailableLanguages { get; } = Enum.GetValues<SupportedLanguage>();
+    public event EventHandler? LanguageChanged { add { } remove { } }
+}

--- a/StudyDocumentManager.Tests/UndoExtensionTests.cs
+++ b/StudyDocumentManager.Tests/UndoExtensionTests.cs
@@ -148,16 +148,17 @@ public class UndoApplierRoutingTests
     }
 
     [Fact]
-    public void ApplyLast_WhenRestoreCountIsPartial_RestoresWhatExistsAndPopsEntry()
+    public void ApplyLast_WhenRestoreCountIsPartial_ThrowsAndKeepsUndoEntry()
     {
         var undo = new UndoService();
         undo.Push(new UndoEntry { DescriptionKey = "UN_DeletedDocuments", DeletedIds = [7, 8] });
 
         var recycleBin = new RecordingRecycleBin { RestoreCount = 1 };
-        new UndoApplier(undo, new RecordingDocuments(), recycleBin, new RecordingCollections()).ApplyLast();
+        var applier = new UndoApplier(undo, new RecordingDocuments(), recycleBin, new RecordingCollections());
 
+        Assert.Throws<InvalidOperationException>(applier.ApplyLast);
         Assert.Single(recycleBin.RestoreCalls);
-        Assert.False(undo.CanUndo);
+        Assert.True(undo.CanUndo);
     }
 
     [Fact]
@@ -326,32 +327,36 @@ public class UndoApplierResilienceTests : DatabaseTestBase
     }
 
     [Fact]
-    public void ApplyLast_DeletedIdsEntryWithPermanentlyDeletedId_RestoresRecoverableOnes()
+    public void ApplyLast_DeletedIdsEntryWithPermanentlyDeletedId_ThrowsKeepsEntryForRetryAndSurvivorRestored()
     {
         var docA = new StudyDocument { Name = "A", Subject = "S1", Type = "PDF" };
-        var docB = new StudyDocument { Name = "B", Subject = "S2", Type = "DOCX" };
         var doomed = new StudyDocument { Name = "C", Subject = "S3", Type = "PDF" };
         Assert.True(Repo.Add(docA));
-        Assert.True(Repo.Add(docB));
         Assert.True(Repo.Add(doomed));
-        Assert.Equal(3, Db.BulkSoftDelete([docA.Id, docB.Id, doomed.Id]));
+        Assert.Equal(2, Db.BulkSoftDelete([docA.Id, doomed.Id]));
         Assert.True(Repo.PermanentDeleteDocument(doomed.Id));
 
         var undo = new UndoService();
-        undo.Push(new UndoEntry
+        var entry = new UndoEntry
         {
             DescriptionKey = "UN_DeletedDocuments",
-            DescriptionArgs = [3],
-            DeletedIds = [docA.Id, doomed.Id, docB.Id],
+            DescriptionArgs = [2],
+            DeletedIds = [docA.Id, doomed.Id],
             CreatedAt = DateTime.Now
-        });
+        };
+        undo.Push(entry);
 
-        new UndoApplier(undo, Repo, Repo, new CollectionRepository(Db)).ApplyLast();
+        var applier = new UndoApplier(undo, Repo, Repo, new CollectionRepository(Db));
 
+        Assert.Throws<InvalidOperationException>(applier.ApplyLast);
+        Assert.NotNull(Repo.GetById(docA.Id));
+        Assert.Null(Repo.GetById(doomed.Id));
+        Assert.Same(entry, undo.Peek());
+        Assert.True(applier.CanUndo);
+
+        Assert.Throws<InvalidOperationException>(applier.ApplyLast);
         Assert.Null(Repo.GetById(doomed.Id));
         Assert.NotNull(Repo.GetById(docA.Id));
-        Assert.NotNull(Repo.GetById(docB.Id));
-        Assert.False(undo.CanUndo);
     }
 
     [Fact]
@@ -692,6 +697,70 @@ public class BulkDeleteFallbackUndoTests : DatabaseTestBase
 
         await model.UndoLastCommand.ExecuteAsync(null);
         Assert.Equal(2, dialogs.Errors.Count);
+    }
+
+    [Fact]
+    public async Task UndoLast_MetadataFallbackWithMemberships_RemovesMembershipsRestoresOriginalsAndPops()
+    {
+        var collections = new CollectionRepository(Db);
+        var collectionId = collections.Create("Study", "focus");
+        var doc = new StudyDocument { Name = "Alpha", Subject = "Math", Type = "PDF" };
+        Assert.True(Repo.Add(doc));
+        Assert.True(collections.AddDocument(collectionId, doc.Id));
+        Assert.Single(collections.GetDocuments(collectionId));
+
+        var preEdit = Clone(Repo.GetById(doc.Id)!);
+        Assert.True(Repo.Update(new StudyDocument { Id = doc.Id, Name = "Alpha", Subject = "Physics", Type = "PDF" }));
+
+        var undo = new UndoService();
+        undo.Push(new UndoEntry
+        {
+            DescriptionKey = "BE_UndoDescription",
+            DescriptionArgs = [1],
+            Originals = [preEdit],
+            AddedCollectionMemberships = [new CollectionMembership(collectionId, doc.Id)],
+            CreatedAt = DateTime.Now
+        });
+
+        var dialogs = new RecordingErrorDialogs();
+        var model = new BulkDeleteModel(Repo, Repo, new CategoryRepository(Db), dialogs, new StubNavigation(), new FormatKeyLocalization(),
+            null, collections, undo);
+
+        await model.UndoLastCommand.ExecuteAsync(null);
+
+        Assert.Equal("Math", Repo.GetById(doc.Id)!.Subject);
+        Assert.Empty(collections.GetDocuments(collectionId));
+        Assert.False(model.UndoLastCommand.CanExecute(null));
+        Assert.Empty(dialogs.Errors);
+    }
+
+    [Fact]
+    public async Task UndoLast_MetadataFallbackWithMembershipsAndNullCollectionRepo_SkipsMembershipRemovalSilently()
+    {
+        var doc = new StudyDocument { Name = "Beta", Subject = "Math", Type = "DOCX" };
+        Assert.True(Repo.Add(doc));
+
+        var preEdit = Clone(Repo.GetById(doc.Id)!);
+        Assert.True(Repo.Update(new StudyDocument { Id = doc.Id, Name = "Beta", Subject = "Physics", Type = "DOCX" }));
+
+        var undo = new UndoService();
+        undo.Push(new UndoEntry
+        {
+            DescriptionKey = "BE_UndoDescription",
+            DescriptionArgs = [1],
+            Originals = [preEdit],
+            AddedCollectionMemberships = [new CollectionMembership(999, doc.Id)],
+            CreatedAt = DateTime.Now
+        });
+
+        var dialogs = new RecordingErrorDialogs();
+        var model = CreateModel(undo, dialogs, null);
+
+        await model.UndoLastCommand.ExecuteAsync(null);
+
+        Assert.Equal("Math", Repo.GetById(doc.Id)!.Subject);
+        Assert.False(model.UndoLastCommand.CanExecute(null));
+        Assert.Empty(dialogs.Errors);
     }
 
     private sealed class FormatKeyLocalization : ILocalizationService

--- a/StudyDocumentManager.Tests/UndoExtensionTests.cs
+++ b/StudyDocumentManager.Tests/UndoExtensionTests.cs
@@ -34,6 +34,26 @@ public class UndoRestoreDocumentsTests : DatabaseTestBase
         Assert.Empty(Repo.GetDeletedDocuments());
         Assert.Contains("Physics", Db.GetAllSubjects());
     }
+
+    [Fact]
+    public void RestoreDocuments_ContainsPermanentlyDeletedId_RestoresRecoverableOnesBestEffort()
+    {
+        var recoverableA = new StudyDocument { Name = "R1", Subject = "Physics", Type = "PDF" };
+        var recoverableB = new StudyDocument { Name = "R2", Subject = "Physics", Type = "PDF" };
+        var doomed = new StudyDocument { Name = "Gone", Subject = "Other", Type = "DOCX" };
+        Assert.True(Repo.Add(recoverableA));
+        Assert.True(Repo.Add(recoverableB));
+        Assert.True(Repo.Add(doomed));
+
+        Assert.Equal(3, Db.BulkSoftDelete([recoverableA.Id, recoverableB.Id, doomed.Id]));
+        Assert.True(Repo.PermanentDeleteDocument(doomed.Id));
+
+        var restored = Repo.RestoreDocuments([recoverableA.Id, doomed.Id, recoverableB.Id]);
+
+        Assert.Equal(2, restored);
+        Assert.Equal([recoverableA.Id, recoverableB.Id], Repo.GetAll().Select(d => d.Id).OrderBy(x => x).ToList());
+        Assert.Empty(Repo.GetDeletedDocuments());
+    }
 }
 
 public class UndoApplierRoutingTests
@@ -128,20 +148,20 @@ public class UndoApplierRoutingTests
     }
 
     [Fact]
-    public void ApplyLast_WhenRestoreCountIsPartial_KeepsUndoEntry()
+    public void ApplyLast_WhenRestoreCountIsPartial_RestoresWhatExistsAndPopsEntry()
     {
         var undo = new UndoService();
         undo.Push(new UndoEntry { DescriptionKey = "UN_DeletedDocuments", DeletedIds = [7, 8] });
 
         var recycleBin = new RecordingRecycleBin { RestoreCount = 1 };
-        var applier = new UndoApplier(undo, new RecordingDocuments(), recycleBin, new RecordingCollections());
+        new UndoApplier(undo, new RecordingDocuments(), recycleBin, new RecordingCollections()).ApplyLast();
 
-        Assert.Throws<InvalidOperationException>(applier.ApplyLast);
-        Assert.True(undo.CanUndo);
+        Assert.Single(recycleBin.RestoreCalls);
+        Assert.False(undo.CanUndo);
     }
 
     [Fact]
-    public void ApplyLast_WhenMembershipRemovalFails_RestoresDocumentAndKeepsUndoEntry()
+    public void ApplyLast_WhenMembershipAlreadyGone_SkipsMembershipAndKeepsDocumentRestore()
     {
         var undo = new UndoService();
         var original = new StudyDocument { Id = 5, Name = "Before" };
@@ -154,12 +174,12 @@ public class UndoApplierRoutingTests
 
         var documents = new RecordingDocuments();
         var collections = new RecordingCollections { RemoveResult = false };
-        var applier = new UndoApplier(undo, documents, new RecordingRecycleBin(), collections);
+        new UndoApplier(undo, documents, new RecordingRecycleBin(), collections).ApplyLast();
 
-        Assert.Throws<InvalidOperationException>(applier.ApplyLast);
-        Assert.Equal(2, documents.Updated.Count);
+        Assert.Single(documents.Updated);
         Assert.Same(original, documents.Updated[0]);
-        Assert.True(undo.CanUndo);
+        Assert.Equal([(42, 5)], collections.RemovedDocs);
+        Assert.False(undo.CanUndo);
     }
 
     [Fact]
@@ -248,6 +268,128 @@ public class UndoApplierRoutingTests
         public List<StudyDocument> GetOverdueDocuments() => [];
         public void EnsureSubjectExists(string subject) { }
         public void EnsureTypeExists(string type) { }
+    }
+}
+
+public class UndoApplierResilienceTests : DatabaseTestBase
+{
+    [Fact]
+    public void ApplyLast_MetadataEntryWithPermanentlyDeletedOriginal_RestoresSurvivorsAndSkipsStaleMembership()
+    {
+        var collections = new CollectionRepository(Db);
+        var collectionId = collections.Create("Study", "focus");
+        var docA = new StudyDocument { Name = "A", Subject = "NewSubject", Type = "PDF" };
+        var docB = new StudyDocument { Name = "B", Subject = "NewSubject", Type = "PDF" };
+        var docC = new StudyDocument { Name = "C", Subject = "NewSubject", Type = "PDF" };
+        Assert.True(Repo.Add(docA));
+        Assert.True(Repo.Add(docB));
+        Assert.True(Repo.Add(docC));
+
+        foreach (var doc in new[] { docA, docB, docC })
+        {
+            Assert.True(collections.AddDocument(collectionId, doc.Id));
+            Assert.Equal(1, Repo.BulkUpdateSubject([doc.Id], "OldSubject"));
+        }
+
+        Assert.True(Repo.Delete(docC.Id));
+        Assert.True(Repo.PermanentDeleteDocument(docC.Id));
+        _ = collections.RemoveDocument(collectionId, docC.Id);
+        Assert.True(collections.RemoveDocument(collectionId, docA.Id));
+        Assert.Equal([docB.Id], collections.GetDocuments(collectionId).Select(d => d.Id).ToList());
+
+        var undo = new UndoService();
+        undo.Push(new UndoEntry
+        {
+            DescriptionKey = "BE_UndoDescription",
+            DescriptionArgs = [3],
+            Originals =
+            [
+                new StudyDocument { Id = docA.Id, Name = "A", Subject = "NewSubject", Type = "PDF" },
+                new StudyDocument { Id = docB.Id, Name = "B", Subject = "NewSubject", Type = "PDF" }
+            ],
+            AddedCollectionMemberships =
+            [
+                new CollectionMembership(collectionId, docA.Id),
+                new CollectionMembership(collectionId, docB.Id),
+                new CollectionMembership(collectionId, docC.Id)
+            ],
+            CreatedAt = DateTime.Now
+        });
+
+        new UndoApplier(undo, Repo, Repo, collections).ApplyLast();
+
+        Assert.Equal("NewSubject", Repo.GetById(docA.Id)!.Subject);
+        Assert.Equal("NewSubject", Repo.GetById(docB.Id)!.Subject);
+        Assert.Null(Repo.GetById(docC.Id));
+        Assert.Empty(collections.GetDocuments(collectionId));
+        Assert.False(undo.CanUndo);
+    }
+
+    [Fact]
+    public void ApplyLast_DeletedIdsEntryWithPermanentlyDeletedId_RestoresRecoverableOnes()
+    {
+        var docA = new StudyDocument { Name = "A", Subject = "S1", Type = "PDF" };
+        var docB = new StudyDocument { Name = "B", Subject = "S2", Type = "DOCX" };
+        var doomed = new StudyDocument { Name = "C", Subject = "S3", Type = "PDF" };
+        Assert.True(Repo.Add(docA));
+        Assert.True(Repo.Add(docB));
+        Assert.True(Repo.Add(doomed));
+        Assert.Equal(3, Db.BulkSoftDelete([docA.Id, docB.Id, doomed.Id]));
+        Assert.True(Repo.PermanentDeleteDocument(doomed.Id));
+
+        var undo = new UndoService();
+        undo.Push(new UndoEntry
+        {
+            DescriptionKey = "UN_DeletedDocuments",
+            DescriptionArgs = [3],
+            DeletedIds = [docA.Id, doomed.Id, docB.Id],
+            CreatedAt = DateTime.Now
+        });
+
+        new UndoApplier(undo, Repo, Repo, new CollectionRepository(Db)).ApplyLast();
+
+        Assert.Null(Repo.GetById(doomed.Id));
+        Assert.NotNull(Repo.GetById(docA.Id));
+        Assert.NotNull(Repo.GetById(docB.Id));
+        Assert.False(undo.CanUndo);
+    }
+
+    [Fact]
+    public void ApplyLast_FastPathMetadataUndo_PermanentlyDeletedOriginal_SkipsItAndRestoresOthers()
+    {
+        var docA = new StudyDocument { Name = "A", Subject = "NewSubject", Type = "PDF" };
+        var docB = new StudyDocument { Name = "B", Subject = "NewSubject", Type = "PDF" };
+        var docC = new StudyDocument { Name = "C", Subject = "NewSubject", Type = "PDF" };
+        Assert.True(Repo.Add(docA));
+        Assert.True(Repo.Add(docB));
+        Assert.True(Repo.Add(docC));
+
+        foreach (var doc in new[] { docA, docB, docC })
+            Assert.Equal(1, Repo.BulkUpdateSubject([doc.Id], "OldSubject"));
+
+        Assert.True(Repo.Delete(docC.Id));
+        Assert.True(Repo.PermanentDeleteDocument(docC.Id));
+
+        var undo = new UndoService();
+        undo.Push(new UndoEntry
+        {
+            DescriptionKey = "BE_UndoDescription",
+            DescriptionArgs = [3],
+            Originals =
+            [
+                new StudyDocument { Id = docA.Id, Name = "A", Subject = "NewSubject", Type = "PDF" },
+                new StudyDocument { Id = docB.Id, Name = "B", Subject = "NewSubject", Type = "PDF" },
+                new StudyDocument { Id = docC.Id, Name = "C", Subject = "NewSubject", Type = "PDF" }
+            ],
+            CreatedAt = DateTime.Now
+        });
+
+        new UndoApplier(undo, Repo, Repo, new CollectionRepository(Db), Repo).ApplyLast();
+
+        Assert.Equal("NewSubject", Repo.GetById(docA.Id)!.Subject);
+        Assert.Equal("NewSubject", Repo.GetById(docB.Id)!.Subject);
+        Assert.Null(Repo.GetById(docC.Id));
+        Assert.False(undo.CanUndo);
     }
 }
 
@@ -405,6 +547,175 @@ public class BulkDeleteLegacyUndoRegressionTests : DatabaseTestBase
 
         Assert.Equal("Math", Repo.GetById(doc.Id)!.Subject);
         Assert.False(model.UndoLastCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public async Task DeleteBulkEdit_UndoWithoutApplier_RestoresSoftDeletedDocs()
+    {
+        var docA = new StudyDocument { Name = "Alpha", Subject = "Math", Type = "PDF" };
+        var docB = new StudyDocument { Name = "Beta", Subject = "Physics", Type = "DOCX" };
+        Assert.True(Repo.Add(docA));
+        Assert.True(Repo.Add(docB));
+
+        var undo = new UndoService();
+        var dialog = new StubDialogService { ConfirmResult = true };
+        var model = new BulkDeleteModel(Repo, Repo, new CategoryRepository(Db), dialog, new StubNavigation(), new KeyLocalization(),
+            null, null, undo, null, Repo);
+        model.Initialize();
+        foreach (var row in model.Documents)
+            row.IsSelected = true;
+
+        await model.DeleteSelectedCommand.ExecuteAsync(null);
+
+        Assert.Empty(Repo.GetAll());
+        Assert.Equal(2, Repo.GetDeletedDocuments().Count);
+        Assert.True(model.UndoLastCommand.CanExecute(null));
+
+        await model.UndoLastCommand.ExecuteAsync(null);
+
+        Assert.Equal([docA.Id, docB.Id], Repo.GetAll().Select(d => d.Id).OrderBy(x => x).ToList());
+        Assert.Empty(Repo.GetDeletedDocuments());
+        Assert.False(model.UndoLastCommand.CanExecute(null));
+    }
+}
+
+public class BulkDeleteFallbackUndoTests : DatabaseTestBase
+{
+    private static StudyDocument Clone(StudyDocument d) => new()
+    {
+        Id = d.Id,
+        Name = d.Name,
+        Subject = d.Subject,
+        Type = d.Type
+    };
+
+    private BulkDeleteModel CreateModel(UndoService undo, IDialogService dialogs, IRecycleBinRepository? recycleBin)
+        => new(Repo, Repo, new CategoryRepository(Db), dialogs, new StubNavigation(), new FormatKeyLocalization(),
+            null, null, undo, null, recycleBin);
+
+    [Fact]
+    public async Task UndoLast_DeletedIdsFallback_RestoresAllPopsAndReportsApplied()
+    {
+        var docA = new StudyDocument { Name = "Alpha", Subject = "Math", Type = "PDF" };
+        var docB = new StudyDocument { Name = "Beta", Subject = "Physics", Type = "DOCX" };
+        Assert.True(Repo.Add(docA));
+        Assert.True(Repo.Add(docB));
+
+        var originals = Repo.GetAll().Select(Clone).ToList();
+        Assert.Equal(2, Db.BulkSoftDelete([docA.Id, docB.Id]));
+
+        var undo = new UndoService();
+        undo.Push(new UndoEntry
+        {
+            DescriptionKey = "UN_DeletedDocuments",
+            DescriptionArgs = [2],
+            Originals = originals,
+            DeletedIds = [docA.Id, docB.Id],
+            CreatedAt = DateTime.Now
+        });
+
+        var dialogs = new RecordingErrorDialogs();
+        var model = CreateModel(undo, dialogs, Repo);
+
+        await model.UndoLastCommand.ExecuteAsync(null);
+
+        Assert.Equal([docA.Id, docB.Id], Repo.GetAll().Select(d => d.Id).OrderBy(x => x).ToList());
+        Assert.Empty(Repo.GetDeletedDocuments());
+        Assert.False(model.UndoLastCommand.CanExecute(null));
+        Assert.Contains("UN_DeletedDocuments", model.StatusText);
+        Assert.DoesNotContain("Msg_Error", model.StatusText);
+        Assert.Empty(dialogs.Errors);
+    }
+
+    [Fact]
+    public async Task UndoLast_DeletedIdsPartialRestore_ReportsPartialNotFullSuccess()
+    {
+        var survivor = new StudyDocument { Name = "Keep", Subject = "Math", Type = "PDF" };
+        var doomed = new StudyDocument { Name = "Gone", Subject = "Physics", Type = "PDF" };
+        Assert.True(Repo.Add(survivor));
+        Assert.True(Repo.Add(doomed));
+
+        var originals = Repo.GetAll().Select(Clone).ToList();
+        Assert.Equal(2, Db.BulkSoftDelete([survivor.Id, doomed.Id]));
+        Assert.True(Repo.PermanentDeleteDocument(doomed.Id));
+
+        var undo = new UndoService();
+        undo.Push(new UndoEntry
+        {
+            DescriptionKey = "UN_DeletedDocuments",
+            DescriptionArgs = [2],
+            Originals = originals,
+            DeletedIds = [survivor.Id, doomed.Id],
+            CreatedAt = DateTime.Now
+        });
+
+        var dialogs = new RecordingErrorDialogs();
+        var model = CreateModel(undo, dialogs, Repo);
+
+        await model.UndoLastCommand.ExecuteAsync(null);
+
+        Assert.NotNull(Repo.GetById(survivor.Id));
+        Assert.Null(Repo.GetById(doomed.Id));
+        Assert.False(model.UndoLastCommand.CanExecute(null));
+        Assert.Empty(dialogs.Errors);
+        Assert.Contains("BE_Result_Partial", model.StatusText);
+        Assert.DoesNotContain("UN_DeletedDocuments", model.StatusText);
+    }
+
+    [Fact]
+    public async Task UndoLast_DeletedIdsWithoutRecycleBin_ShowsErrorKeepsEntryMutatesNothing()
+    {
+        var doc = new StudyDocument { Name = "Alpha", Subject = "Math", Type = "PDF" };
+        Assert.True(Repo.Add(doc));
+
+        var originals = Repo.GetAll().Select(Clone).ToList();
+        Assert.Equal(1, Db.BulkSoftDelete([doc.Id]));
+
+        var undo = new UndoService();
+        undo.Push(new UndoEntry
+        {
+            DescriptionKey = "UN_DeletedDocuments",
+            Originals = originals,
+            DeletedIds = [doc.Id],
+            CreatedAt = DateTime.Now
+        });
+
+        var dialogs = new RecordingErrorDialogs();
+        var model = CreateModel(undo, dialogs, null);
+
+        await model.UndoLastCommand.ExecuteAsync(null);
+
+        Assert.Single(dialogs.Errors);
+        Assert.Empty(Repo.GetAll());
+        Assert.Single(Repo.GetDeletedDocuments());
+        Assert.True(model.UndoLastCommand.CanExecute(null));
+
+        await model.UndoLastCommand.ExecuteAsync(null);
+        Assert.Equal(2, dialogs.Errors.Count);
+    }
+
+    private sealed class FormatKeyLocalization : ILocalizationService
+    {
+        public string this[string key] => $"{key}:{{0}}";
+        public SupportedLanguage CurrentLanguage => SupportedLanguage.Japanese;
+        public void SetLanguage(SupportedLanguage language) { }
+        public IReadOnlyList<SupportedLanguage> AvailableLanguages { get; } = Enum.GetValues<SupportedLanguage>();
+        public event EventHandler? LanguageChanged { add { } remove { } }
+    }
+
+    private sealed class RecordingErrorDialogs : IDialogService
+    {
+        public List<string> Errors { get; } = [];
+
+        public Task ShowMessageAsync(string title, string message) => Task.CompletedTask;
+        public Task ShowErrorAsync(string title, string message)
+        {
+            Errors.Add(message);
+            return Task.CompletedTask;
+        }
+        public Task<bool> ShowConfirmAsync(string title, string message) => Task.FromResult(true);
+        public Task<bool> ShowConfirmAsync(string title, string message, string confirmText, bool isDanger = false) => Task.FromResult(true);
+        public Task<string?> ShowInputAsync(string title, string label, string defaultValue = "", string watermark = "") => Task.FromResult<string?>(null);
     }
 }
 

--- a/StudyDocumentManager.Tests/UndoExtensionTests.cs
+++ b/StudyDocumentManager.Tests/UndoExtensionTests.cs
@@ -93,6 +93,54 @@ public class UndoApplierRoutingTests
     }
 
     [Fact]
+    public void ApplyLast_MetadataEntry_RemovesAddedCollectionMemberships()
+    {
+        var undo = new UndoService();
+        undo.Push(new UndoEntry
+        {
+            DescriptionKey = "BE_UndoDescription",
+            Originals = [new StudyDocument { Id = 5 }],
+            AddedCollectionMemberships = [new CollectionMembership(42, 5)]
+        });
+
+        var collections = new RecordingCollections();
+        new UndoApplier(undo, new RecordingDocuments(), new RecordingRecycleBin(), collections).ApplyLast();
+
+        Assert.Equal([(42, 5)], collections.RemovedDocs);
+        Assert.False(undo.CanUndo);
+    }
+
+    [Fact]
+    public void ApplyLast_WhenDocumentRestoreFails_KeepsUndoEntry()
+    {
+        var undo = new UndoService();
+        undo.Push(new UndoEntry
+        {
+            DescriptionKey = "BE_UndoDescription",
+            Originals = [new StudyDocument { Id = 5 }]
+        });
+
+        var documents = new RecordingDocuments { UpdateResult = false };
+        var applier = new UndoApplier(undo, documents, new RecordingRecycleBin(), new RecordingCollections());
+
+        Assert.Throws<InvalidOperationException>(applier.ApplyLast);
+        Assert.True(undo.CanUndo);
+    }
+
+    [Fact]
+    public void ApplyLast_WhenRestoreCountIsPartial_KeepsUndoEntry()
+    {
+        var undo = new UndoService();
+        undo.Push(new UndoEntry { DescriptionKey = "UN_DeletedDocuments", DeletedIds = [7, 8] });
+
+        var recycleBin = new RecordingRecycleBin { RestoreCount = 1 };
+        var applier = new UndoApplier(undo, new RecordingDocuments(), recycleBin, new RecordingCollections());
+
+        Assert.Throws<InvalidOperationException>(applier.ApplyLast);
+        Assert.True(undo.CanUndo);
+    }
+
+    [Fact]
     public void ApplyLast_EmptyStack_Throws()
     {
         var applier = new UndoApplier(new UndoService(), new RecordingDocuments(), new RecordingRecycleBin(), new RecordingCollections());
@@ -103,11 +151,12 @@ public class UndoApplierRoutingTests
     private sealed class RecordingRecycleBin : IRecycleBinRepository
     {
         public List<IReadOnlyList<int>> RestoreCalls { get; } = [];
+        public int? RestoreCount { get; init; }
 
         public int RestoreDocuments(IReadOnlyList<int> ids)
         {
             RestoreCalls.Add(ids);
-            return ids.Count;
+            return RestoreCount ?? ids.Count;
         }
 
         public List<StudyDocument> GetDeletedDocuments() => [];
@@ -122,6 +171,7 @@ public class UndoApplierRoutingTests
         public int NextId { get; set; } = 42;
         public List<(string Name, string? Description)> Created { get; } = [];
         public List<(int CollectionId, int DocumentId)> AddedDocs { get; } = [];
+        public List<(int CollectionId, int DocumentId)> RemovedDocs { get; } = [];
 
         public List<(int Id, string Name, string? Description, DateTime CreatedAt, int ItemCount)> GetAll() => [];
 
@@ -141,12 +191,17 @@ public class UndoApplierRoutingTests
             return true;
         }
 
-        public bool RemoveDocument(int collectionId, int documentId) => true;
+        public bool RemoveDocument(int collectionId, int documentId)
+        {
+            RemovedDocs.Add((collectionId, documentId));
+            return true;
+        }
     }
 
     private sealed class RecordingDocuments : IDocumentRepository
     {
         public List<StudyDocument> Updated { get; } = [];
+        public bool UpdateResult { get; init; } = true;
 
         public List<StudyDocument> GetAll() => [];
         public StudyDocument? GetById(int id) => null;
@@ -159,7 +214,7 @@ public class UndoApplierRoutingTests
         public bool Update(StudyDocument document)
         {
             Updated.Add(document);
-            return true;
+            return UpdateResult;
         }
 
         public bool Delete(int id) => true;

--- a/StudyDocumentManager/App.axaml.cs
+++ b/StudyDocumentManager/App.axaml.cs
@@ -102,6 +102,7 @@ public partial class App : Application
         services.AddSingleton<IRecycleBinRepository>(sp => sp.GetRequiredService<DocumentRepository>());
         services.AddSingleton<IBulkOperationRepository>(sp => sp.GetRequiredService<DocumentRepository>());
         services.AddSingleton<IFileIntegrityRepository>(sp => sp.GetRequiredService<DocumentRepository>());
+        services.AddSingleton<IUndoRepository>(sp => sp.GetRequiredService<DocumentRepository>());
         services.AddSingleton<ICategoryRepository, CategoryRepository>();
         services.AddSingleton<ICollectionRepository, CollectionRepository>();
         services.AddSingleton<IPersonalNoteRepository, PersonalNoteRepository>();

--- a/StudyDocumentManager/App.axaml.cs
+++ b/StudyDocumentManager/App.axaml.cs
@@ -108,6 +108,7 @@ public partial class App : Application
         services.AddSingleton<IRelatedDocumentRepository, RelatedDocumentRepository>();
         services.AddSingleton<IRecentFileRepository, RecentFileRepository>();
         services.AddSingleton<IReportRepository, ReportRepository>();
+        services.AddSingleton<ISavedSearchRepository, SavedSearchRepository>();
         services.AddSingleton<ISettingsService, SettingsRepository>();
 
         // Services
@@ -145,6 +146,9 @@ public partial class App : Application
         services.AddSingleton<ILocalizationService>(sp => sp.GetRequiredService<LocalizationService>());
         services.AddSingleton<IUpdateService, Services.UpdateService>();
         services.AddSingleton<IToastService, Services.ToastService>();
+        services.AddSingleton<UndoService>();
+        services.AddSingleton<IUndoService>(sp => sp.GetRequiredService<UndoService>());
+        services.AddSingleton<IUndoApplier, UndoApplier>();
 
         // モデル — メイン
         services.AddSingleton<MainWindowModel>();
@@ -163,6 +167,7 @@ public partial class App : Application
         services.AddTransient<CollectionManagementModel>();
         services.AddTransient<RecycleBinModel>();
         services.AddTransient<FileIntegrityCheckModel>();
+        services.AddTransient<SmartViewsModel>();
 
         // モデル — レポート
         services.AddTransient<ReportModel>();

--- a/StudyDocumentManager/Models/AddEditModel.cs
+++ b/StudyDocumentManager/Models/AddEditModel.cs
@@ -32,9 +32,13 @@ public partial class AddEditModel : ModelBase
     [ObservableProperty] private bool _isEditing;
     [ObservableProperty] private bool _hasNameValidationError;
     [ObservableProperty] private string _nameValidationMessage = string.Empty;
+    [ObservableProperty] private string _selectedStatus = DocumentStatus.Unread;
+    [ObservableProperty] private bool _hasStatusValidationError;
+    [ObservableProperty] private string _statusValidationMessage = string.Empty;
 
     [ObservableProperty] private ObservableCollection<string> _subjects = new();
     [ObservableProperty] private ObservableCollection<string> _types = new();
+    [ObservableProperty] private List<StatusOption> _statusOptions = [];
 
     public AddEditModel(IDocumentRepository repository, ICategoryRepository categoryRepo, IDialogService dialogService, IFileDialogService fileDialogService, INavigationService navigationService, ILocalizationService loc)
     {
@@ -50,6 +54,7 @@ public partial class AddEditModel : ModelBase
         PageTitle = _loc["AddEdit_PageTitleAdd"];
         Subjects = new ObservableCollection<string>(_categoryRepo.GetAllSubjects());
         Types = new ObservableCollection<string>(_categoryRepo.GetAllTypes());
+        BuildStatusOptions();
     }
 
     public void AttachLocalization()
@@ -74,9 +79,26 @@ public partial class AddEditModel : ModelBase
     private void OnLanguageChanged(object? sender, EventArgs e)
     {
         PageTitle = _loc[IsEditing ? "AddEdit_PageTitleEdit" : "AddEdit_PageTitleAdd"];
+        BuildStatusOptions();
         if (HasNameValidationError)
             NameValidationMessage = _loc["AddEdit_NameRequired"];
+        if (HasStatusValidationError)
+            StatusValidationMessage = _loc["DS_Error_InvalidStatus"];
     }
+
+    private void BuildStatusOptions()
+        => StatusOptions = [..DocumentStatus.All.Select(s => new StatusOption(s, GetStatusLabel(s)))];
+
+    private string GetStatusLabel(string status) => status switch
+    {
+        DocumentStatus.Unread => _loc["DS_Kind_Unread"],
+        DocumentStatus.InProgress => _loc["DS_Kind_InProgress"],
+        DocumentStatus.Read => _loc["DS_Kind_Read"],
+        DocumentStatus.NeedsAction => _loc["DS_Kind_NeedsAction"],
+        DocumentStatus.Completed => _loc["DS_Kind_Completed"],
+        DocumentStatus.Archived => _loc["DS_Kind_Archived"],
+        _ => status
+    };
 
     public void LoadDocument(int documentId)
     {
@@ -96,6 +118,7 @@ public partial class AddEditModel : ModelBase
         Tags = doc.Tags;
         IsImportant = doc.IsImportant;
         Deadline = doc.Deadline.HasValue ? new DateTimeOffset(doc.Deadline.Value) : null;
+        SelectedStatus = DocumentStatus.IsValid(doc.Status) ? doc.Status : DocumentStatus.Unread;
     }
 
     partial void OnNameChanged(string value)
@@ -105,6 +128,29 @@ public partial class AddEditModel : ModelBase
             HasNameValidationError = false;
             NameValidationMessage = string.Empty;
         }
+    }
+
+    partial void OnSelectedStatusChanged(string value)
+    {
+        if (DocumentStatus.IsValid(value) && HasStatusValidationError)
+        {
+            HasStatusValidationError = false;
+            StatusValidationMessage = string.Empty;
+        }
+    }
+
+    private bool ValidateStatus()
+    {
+        if (DocumentStatus.IsValid(SelectedStatus))
+        {
+            HasStatusValidationError = false;
+            StatusValidationMessage = string.Empty;
+            return true;
+        }
+
+        HasStatusValidationError = true;
+        StatusValidationMessage = _loc["DS_Error_InvalidStatus"];
+        return false;
     }
 
     private bool ValidateName()
@@ -161,6 +207,11 @@ public partial class AddEditModel : ModelBase
             return;
         }
 
+        if (!ValidateStatus())
+        {
+            return;
+        }
+
         var filePath = FilePath.Trim();
         var doc = new StudyDocument
         {
@@ -173,7 +224,8 @@ public partial class AddEditModel : ModelBase
             Tags = Tags.Trim(),
             IsImportant = IsImportant,
             Deadline = Deadline?.DateTime,
-            FileSize = GetFileSize(filePath)
+            FileSize = GetFileSize(filePath),
+            Status = SelectedStatus
         };
 
         try

--- a/StudyDocumentManager/Models/BulkDeleteModel.cs
+++ b/StudyDocumentManager/Models/BulkDeleteModel.cs
@@ -260,7 +260,9 @@ public partial class BulkDeleteModel : ModelBase
                 {
                     DescriptionKey = "BE_UndoDescription",
                     DescriptionArgs = [outcome.Succeeded],
-                    Originals = originals,
+                    Originals = originals
+                        .Where(original => outcome.Items.Any(item => item.DocumentId == original.Id && item.Success))
+                        .ToList(),
                     AddedCollectionMemberships = addedMemberships,
                     CreatedAt = DateTime.Now
                 });

--- a/StudyDocumentManager/Models/BulkDeleteModel.cs
+++ b/StudyDocumentManager/Models/BulkDeleteModel.cs
@@ -16,6 +16,10 @@ public partial class BulkDeleteModel : ModelBase
     private readonly IDialogService _dialogService;
     private readonly INavigationService _navigationService;
     private readonly ILocalizationService _loc;
+    private readonly ICustomDialogService? _customDialogs;
+    private readonly ICollectionRepository? _collectionRepo;
+    private readonly IUndoService _undo;
+    private readonly IUndoApplier? _undoApplier;
 
     private const string AllFilter = "All";
 
@@ -30,12 +34,40 @@ public partial class BulkDeleteModel : ModelBase
     [ObservableProperty] private List<string> _availableSubjects = new();
     [ObservableProperty] private string? _newSubjectValue;
 
+    [ObservableProperty] private bool _enableSubject;
+    [ObservableProperty] private string _newSubject = "";
+    [ObservableProperty] private bool _enableType;
+    [ObservableProperty] private string? _newType;
+    [ObservableProperty] private bool _enableTags;
+    [ObservableProperty] private string? _newTags;
+    [ObservableProperty] private bool _enableImportant;
+    [ObservableProperty] private bool _newImportant;
+    [ObservableProperty] private bool _enableDeadline;
+    [ObservableProperty] private DateTimeOffset? _newDeadline;
+    [ObservableProperty] private bool _enableStatus;
+    [ObservableProperty] private string _newStatus = DocumentStatus.Unread;
+    [ObservableProperty] private List<StatusOption> _statusOptions = [];
+    [ObservableProperty] private StatusOption? _selectedStatusOption;
+    [ObservableProperty] private bool _enableCollectionAdd;
+    [ObservableProperty] private int? _selectedCollectionId;
+    [ObservableProperty] private List<BulkCollectionOption> _collectionOptions = [];
+    [ObservableProperty] private BulkCollectionOption? _selectedCollectionOption;
+
     [ObservableProperty] private string _statusText = "";
     public int SelectedCount => Documents.Count(d => d.IsSelected);
     public string SelectedCountText => string.Format(_loc["Bulk_SelectedCount"], SelectedCount);
     public bool HasSelection => SelectedCount > 0;
+    public bool HasAnyEnabledChange =>
+        (EnableSubject && !string.IsNullOrWhiteSpace(NewSubject))
+        || (EnableType && !string.IsNullOrWhiteSpace(NewType))
+        || (EnableTags && !string.IsNullOrWhiteSpace(NewTags))
+        || EnableImportant
+        || (EnableDeadline && NewDeadline.HasValue)
+        || EnableStatus
+        || (EnableCollectionAdd && SelectedCollectionId.HasValue);
 
-    public BulkDeleteModel(IDocumentRepository repository, IBulkOperationRepository bulkRepo, ICategoryRepository categoryRepo, IDialogService dialogService, INavigationService navigationService, ILocalizationService loc)
+    public BulkDeleteModel(IDocumentRepository repository, IBulkOperationRepository bulkRepo, ICategoryRepository categoryRepo, IDialogService dialogService, INavigationService navigationService, ILocalizationService loc,
+        ICustomDialogService? customDialogService = null, ICollectionRepository? collectionRepo = null, IUndoService? undoService = null, IUndoApplier? undoApplier = null)
     {
         _repository = repository;
         _bulkRepo = bulkRepo;
@@ -43,6 +75,10 @@ public partial class BulkDeleteModel : ModelBase
         _dialogService = dialogService;
         _navigationService = navigationService;
         _loc = loc;
+        _customDialogs = customDialogService;
+        _collectionRepo = collectionRepo;
+        _undo = undoService ?? new UndoService();
+        _undoApplier = undoApplier;
     }
 
     /// <summary>
@@ -51,6 +87,7 @@ public partial class BulkDeleteModel : ModelBase
     public void Initialize()
     {
         LoadFilterData();
+        LoadBulkEditOptions();
         LoadData();
     }
 
@@ -71,6 +108,19 @@ public partial class BulkDeleteModel : ModelBase
         SelectedType = _loc["Filter_AllItems"];
 
         AvailableSubjects = new List<string>(subjects);
+    }
+
+    private void LoadBulkEditOptions()
+    {
+        StatusOptions = [.. DocumentStatus.All.Select(s => new StatusOption(s, GetStatusLabel(s)))];
+        SelectedStatusOption = StatusOptions.FirstOrDefault(o => o.Value == NewStatus) ?? StatusOptions.FirstOrDefault();
+
+        var options = new List<BulkCollectionOption> { new() { Id = null, Label = _loc["BE_CollectionNone"] } };
+        if (_collectionRepo != null)
+            foreach (var collection in _collectionRepo.GetAll())
+                options.Add(new BulkCollectionOption { Id = collection.Id, Label = collection.Name });
+        CollectionOptions = options;
+        SelectedCollectionOption = options[0];
     }
 
     private void LoadData(HashSet<int>? selectedIds = null)
@@ -113,13 +163,217 @@ public partial class BulkDeleteModel : ModelBase
         OnPropertyChanged(nameof(SelectedCount));
         OnPropertyChanged(nameof(SelectedCountText));
         OnPropertyChanged(nameof(HasSelection));
+        ApplyBulkEditCommand.NotifyCanExecuteChanged();
     }
+
+    private void NotifyBulkEditStateChanged()
+    {
+        OnPropertyChanged(nameof(HasAnyEnabledChange));
+        ApplyBulkEditCommand.NotifyCanExecuteChanged();
+    }
+
+    partial void OnSelectedStatusOptionChanged(StatusOption? value)
+    {
+        if (value != null)
+            NewStatus = value.Value;
+        NotifyBulkEditStateChanged();
+    }
+
+    partial void OnSelectedCollectionOptionChanged(BulkCollectionOption? value)
+    {
+        SelectedCollectionId = value?.Id;
+    }
+
+    partial void OnEnableSubjectChanged(bool value) => NotifyBulkEditStateChanged();
+    partial void OnNewSubjectChanged(string value) => NotifyBulkEditStateChanged();
+    partial void OnEnableTypeChanged(bool value) => NotifyBulkEditStateChanged();
+    partial void OnNewTypeChanged(string? value) => NotifyBulkEditStateChanged();
+    partial void OnEnableTagsChanged(bool value) => NotifyBulkEditStateChanged();
+    partial void OnNewTagsChanged(string? value) => NotifyBulkEditStateChanged();
+    partial void OnEnableImportantChanged(bool value) => NotifyBulkEditStateChanged();
+    partial void OnNewImportantChanged(bool value) => NotifyBulkEditStateChanged();
+    partial void OnEnableDeadlineChanged(bool value) => NotifyBulkEditStateChanged();
+    partial void OnNewDeadlineChanged(DateTimeOffset? value) => NotifyBulkEditStateChanged();
+    partial void OnEnableStatusChanged(bool value) => NotifyBulkEditStateChanged();
+    partial void OnNewStatusChanged(string value) => NotifyBulkEditStateChanged();
+    partial void OnEnableCollectionAddChanged(bool value) => NotifyBulkEditStateChanged();
+    partial void OnSelectedCollectionIdChanged(int? value) => NotifyBulkEditStateChanged();
 
     [RelayCommand]
     private void Search() => LoadData();
 
     partial void OnSelectedSubjectChanged(string value) => LoadData();
     partial void OnSelectedTypeChanged(string value) => LoadData();
+
+    private bool CanApplyBulkEdit() => HasSelection && HasAnyEnabledChange;
+
+    [RelayCommand(CanExecute = nameof(CanApplyBulkEdit))]
+    private async Task ApplyBulkEditAsync()
+    {
+        var selected = Documents.Where(d => d.IsSelected).ToList();
+        if (selected.Count == 0)
+        {
+            await _dialogService.ShowErrorAsync(_loc["Dialog_Error"], _loc["BE_NoSelectionHint"]);
+            return;
+        }
+
+        var changes = BuildChanges();
+        if (!changes.HasAnyChange)
+        {
+            await _dialogService.ShowErrorAsync(_loc["Dialog_Error"], _loc["BE_NoFieldsEnabledHint"]);
+            return;
+        }
+
+        try
+        {
+            var ids = selected.Select(s => s.Document.Id).ToList();
+            var originals = new List<StudyDocument>();
+            foreach (var id in ids)
+            {
+                var snapshot = _repository.GetById(id);
+                if (snapshot != null)
+                    originals.Add(snapshot);
+            }
+
+            if (originals.Count == 0)
+                return;
+
+            var confirmed = await ConfirmPreviewAsync(originals.Count, BuildPreviewPairs(changes));
+            if (!confirmed) return;
+
+            var outcome = _bulkRepo.BulkEditMetadata([.. originals.Select(o => o.Id)], changes);
+
+            if (outcome.Succeeded > 0)
+            {
+                _undo.Push(new UndoEntry
+                {
+                    DescriptionKey = "BE_UndoDescription",
+                    DescriptionArgs = [outcome.Succeeded],
+                    Originals = originals,
+                    CreatedAt = DateTime.Now
+                });
+                UndoLastCommand.NotifyCanExecuteChanged();
+            }
+
+            if (outcome.Succeeded == outcome.Requested)
+            {
+                await _dialogService.ShowMessageAsync(_loc["Dialog_Complete"],
+                    string.Format(_loc["BE_Result_AllSuccess"], outcome.Succeeded, outcome.Requested));
+            }
+            else
+            {
+                await _dialogService.ShowErrorAsync(_loc["Dialog_Error"], BuildPartialReport(outcome));
+            }
+
+            LoadData([.. ids]);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (Exception)
+        {
+            await _dialogService.ShowErrorAsync(_loc["Dialog_Error"], _loc["Msg_Error"]);
+        }
+    }
+
+    private bool CanUndoLast() => _undo.CanUndo;
+
+    [RelayCommand(CanExecute = nameof(CanUndoLast))]
+    private async Task UndoLastAsync()
+    {
+        var entry = _undo.Peek();
+        if (entry == null) return;
+        UndoLastCommand.NotifyCanExecuteChanged();
+
+        try
+        {
+            if (_undoApplier != null)
+            {
+                _undoApplier.ApplyLast();
+                LoadData();
+            }
+            else
+            {
+                _ = _undo.Pop() ?? throw new InvalidOperationException("Nothing to undo.");
+                foreach (var original in entry.Originals)
+                    _repository.Update(original);
+                LoadData([.. entry.Originals.Select(o => o.Id)]);
+            }
+
+            var detail = string.Format(_loc[entry.DescriptionKey], entry.DescriptionArgs ?? []);
+            StatusText = string.Format(_loc["UN_Applied"], detail);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (Exception)
+        {
+            await _dialogService.ShowErrorAsync(_loc["Dialog_Error"], _loc["Msg_Error"]);
+        }
+    }
+
+    private BulkEditChanges BuildChanges() => new()
+    {
+        Subject = EnableSubject && !string.IsNullOrWhiteSpace(NewSubject) ? NewSubject.Trim() : null,
+        Type = EnableType && !string.IsNullOrWhiteSpace(NewType) ? NewType!.Trim() : null,
+        Tags = EnableTags && !string.IsNullOrWhiteSpace(NewTags) ? NewTags!.Trim() : null,
+        IsImportant = EnableImportant ? NewImportant : null,
+        Deadline = EnableDeadline ? NewDeadline?.DateTime : null,
+        Status = EnableStatus && !string.IsNullOrWhiteSpace(NewStatus) ? NewStatus : null,
+        AddToCollectionId = EnableCollectionAdd && SelectedCollectionId.HasValue ? SelectedCollectionId : null
+    };
+
+    private List<(string FieldLabel, string NewValue)> BuildPreviewPairs(BulkEditChanges changes)
+    {
+        var pairs = new List<(string FieldLabel, string NewValue)>();
+        if (changes.Subject != null) pairs.Add((_loc["BE_Field_Subject"], changes.Subject));
+        if (changes.Type != null) pairs.Add((_loc["BE_Field_Type"], changes.Type));
+        if (changes.Tags != null) pairs.Add((_loc["BE_Field_Tags"], changes.Tags));
+        if (changes.IsImportant.HasValue)
+            pairs.Add((_loc["BE_Field_Important"], changes.IsImportant.Value ? _loc["Dashboard_CsvYes"] : _loc["Dashboard_CsvNo"]));
+        if (changes.Deadline.HasValue) pairs.Add((_loc["BE_Field_Deadline"], changes.Deadline.Value.ToString("yyyy/MM/dd")));
+        if (changes.Status != null) pairs.Add((_loc["BE_Field_Status"], GetStatusLabel(changes.Status)));
+        if (changes.AddToCollectionId.HasValue)
+            pairs.Add((_loc["BE_Field_CollectionAdd"], ResolveCollectionLabel(changes.AddToCollectionId.Value)));
+        return pairs;
+    }
+
+    private async Task<bool> ConfirmPreviewAsync(int affectedCount, List<(string FieldLabel, string NewValue)> changes)
+    {
+        if (_customDialogs != null)
+            return await _customDialogs.ShowBulkEditPreviewAsync(affectedCount, changes);
+
+        var summary = string.Join(Environment.NewLine, changes.Select(c => $"{c.FieldLabel}: {c.NewValue}"));
+        return await _dialogService.ShowConfirmAsync(_loc["BE_PreviewTitle"],
+            string.Format(_loc["BE_PreviewAffected"], affectedCount) + Environment.NewLine + summary,
+            _loc["BE_ConfirmApply"], isDanger: true);
+    }
+
+    private string BuildPartialReport(BulkEditOutcome outcome)
+    {
+        var failedIds = outcome.FailedIds;
+        var failedNames = failedIds
+            .Select(id => _repository.GetById(id)?.Name ?? $"#{id}")
+            .ToList();
+
+        return string.Format(_loc["BE_Result_Partial"], outcome.Succeeded, outcome.Requested)
+            + Environment.NewLine + _loc["BE_FailedItemsHeader"]
+            + Environment.NewLine + string.Join(Environment.NewLine, failedNames);
+    }
+
+    private string ResolveCollectionLabel(int collectionId)
+        => CollectionOptions.FirstOrDefault(o => o.Id == collectionId)?.Label ?? $"#{collectionId}";
+
+    private string GetStatusLabel(string status) => status switch
+    {
+        DocumentStatus.Unread => _loc["DS_Kind_Unread"],
+        DocumentStatus.InProgress => _loc["DS_Kind_InProgress"],
+        DocumentStatus.Read => _loc["DS_Kind_Read"],
+        DocumentStatus.NeedsAction => _loc["DS_Kind_NeedsAction"],
+        DocumentStatus.Completed => _loc["DS_Kind_Completed"],
+        DocumentStatus.Archived => _loc["DS_Kind_Archived"],
+        _ => status
+    };
 
     [RelayCommand]
     private async Task DeleteSelectedAsync()
@@ -138,7 +392,16 @@ public partial class BulkDeleteModel : ModelBase
                 _loc["Action_Delete"], isDanger: true);
             if (!confirmed) return;
 
-            var deleted = _bulkRepo.BulkSoftDelete(selected.Select(s => s.Document.Id).ToList());
+            var deletedIds = selected.Select(s => s.Document.Id).ToList();
+            var originals = new List<StudyDocument>();
+            foreach (var id in deletedIds)
+            {
+                var snapshot = _repository.GetById(id);
+                if (snapshot != null)
+                    originals.Add(snapshot);
+            }
+
+            var deleted = _bulkRepo.BulkSoftDelete(deletedIds);
             if (deleted != selected.Count)
             {
                 LoadData(selected.Select(item => item.Document.Id).ToHashSet());
@@ -146,6 +409,16 @@ public partial class BulkDeleteModel : ModelBase
                     string.Format(_loc["Operation_Partial"], deleted, selected.Count));
                 return;
             }
+
+            _undo.Push(new UndoEntry
+            {
+                DescriptionKey = "UN_DeletedDocuments",
+                DescriptionArgs = [deleted],
+                Originals = originals,
+                DeletedIds = deletedIds,
+                CreatedAt = DateTime.Now
+            });
+            UndoLastCommand.NotifyCanExecuteChanged();
 
             await _dialogService.ShowMessageAsync(_loc["Dialog_Complete"],
                 string.Format(_loc["Bulk_DeleteDone"], deleted));
@@ -262,4 +535,10 @@ public partial class SelectableDocument : ObservableObject
 {
     [ObservableProperty] private bool _isSelected;
     [ObservableProperty] private StudyDocument _document = new();
+}
+
+public sealed class BulkCollectionOption
+{
+    public int? Id { get; init; }
+    public string Label { get; init; } = string.Empty;
 }

--- a/StudyDocumentManager/Models/BulkDeleteModel.cs
+++ b/StudyDocumentManager/Models/BulkDeleteModel.cs
@@ -238,6 +238,10 @@ public partial class BulkDeleteModel : ModelBase
             if (originals.Count == 0)
                 return;
 
+            HashSet<int> existingCollectionMembers = changes.AddToCollectionId is int collectionId && _collectionRepo != null
+                ? _collectionRepo.GetDocuments(collectionId).Select(document => document.Id).ToHashSet()
+                : [];
+
             var confirmed = await ConfirmPreviewAsync(originals.Count, BuildPreviewPairs(changes));
             if (!confirmed) return;
 
@@ -245,11 +249,19 @@ public partial class BulkDeleteModel : ModelBase
 
             if (outcome.Succeeded > 0)
             {
+                var addedMemberships = changes.AddToCollectionId is int addedCollectionId
+                    ? outcome.Items
+                        .Where(item => item.Success && !existingCollectionMembers.Contains(item.DocumentId))
+                        .Select(item => new CollectionMembership(addedCollectionId, item.DocumentId))
+                        .ToList()
+                    : [];
+
                 _undo.Push(new UndoEntry
                 {
                     DescriptionKey = "BE_UndoDescription",
                     DescriptionArgs = [outcome.Succeeded],
                     Originals = originals,
+                    AddedCollectionMemberships = addedMemberships,
                     CreatedAt = DateTime.Now
                 });
                 UndoLastCommand.NotifyCanExecuteChanged();

--- a/StudyDocumentManager/Models/BulkDeleteModel.cs
+++ b/StudyDocumentManager/Models/BulkDeleteModel.cs
@@ -340,6 +340,11 @@ public partial class BulkDeleteModel : ModelBase
         catch (OperationCanceledException)
         {
         }
+        catch (UndoPartialRestoreException ex)
+        {
+            LoadData();
+            StatusText = string.Format(_loc["UN_Applied"], string.Format(_loc["BE_Result_Partial"], ex.RestoredCount, ex.RequestedCount));
+        }
         catch (Exception)
         {
             await _dialogService.ShowErrorAsync(_loc["Dialog_Error"], _loc["Msg_Error"]);

--- a/StudyDocumentManager/Models/BulkDeleteModel.cs
+++ b/StudyDocumentManager/Models/BulkDeleteModel.cs
@@ -20,6 +20,7 @@ public partial class BulkDeleteModel : ModelBase
     private readonly ICollectionRepository? _collectionRepo;
     private readonly IUndoService _undo;
     private readonly IUndoApplier? _undoApplier;
+    private readonly IRecycleBinRepository? _recycleBinRepo;
 
     private const string AllFilter = "All";
 
@@ -67,7 +68,7 @@ public partial class BulkDeleteModel : ModelBase
         || (EnableCollectionAdd && SelectedCollectionId.HasValue);
 
     public BulkDeleteModel(IDocumentRepository repository, IBulkOperationRepository bulkRepo, ICategoryRepository categoryRepo, IDialogService dialogService, INavigationService navigationService, ILocalizationService loc,
-        ICustomDialogService? customDialogService = null, ICollectionRepository? collectionRepo = null, IUndoService? undoService = null, IUndoApplier? undoApplier = null)
+        ICustomDialogService? customDialogService = null, ICollectionRepository? collectionRepo = null, IUndoService? undoService = null, IUndoApplier? undoApplier = null, IRecycleBinRepository? recycleBinRepository = null)
     {
         _repository = repository;
         _bulkRepo = bulkRepo;
@@ -79,6 +80,7 @@ public partial class BulkDeleteModel : ModelBase
         _collectionRepo = collectionRepo;
         _undo = undoService ?? new UndoService();
         _undoApplier = undoApplier;
+        _recycleBinRepo = recycleBinRepository;
     }
 
     /// <summary>
@@ -301,20 +303,34 @@ public partial class BulkDeleteModel : ModelBase
 
         try
         {
+            string detail;
             if (_undoApplier != null)
             {
                 _undoApplier.ApplyLast();
                 LoadData();
+                detail = string.Format(_loc[entry.DescriptionKey], entry.DescriptionArgs ?? []);
+            }
+            else if (entry.DeletedIds.Count > 0)
+            {
+                if (_recycleBinRepo == null)
+                    throw new InvalidOperationException("Recycle bin repository is required to undo deleted documents.");
+
+                var restored = _recycleBinRepo.RestoreDocuments(entry.DeletedIds);
+                LoadData();
+                _undo.Pop();
+                detail = restored == entry.DeletedIds.Count
+                    ? string.Format(_loc[entry.DescriptionKey], entry.DescriptionArgs ?? [])
+                    : string.Format(_loc["BE_Result_Partial"], restored, entry.DeletedIds.Count);
             }
             else
             {
-                _ = _undo.Pop() ?? throw new InvalidOperationException("Nothing to undo.");
                 foreach (var original in entry.Originals)
                     _repository.Update(original);
                 LoadData([.. entry.Originals.Select(o => o.Id)]);
+                _undo.Pop();
+                detail = string.Format(_loc[entry.DescriptionKey], entry.DescriptionArgs ?? []);
             }
 
-            var detail = string.Format(_loc[entry.DescriptionKey], entry.DescriptionArgs ?? []);
             StatusText = string.Format(_loc["UN_Applied"], detail);
         }
         catch (OperationCanceledException)

--- a/StudyDocumentManager/Models/BulkDeleteModel.cs
+++ b/StudyDocumentManager/Models/BulkDeleteModel.cs
@@ -326,6 +326,10 @@ public partial class BulkDeleteModel : ModelBase
             {
                 foreach (var original in entry.Originals)
                     _repository.Update(original);
+
+                foreach (var membership in entry.AddedCollectionMemberships)
+                    _ = _collectionRepo?.RemoveDocument(membership.CollectionId, membership.DocumentId);
+
                 LoadData([.. entry.Originals.Select(o => o.Id)]);
                 _undo.Pop();
                 detail = string.Format(_loc[entry.DescriptionKey], entry.DescriptionArgs ?? []);

--- a/StudyDocumentManager/Models/CategoryManagementModel.cs
+++ b/StudyDocumentManager/Models/CategoryManagementModel.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using StudyDocumentManager.Core.Entities;
 using StudyDocumentManager.Core.Interfaces;
 
 using StudyDocumentManager.Services;
@@ -14,6 +15,8 @@ public partial class CategoryManagementModel : ModelBase
     private readonly ICategoryRepository _categoryRepo;
     private readonly IDialogService _dialogService;
     private readonly ILocalizationService _loc;
+    private readonly ICustomDialogService? _customDialogs;
+    private readonly IUndoService? _undo;
 
     [ObservableProperty] private ObservableCollection<CategoryItem> _subjects = new();
     [ObservableProperty] private ObservableCollection<CategoryItem> _types = new();
@@ -29,12 +32,15 @@ public partial class CategoryManagementModel : ModelBase
 
     public string StatusText => string.Format(_loc["Status_CategorySummary"], TotalDocumentCount, Subjects.Count, Types.Count);
 
-    public CategoryManagementModel(IDocumentRepository repository, ICategoryRepository categoryRepo, IDialogService dialogService, ILocalizationService loc)
+    public CategoryManagementModel(IDocumentRepository repository, ICategoryRepository categoryRepo, IDialogService dialogService, ILocalizationService loc,
+        ICustomDialogService? customDialogService = null, IUndoService? undoService = null)
     {
         _repository = repository;
         _categoryRepo = categoryRepo;
         _dialogService = dialogService;
         _loc = loc;
+        _customDialogs = customDialogService;
+        _undo = undoService;
         LoadData();
     }
 
@@ -63,12 +69,14 @@ public partial class CategoryManagementModel : ModelBase
 
         try
         {
+            var originals = CaptureOriginalsBySubject(subject.Name);
             if (!_categoryRepo.UpdateSubjectName(subject.Name, newName.Trim()))
             {
                 await _dialogService.ShowErrorAsync(_loc["Dialog_Error"], _loc["Msg_Error"]);
                 return;
             }
 
+            PushRenameUndo(originals, subject.Name, newName.Trim());
             LoadData();
             await _dialogService.ShowMessageAsync(_loc["Dialog_Success"],
                 string.Format(_loc["Category_RenameSubjectDone"], newName.Trim()));
@@ -90,12 +98,14 @@ public partial class CategoryManagementModel : ModelBase
 
         try
         {
+            var originals = CaptureOriginalsByType(type.Name);
             if (!_categoryRepo.UpdateTypeName(type.Name, newName.Trim()))
             {
                 await _dialogService.ShowErrorAsync(_loc["Dialog_Error"], _loc["Msg_Error"]);
                 return;
             }
 
+            PushRenameUndo(originals, type.Name, newName.Trim());
             LoadData();
             await _dialogService.ShowMessageAsync(_loc["Dialog_Success"],
                 string.Format(_loc["Category_RenameTypeDone"], newName.Trim()));
@@ -116,18 +126,29 @@ public partial class CategoryManagementModel : ModelBase
             targets = [SelectedSubject];
         }
 
-        int totalDocs = targets.Sum(t => t.Count);
-        string namesStr = targets.Count == 1
-            ? $"'{targets[0].Name}'"
-            : string.Format(_loc["Category_SelectedCount"], targets.Count);
+        var allDocs = _repository.GetAll();
+        var affectedDocs = allDocs.Where(d => targets.Any(t => t.Name == d.Subject)).ToList();
 
-        string confirmMsg = totalDocs == 0
-            ? string.Format(_loc["Category_DeleteConfirmMsg"], namesStr)
-            : string.Format(_loc["Category_DeleteWithDocsMsg"], namesStr, totalDocs);
-
-        bool confirm = await _dialogService.ShowConfirmAsync(_loc["Category_ConfirmDeleteSubject"], confirmMsg,
-            _loc["Action_Delete"], isDanger: true);
-        if (!confirm) return;
+        bool confirmed;
+        if (_customDialogs != null)
+        {
+            confirmed = await _customDialogs.ShowAffectedItemsPreviewAsync(
+                string.Format(_loc["PV_CascadeTitle"], BuildTargetNames(targets)),
+                affectedDocs.Count,
+                affectedDocs.Select(d => d.Name).ToList(),
+                _loc["PV_RecycleBinNote"]);
+        }
+        else
+        {
+            int totalDocs = targets.Sum(t => t.Count);
+            string namesStr = BuildTargetNames(targets);
+            string confirmMsg = totalDocs == 0
+                ? string.Format(_loc["Category_DeleteConfirmMsg"], namesStr)
+                : string.Format(_loc["Category_DeleteWithDocsMsg"], namesStr, totalDocs);
+            confirmed = await _dialogService.ShowConfirmAsync(_loc["Category_ConfirmDeleteSubject"], confirmMsg,
+                _loc["Action_Delete"], isDanger: true);
+        }
+        if (!confirmed) return;
 
         try
         {
@@ -139,6 +160,8 @@ public partial class CategoryManagementModel : ModelBase
                     return;
                 }
             }
+
+            PushCascadeUndo(affectedDocs);
 
             LoadData();
             SelectedSubjects = new List<CategoryItem>();
@@ -164,18 +187,29 @@ public partial class CategoryManagementModel : ModelBase
             targets = [SelectedType];
         }
 
-        int totalDocs = targets.Sum(t => t.Count);
-        string namesStr = targets.Count == 1
-            ? $"'{targets[0].Name}'"
-            : string.Format(_loc["Category_SelectedCount"], targets.Count);
+        var allDocs = _repository.GetAll();
+        var affectedDocs = allDocs.Where(d => targets.Any(t => t.Name == d.Type)).ToList();
 
-        string confirmMsg = totalDocs == 0
-            ? string.Format(_loc["Category_DeleteConfirmMsg"], namesStr)
-            : string.Format(_loc["Category_DeleteWithDocsMsg"], namesStr, totalDocs);
-
-        bool confirm = await _dialogService.ShowConfirmAsync(_loc["Category_ConfirmDeleteType"], confirmMsg,
-            _loc["Action_Delete"], isDanger: true);
-        if (!confirm) return;
+        bool confirmed;
+        if (_customDialogs != null)
+        {
+            confirmed = await _customDialogs.ShowAffectedItemsPreviewAsync(
+                string.Format(_loc["PV_CascadeTitle"], BuildTargetNames(targets)),
+                affectedDocs.Count,
+                affectedDocs.Select(d => d.Name).ToList(),
+                _loc["PV_RecycleBinNote"]);
+        }
+        else
+        {
+            int totalDocs = targets.Sum(t => t.Count);
+            string namesStr = BuildTargetNames(targets);
+            string confirmMsg = totalDocs == 0
+                ? string.Format(_loc["Category_DeleteConfirmMsg"], namesStr)
+                : string.Format(_loc["Category_DeleteWithDocsMsg"], namesStr, totalDocs);
+            confirmed = await _dialogService.ShowConfirmAsync(_loc["Category_ConfirmDeleteType"], confirmMsg,
+                _loc["Action_Delete"], isDanger: true);
+        }
+        if (!confirmed) return;
 
         try
         {
@@ -187,6 +221,8 @@ public partial class CategoryManagementModel : ModelBase
                     return;
                 }
             }
+
+            PushCascadeUndo(affectedDocs);
 
             LoadData();
             SelectedTypes = new List<CategoryItem>();
@@ -270,6 +306,41 @@ public partial class CategoryManagementModel : ModelBase
     private void Refresh()
     {
         LoadData();
+    }
+
+    private string BuildTargetNames(List<CategoryItem> targets)
+        => targets.Count == 1
+            ? $"'{targets[0].Name}'"
+            : string.Format(_loc["Category_SelectedCount"], targets.Count);
+
+    private List<StudyDocument> CaptureOriginalsBySubject(string subject)
+        => _repository.GetAll().Where(d => d.Subject == subject).ToList();
+
+    private List<StudyDocument> CaptureOriginalsByType(string type)
+        => _repository.GetAll().Where(d => d.Type == type).ToList();
+
+    private void PushRenameUndo(List<StudyDocument> originals, string oldName, string newName)
+    {
+        if (originals.Count == 0) return;
+        _undo?.Push(new UndoEntry
+        {
+            DescriptionKey = "UN_Renamed",
+            DescriptionArgs = [oldName, newName],
+            Originals = originals,
+            CreatedAt = DateTime.Now
+        });
+    }
+
+    private void PushCascadeUndo(List<StudyDocument> affectedDocs)
+    {
+        if (affectedDocs.Count == 0) return;
+        _undo?.Push(new UndoEntry
+        {
+            DescriptionKey = "UN_DeletedDocuments",
+            DescriptionArgs = [affectedDocs.Count],
+            DeletedIds = [.. affectedDocs.Select(d => d.Id)],
+            CreatedAt = DateTime.Now
+        });
     }
 }
 

--- a/StudyDocumentManager/Models/CollectionManagementModel.cs
+++ b/StudyDocumentManager/Models/CollectionManagementModel.cs
@@ -15,6 +15,7 @@ public partial class CollectionManagementModel : ModelBase
     private readonly IDialogService _dialogService;
     private readonly ICustomDialogService _customDialogService;
     private readonly ILocalizationService _loc;
+    private readonly IUndoService? _undo;
 
     [ObservableProperty] private ObservableCollection<CollectionItem> _collections = [];
     [ObservableProperty] private CollectionItem? _selectedCollection;
@@ -23,13 +24,14 @@ public partial class CollectionManagementModel : ModelBase
     [ObservableProperty] private ObservableCollection<StudyDocument> _allDocuments = [];
     [ObservableProperty] private IList _selectedDocumentsInCollection = new List<StudyDocument>();
 
-    public CollectionManagementModel(IDocumentRepository repository, ICollectionRepository collectionRepo, IDialogService dialogService, ICustomDialogService customDialogService, ILocalizationService loc)
+    public CollectionManagementModel(IDocumentRepository repository, ICollectionRepository collectionRepo, IDialogService dialogService, ICustomDialogService customDialogService, ILocalizationService loc, IUndoService? undoService = null)
     {
         _repository = repository;
         _collectionRepo = collectionRepo;
         _dialogService = dialogService;
         _customDialogService = customDialogService;
         _loc = loc;
+        _undo = undoService;
         LoadCollections();
     }
 
@@ -129,9 +131,22 @@ public partial class CollectionManagementModel : ModelBase
         if (SelectedCollection == null) return;
 
         var collectionId = SelectedCollection.Id;
-        var confirmed = await _dialogService.ShowConfirmAsync(_loc["Dialog_Confirm"],
-            string.Format(_loc["Collection_ConfirmDelete"], SelectedCollection.Name),
-            _loc["Action_Delete"], isDanger: true);
+        var collectionName = SelectedCollection.Name;
+        var collectionDescription = SelectedCollection.Description;
+
+        List<StudyDocument> memberDocuments;
+        try
+        {
+            memberDocuments = _collectionRepo.GetDocuments(collectionId);
+        }
+        catch (Exception ex)
+        {
+            await _dialogService.ShowErrorAsync(_loc["Dialog_Error"],
+                string.Format(_loc["Collection_LoadError"], ex.Message));
+            return;
+        }
+
+        var confirmed = await ConfirmDeletePreviewAsync(collectionName, memberDocuments);
         if (!confirmed) return;
 
         try
@@ -141,6 +156,14 @@ public partial class CollectionManagementModel : ModelBase
                 await _dialogService.ShowErrorAsync(_loc["Dialog_Error"], _loc["Msg_Error"]);
                 return;
             }
+
+            _undo?.Push(new UndoEntry
+            {
+                DescriptionKey = "UN_CollectionRestorable",
+                DescriptionArgs = [collectionName],
+                Collection = new CollectionSnapshot(collectionName, collectionDescription, [.. memberDocuments.Select(d => d.Id)]),
+                CreatedAt = DateTime.Now
+            });
 
             SelectedCollection = null;
             LoadCollections();
@@ -283,6 +306,24 @@ public partial class CollectionManagementModel : ModelBase
 
     [RelayCommand]
     private void Refresh() => LoadCollections();
+
+    private async Task<bool> ConfirmDeletePreviewAsync(string collectionName, List<StudyDocument> memberDocuments)
+    {
+        try
+        {
+            return await _customDialogService.ShowAffectedItemsPreviewAsync(
+                _loc["PV_DeleteCollection"],
+                memberDocuments.Count,
+                memberDocuments.Select(d => d.Name).ToList(),
+                _loc["PV_MembershipNote"]);
+        }
+        catch (NotSupportedException)
+        {
+            return await _dialogService.ShowConfirmAsync(_loc["Dialog_Confirm"],
+                string.Format(_loc["Collection_ConfirmDelete"], collectionName),
+                _loc["Action_Delete"], isDanger: true);
+        }
+    }
 }
 
 public class CollectionItem

--- a/StudyDocumentManager/Models/DashboardModel.cs
+++ b/StudyDocumentManager/Models/DashboardModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Globalization;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using StudyDocumentManager.Core.Entities;
@@ -14,6 +15,7 @@ public partial class DashboardModel : ModelBase
 {
     private const string FILTER_ALL_SUBJECTS_KEY = "Filter_AllSubjects";
     private const string FILTER_ALL_TYPES_KEY = "Filter_AllTypes";
+    public const string FILTER_ALL_STATUS_KEY = "Filter_AllStatuses";
 
     private readonly IDocumentRepository _repository;
     private readonly IRecycleBinRepository _recycleBinRepo;
@@ -77,6 +79,10 @@ public partial class DashboardModel : ModelBase
     [ObservableProperty] private bool _isEmptyState;
     [ObservableProperty] private bool _hasLoadError;
     [ObservableProperty] private string _stateMessage = string.Empty;
+    [ObservableProperty] private string _lastBackupDisplay = string.Empty;
+    [ObservableProperty] private bool _isBackupStale;
+    [ObservableProperty] private string _lastBackupWarning = string.Empty;
+    [ObservableProperty] private string _backupDirectoryInfo = string.Empty;
 
     // ——— Search & Filter ——— 
     [ObservableProperty] private string _searchKeyword = string.Empty;
@@ -84,6 +90,8 @@ public partial class DashboardModel : ModelBase
     [ObservableProperty] private List<string> _types = new();
     [ObservableProperty] private string _selectedSubject = FILTER_ALL_SUBJECTS_KEY;
     [ObservableProperty] private string _selectedType = FILTER_ALL_TYPES_KEY;
+    [ObservableProperty] private string _selectedStatus = FILTER_ALL_STATUS_KEY;
+    [ObservableProperty] private List<StatusOption> _statusOptions = [];
 
     // ——— Advanced Filter ——— 
     [ObservableProperty] private bool _isAdvancedFilterVisible;
@@ -103,6 +111,7 @@ public partial class DashboardModel : ModelBase
             if (IsDateFilterEnabled && (FilterFromDate.HasValue || FilterToDate.HasValue)) count++;
             if (IsSizeFilterEnabled) count++;
             if (IsImportantOnly) count++;
+            if (SelectedStatus != FILTER_ALL_STATUS_KEY) count++;
             return count;
         }
     }
@@ -155,11 +164,13 @@ public partial class DashboardModel : ModelBase
         _exportService = exportService;
         _backupService = backupService;
         _loc = localizationService;
+        BuildStatusOptions();
         _statusText = _loc[_statusKey];
         _loc.LanguageChanged += (_, _) =>
         {
             Subjects = [FILTER_ALL_SUBJECTS_KEY, .._availableSubjects];
             Types = [FILTER_ALL_TYPES_KEY, .._availableTypes];
+            BuildStatusOptions();
 
             if (_allDocuments.Count > 0 || Documents.Count > 0 || IsEmptyState || HasLoadError)
                 BuildCategoryTree(_allDocuments, _availableSubjects, _availableTypes);
@@ -214,6 +225,7 @@ public partial class DashboardModel : ModelBase
             Types = [FILTER_ALL_TYPES_KEY, ..types];
             SelectedSubject = FILTER_ALL_SUBJECTS_KEY;
             SelectedType = FILTER_ALL_TYPES_KEY;
+            SelectedStatus = FILTER_ALL_STATUS_KEY;
             Documents = docs.ToList();
             BuildCategoryTree(docs, subjects, types);
 
@@ -236,6 +248,13 @@ public partial class DashboardModel : ModelBase
         {
             _isLoadingData = false;
             IsLoading = false;
+        }
+
+        if (_pendingSavedSearch != null)
+        {
+            var pending = _pendingSavedSearch;
+            _pendingSavedSearch = null;
+            ApplySavedSearch(pending);
         }
     }
 
@@ -298,6 +317,24 @@ public partial class DashboardModel : ModelBase
 
         return key is null ? canonicalType : _loc[key];
     }
+
+    private void BuildStatusOptions()
+        => StatusOptions =
+        [
+            new(FILTER_ALL_STATUS_KEY, _loc["DS_FilterAll"]),
+            ..DocumentStatus.All.Select(s => new StatusOption(s, GetStatusLabel(s)))
+        ];
+
+    private string GetStatusLabel(string status) => status switch
+    {
+        DocumentStatus.Unread => _loc["DS_Kind_Unread"],
+        DocumentStatus.InProgress => _loc["DS_Kind_InProgress"],
+        DocumentStatus.Read => _loc["DS_Kind_Read"],
+        DocumentStatus.NeedsAction => _loc["DS_Kind_NeedsAction"],
+        DocumentStatus.Completed => _loc["DS_Kind_Completed"],
+        DocumentStatus.Archived => _loc["DS_Kind_Archived"],
+        _ => status
+    };
 
     private void BuildCategoryTree(IList<StudyDocument> docs, List<string> subjects, List<string> types)
     {
@@ -511,28 +548,38 @@ public partial class DashboardModel : ModelBase
 
         try
         {
-            string keyword = SearchKeyword?.Trim() ?? "";
-            string subject = SelectedSubject == FILTER_ALL_SUBJECTS_KEY ? "" : SelectedSubject;
-            string type = SelectedType == FILTER_ALL_TYPES_KEY ? "" : SelectedType;
-            DateTime? fromDate = IsDateFilterEnabled && FilterFromDate.HasValue ? FilterFromDate.Value.DateTime : null;
-            DateTime? toDate = IsDateFilterEnabled && FilterToDate.HasValue ? FilterToDate.Value.DateTime : null;
-            double? minSize = IsSizeFilterEnabled ? FilterMinSize : null;
-            double? maxSize = IsSizeFilterEnabled ? FilterMaxSize : null;
-            bool? isImportant = IsImportantOnly ? true : null;
-            bool hasFilter = !string.IsNullOrEmpty(subject) || !string.IsNullOrEmpty(type)
-                || fromDate.HasValue || toDate.HasValue || minSize.HasValue || maxSize.HasValue
-                || isImportant.HasValue || !string.IsNullOrEmpty(keyword);
-
-            var results = hasFilter
-                ? _repository.SearchAdvanced(keyword, subject, type, fromDate, toDate, minSize, maxSize, isImportant)
-                : _repository.GetAll();
-
-            UpdateVisibleState(results);
+            ApplyFiltersCore();
         }
         finally
         {
             _isApplyingFilters = false;
         }
+    }
+
+    private void ApplyFiltersCore()
+    {
+        string keyword = SearchKeyword?.Trim() ?? "";
+        string subject = SelectedSubject == FILTER_ALL_SUBJECTS_KEY ? "" : SelectedSubject;
+        string type = SelectedType == FILTER_ALL_TYPES_KEY ? "" : SelectedType;
+        DateTime? fromDate = IsDateFilterEnabled && FilterFromDate.HasValue ? FilterFromDate.Value.DateTime : null;
+        DateTime? toDate = IsDateFilterEnabled && FilterToDate.HasValue ? FilterToDate.Value.DateTime : null;
+        double? minSize = IsSizeFilterEnabled ? FilterMinSize : null;
+        double? maxSize = IsSizeFilterEnabled ? FilterMaxSize : null;
+        bool? isImportant = IsImportantOnly ? true : null;
+        string? status = SelectedStatus == FILTER_ALL_STATUS_KEY ? null : SelectedStatus;
+        bool hasFilter = !string.IsNullOrEmpty(subject) || !string.IsNullOrEmpty(type)
+            || fromDate.HasValue || toDate.HasValue || minSize.HasValue || maxSize.HasValue
+            || isImportant.HasValue || !string.IsNullOrEmpty(keyword)
+            || status != null;
+
+        var results = !hasFilter
+            ? _repository.GetAll()
+            : status != null
+                ? _repository.SearchAdvancedWithStatus(keyword, subject, type, fromDate, toDate, minSize, maxSize, isImportant, status)
+                : _repository.SearchAdvanced(keyword, subject, type, fromDate, toDate, minSize, maxSize, isImportant);
+
+        OnPropertyChanged(nameof(ActiveFilterCount));
+        UpdateVisibleState(results);
     }
 
     // ——— Document actions ——— 
@@ -668,6 +715,7 @@ public partial class DashboardModel : ModelBase
         SearchKeyword = string.Empty;
         SelectedSubject = FILTER_ALL_SUBJECTS_KEY;
         SelectedType = FILTER_ALL_TYPES_KEY;
+        SelectedStatus = FILTER_ALL_STATUS_KEY;
         IsAdvancedFilterVisible = false;
         IsDateFilterEnabled = false;
         FilterFromDate = null;
@@ -858,6 +906,79 @@ public partial class DashboardModel : ModelBase
         SetLocalizedStatus("Status_Overdue", docs.Count);
     }
 
+    // スマートビュー実行（NavigationService "run-smartview" 経由）
+    public void ApplySavedSearch(SavedSearchCriteria? criteria)
+    {
+        if (criteria == null || _isApplyingFilters) return;
+
+        // View の遅延初期化前に呼ばれた場合は保留し、LoadData 完了後に適用する
+        if (_isLoadingData || IsLoading)
+        {
+            _pendingSavedSearch = criteria;
+            return;
+        }
+
+        ApplySavedSearchCore(criteria);
+    }
+
+    private SavedSearchCriteria? _pendingSavedSearch;
+
+    private void ApplySavedSearchCore(SavedSearchCriteria criteria)
+    {
+        _isApplyingFilters = true;
+        try
+        {
+            SearchKeyword = criteria.Keyword ?? string.Empty;
+            SelectedSubject = string.IsNullOrEmpty(criteria.Subject) ? FILTER_ALL_SUBJECTS_KEY : criteria.Subject;
+            SelectedType = string.IsNullOrEmpty(criteria.Type) ? FILTER_ALL_TYPES_KEY : criteria.Type;
+            SelectedStatus = FILTER_ALL_STATUS_KEY;
+            FilterFromDate = criteria.FromDate.HasValue ? new DateTimeOffset(criteria.FromDate.Value) : null;
+            FilterToDate = criteria.ToDate.HasValue ? new DateTimeOffset(criteria.ToDate.Value) : null;
+            FilterMinSize = criteria.MinSize ?? 0;
+            FilterMaxSize = criteria.MaxSize ?? 100;
+            IsDateFilterEnabled = criteria.FromDate.HasValue || criteria.ToDate.HasValue;
+            IsSizeFilterEnabled = criteria.MinSize.HasValue || criteria.MaxSize.HasValue;
+            IsImportantOnly = criteria.IsImportant ?? false;
+            IsAdvancedFilterVisible = IsDateFilterEnabled || IsSizeFilterEnabled || (criteria.IsImportant ?? false);
+
+            switch (criteria.Kind)
+            {
+                case SavedSearchKinds.Uncategorized:
+                    UpdateVisibleState(_repository.GetUncategorizedDocuments());
+                    break;
+                case SavedSearchKinds.MissingMetadata:
+                    UpdateVisibleState(_repository.GetDocumentsWithMissingMetadata());
+                    break;
+                case SavedSearchKinds.MissingFile:
+                    UpdateVisibleState(_repository.GetAll()
+                        .Where(d => !string.IsNullOrEmpty(d.FilePath) && !File.Exists(d.FilePath))
+                        .ToList());
+                    break;
+                case SavedSearchKinds.RecentlyAdded:
+                    FilterFromDate = DateTimeOffset.Now.AddDays(-criteria.RecentDays);
+                    IsDateFilterEnabled = true;
+                    ApplyFiltersCore();
+                    break;
+                case SavedSearchKinds.Important:
+                    IsImportantOnly = true;
+                    ApplyFiltersCore();
+                    break;
+                case SavedSearchKinds.DueSoon:
+                    var upcoming = _repository.GetUpcomingDeadlines(criteria.DeadlineDays);
+                    Documents = upcoming.ToList();
+                    SetLocalizedStatus("Status_UpcomingDeadlines", upcoming.Count);
+                    break;
+                default:
+                    ApplyFiltersCore();
+                    break;
+            }
+        }
+        finally
+        {
+            _isApplyingFilters = false;
+        }
+    }
+
     // ——— About dialog ——— 
     [RelayCommand]
     private async Task ShowAboutAsync()
@@ -876,4 +997,11 @@ public partial class DashboardModel : ModelBase
     {
         if (!_isLoadingData) ApplyFilters();
     }
+
+    partial void OnSelectedStatusChanged(string value)
+    {
+        if (!_isLoadingData) ApplyFilters();
+    }
 }
+
+public sealed record StatusOption(string Value, string Display);

--- a/StudyDocumentManager/Models/MainWindowModel.cs
+++ b/StudyDocumentManager/Models/MainWindowModel.cs
@@ -22,6 +22,9 @@ public partial class MainWindowModel : ModelBase
     [ObservableProperty]
     private SupportedLanguage _selectedLanguage;
 
+    [ObservableProperty]
+    private bool _canUndo;
+
     public IReadOnlyList<SupportedLanguage> AvailableLanguages => _loc.AvailableLanguages;
 
     public bool CanGoBack => _navigationService.CanGoBack;
@@ -35,6 +38,8 @@ public partial class MainWindowModel : ModelBase
     private readonly ILocalizationService _loc;
     private readonly ISettingsService _settingsService;
     private readonly IUpdateService _updateService;
+    private readonly IUndoApplier? _undoApplier;
+    private readonly IUndoService? _undoService;
     private string? _statusKey = "Status_TotalDocs";
     private object[] _statusArguments = [0];
 
@@ -47,7 +52,9 @@ public partial class MainWindowModel : ModelBase
         IApplicationLifecycleService lifecycleService,
         ILocalizationService loc,
         ISettingsService settingsService,
-        IUpdateService updateService)
+        IUpdateService updateService,
+        IUndoApplier? undoApplier = null,
+        IUndoService? undoService = null)
     {
         _navigationService = navigationService;
         _dialogService = dialogService;
@@ -57,8 +64,15 @@ public partial class MainWindowModel : ModelBase
         _loc = loc;
         _settingsService = settingsService;
         _updateService = updateService;
+        _undoApplier = undoApplier;
+        _undoService = undoService;
         _currentView = dashboardModel;
         _statusText = FormatLocalizedStatus();
+        if (_undoService != null)
+        {
+            CanUndo = _undoApplier != null && _undoService.CanUndo;
+            _undoService.StackChanged += () => CanUndo = _undoApplier != null && _undoApplier.CanUndo;
+        }
         _loc.LanguageChanged += (_, _) =>
         {
             if (_statusKey != null)
@@ -131,6 +145,47 @@ public partial class MainWindowModel : ModelBase
         {
             _navigationService.GoBack();
             OnPropertyChanged(nameof(CanGoBack));
+        }
+    }
+
+    [RelayCommand]
+    private async Task UndoLastAsync()
+    {
+        if (!CanUndo || _undoApplier == null) return;
+
+        var entry = _undoService?.Peek();
+        try
+        {
+            _undoApplier.ApplyLast();
+        }
+        catch (Exception)
+        {
+            await _dialogService.ShowErrorAsync(_loc["Dialog_Error"], _loc["Msg_Error"]);
+            return;
+        }
+
+        if (entry != null)
+        {
+            var detail = string.Format(_loc[entry.DescriptionKey], entry.DescriptionArgs ?? []);
+            SetLocalizedStatus("UN_Applied", detail);
+        }
+
+        RefreshCurrentViewAfterUndo();
+    }
+
+    private void RefreshCurrentViewAfterUndo()
+    {
+        switch (CurrentView)
+        {
+            case DashboardModel dashboard:
+                dashboard.RefreshCommand.Execute(null);
+                break;
+            case CategoryManagementModel categoryManagement:
+                categoryManagement.RefreshCommand.Execute(null);
+                break;
+            case CollectionManagementModel collectionManagement:
+                collectionManagement.RefreshCommand.Execute(null);
+                break;
         }
     }
 
@@ -214,6 +269,9 @@ public partial class MainWindowModel : ModelBase
                 break;
             case CategoryManagementModel catMgmt:
                 SetExternalStatus(catMgmt.StatusText);
+                break;
+            case SmartViewsModel smartViews:
+                SetExternalStatus(smartViews.StatusText);
                 break;
             default:
                 SetExternalStatus(string.Empty);

--- a/StudyDocumentManager/Models/MainWindowModel.cs
+++ b/StudyDocumentManager/Models/MainWindowModel.cs
@@ -158,6 +158,12 @@ public partial class MainWindowModel : ModelBase
         {
             _undoApplier.ApplyLast();
         }
+        catch (UndoPartialRestoreException ex)
+        {
+            SetLocalizedStatus("UN_Applied", string.Format(_loc["BE_Result_Partial"], ex.RestoredCount, ex.RequestedCount));
+            RefreshCurrentViewAfterUndo();
+            return;
+        }
         catch (Exception)
         {
             await _dialogService.ShowErrorAsync(_loc["Dialog_Error"], _loc["Msg_Error"]);

--- a/StudyDocumentManager/Models/ReportModel.cs
+++ b/StudyDocumentManager/Models/ReportModel.cs
@@ -13,15 +13,20 @@ public partial class ReportModel : ModelBase
     [ObservableProperty] private ObservableCollection<ChartDataItem> _byTypeData = new();
     [ObservableProperty] private ObservableCollection<ChartDataItem> _byDayData = new();
     [ObservableProperty] private ObservableCollection<ChartDataItem> _byMonthData = new();
+    [ObservableProperty] private ObservableCollection<StatusCountItem> _byStatusData = new();
     [ObservableProperty] private bool _hasDayData;
     [ObservableProperty] private bool _hasMonthData;
 
 
     private readonly IReportRepository _reportRepo;
+    private readonly IDocumentRepository? _documentRepo;
+    private readonly ILocalizationService? _loc;
 
-    public ReportModel(IReportRepository reportRepo)
+    public ReportModel(IReportRepository reportRepo, IDocumentRepository? documentRepo = null, ILocalizationService? localizationService = null)
     {
         _reportRepo = reportRepo;
+        _documentRepo = documentRepo;
+        _loc = localizationService;
         LoadAllData();
     }
 
@@ -42,7 +47,38 @@ public partial class ReportModel : ModelBase
 
         HasDayData = ByDayData.Any(item => item.Value > 0);
         HasMonthData = ByMonthData.Any(item => item.Value > 0);
+        ByStatusData = CreateStatusCounts();
     }
+
+    private ObservableCollection<StatusCountItem> CreateStatusCounts()
+    {
+        var counts = _documentRepo?.GetStatusCounts() ?? [];
+        var items = DocumentStatus.All
+            .Select(kind => new StatusCountItem
+            {
+                Kind = kind,
+                Label = GetStatusLabel(kind),
+                Value = counts.TryGetValue(kind, out int count) ? count : 0
+            })
+            .ToList();
+        var max = items.Count > 0 ? items.Max(x => x.Value) : 1;
+        if (max == 0) max = 1;
+        foreach (var item in items) item.MaxValue = max;
+        return new ObservableCollection<StatusCountItem>(items);
+    }
+
+    private string GetStatusLabel(string status) => status switch
+    {
+        DocumentStatus.Unread => Loc("DS_Kind_Unread"),
+        DocumentStatus.InProgress => Loc("DS_Kind_InProgress"),
+        DocumentStatus.Read => Loc("DS_Kind_Read"),
+        DocumentStatus.NeedsAction => Loc("DS_Kind_NeedsAction"),
+        DocumentStatus.Completed => Loc("DS_Kind_Completed"),
+        DocumentStatus.Archived => Loc("DS_Kind_Archived"),
+        _ => status
+    };
+
+    private string Loc(string key) => _loc?[key] ?? key;
 
     private static ObservableCollection<ChartDataItem> CreateChartData(IEnumerable<ChartDataItem> items)
     {
@@ -63,5 +99,15 @@ public class ChartDataItem
     public int MaxValue { get; set; } = 1;
 
     // For bar chart visualization (proportional width, max ~300px)
+    public double BarWidth => MaxValue > 0 ? (double)Value / MaxValue * 300.0 : 0;
+}
+
+public class StatusCountItem
+{
+    public string Kind { get; set; } = string.Empty;
+    public string Label { get; set; } = string.Empty;
+    public int Value { get; set; }
+    public int MaxValue { get; set; } = 1;
+
     public double BarWidth => MaxValue > 0 ? (double)Value / MaxValue * 300.0 : 0;
 }

--- a/StudyDocumentManager/Models/SmartViewsModel.cs
+++ b/StudyDocumentManager/Models/SmartViewsModel.cs
@@ -1,0 +1,435 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using StudyDocumentManager.Core.Entities;
+using StudyDocumentManager.Core.Interfaces;
+using StudyDocumentManager.Services;
+
+namespace StudyDocumentManager.Models;
+
+public partial class SmartViewsModel : ModelBase
+{
+    private readonly ISavedSearchRepository _savedSearchRepo;
+    private readonly ICategoryRepository _categoryRepo;
+    private readonly IDialogService _dialogService;
+    private readonly INavigationService _navigationService;
+    private readonly ILocalizationService _loc;
+    private bool _localizationSubscribed;
+    private string _statusKey = "Status_Ready";
+    private object[] _statusArguments = [];
+    private int? _editingId;
+    private string _editingOriginalName = string.Empty;
+
+    [ObservableProperty] private ObservableCollection<SavedSearchRow> _savedViews = [];
+    [ObservableProperty] private SavedSearchRow? _selectedSavedSearch;
+    [ObservableProperty] private ObservableCollection<SmartViewKindOption> _kindOptions = [];
+    [ObservableProperty] private SmartViewKindOption? _selectedKindOption;
+    [ObservableProperty] private ObservableCollection<string> _subjects = [];
+    [ObservableProperty] private ObservableCollection<string> _types = [];
+
+    [ObservableProperty] private bool _isLoading;
+    [ObservableProperty] private bool _hasLoadError;
+    [ObservableProperty] private string _statusText = string.Empty;
+
+    [ObservableProperty] private bool _isEditing;
+    [ObservableProperty] private string _editorName = string.Empty;
+    [ObservableProperty] private string _editorKeyword = string.Empty;
+    [ObservableProperty] private string? _editorSubject;
+    [ObservableProperty] private string? _editorType;
+    [ObservableProperty] private DateTimeOffset? _editorFromDate;
+    [ObservableProperty] private DateTimeOffset? _editorToDate;
+    [ObservableProperty] private double? _editorMinSize;
+    [ObservableProperty] private double? _editorMaxSize;
+    [ObservableProperty] private bool _editorIsImportantOnly;
+    [ObservableProperty] private int _editorRecentDays = 7;
+    [ObservableProperty] private int _editorDeadlineDays = 7;
+
+    public SmartViewsModel(
+        ISavedSearchRepository savedSearchRepo,
+        ICategoryRepository categoryRepo,
+        IDialogService dialogService,
+        INavigationService navigationService,
+        ILocalizationService loc)
+    {
+        _savedSearchRepo = savedSearchRepo;
+        _categoryRepo = categoryRepo;
+        _dialogService = dialogService;
+        _navigationService = navigationService;
+        _loc = loc;
+
+        Subjects = new ObservableCollection<string>(_categoryRepo.GetAllSubjects());
+        Types = new ObservableCollection<string>(_categoryRepo.GetAllTypes());
+        RefreshKindLabels();
+        StatusText = FormatLocalizedStatus();
+        _loc.LanguageChanged += OnLanguageChanged;
+        _localizationSubscribed = true;
+
+        LoadViews();
+    }
+
+    public void AttachLocalization()
+    {
+        if (_localizationSubscribed)
+            return;
+
+        _loc.LanguageChanged += OnLanguageChanged;
+        _localizationSubscribed = true;
+        OnLanguageChanged(this, EventArgs.Empty);
+    }
+
+    public void DetachLocalization()
+    {
+        if (!_localizationSubscribed)
+            return;
+
+        _loc.LanguageChanged -= OnLanguageChanged;
+        _localizationSubscribed = false;
+    }
+
+    public bool HasSelection => SelectedSavedSearch != null;
+    public bool IsEmptyState => !IsLoading && !HasLoadError && SavedViews.Count == 0;
+    public bool ShowNoSelectionHint => SelectedSavedSearch == null && !IsEditing;
+    public bool IsStandardFieldsVisible => SelectedKindOption?.Key == SavedSearchKinds.Standard;
+    public bool IsRecentDaysVisible => SelectedKindOption?.Key == SavedSearchKinds.RecentlyAdded;
+    public bool IsDeadlineDaysVisible => SelectedKindOption?.Key == SavedSearchKinds.DueSoon;
+
+    private void OnLanguageChanged(object? sender, EventArgs e)
+    {
+        RefreshKindLabels();
+        StatusText = FormatLocalizedStatus();
+    }
+
+    private void RefreshKindLabels()
+    {
+        var selectedKey = SelectedKindOption?.Key;
+        KindOptions = new ObservableCollection<SmartViewKindOption>(BuildKindOptions());
+        SelectedKindOption = KindOptions.FirstOrDefault(k => k.Key == selectedKey) ?? KindOptions[0];
+
+        foreach (var row in SavedViews)
+            row.KindLabel = GetKindLabel(row.Kind);
+    }
+
+    private List<SmartViewKindOption> BuildKindOptions() =>
+    [
+        new() { Key = SavedSearchKinds.Standard, Label = _loc["SV_Kind_Standard"] },
+        new() { Key = SavedSearchKinds.Uncategorized, Label = _loc["SV_Kind_Uncategorized"] },
+        new() { Key = SavedSearchKinds.MissingMetadata, Label = _loc["SV_Kind_MissingMetadata"] },
+        new() { Key = SavedSearchKinds.MissingFile, Label = _loc["SV_Kind_MissingFile"] },
+        new() { Key = SavedSearchKinds.RecentlyAdded, Label = _loc["SV_Kind_RecentlyAdded"] },
+        new() { Key = SavedSearchKinds.Important, Label = _loc["SV_Kind_Important"] },
+        new() { Key = SavedSearchKinds.DueSoon, Label = _loc["SV_Kind_DueSoon"] },
+    ];
+
+    private string GetKindLabel(string kind) => kind switch
+    {
+        SavedSearchKinds.Uncategorized => _loc["SV_Kind_Uncategorized"],
+        SavedSearchKinds.MissingMetadata => _loc["SV_Kind_MissingMetadata"],
+        SavedSearchKinds.MissingFile => _loc["SV_Kind_MissingFile"],
+        SavedSearchKinds.RecentlyAdded => _loc["SV_Kind_RecentlyAdded"],
+        SavedSearchKinds.Important => _loc["SV_Kind_Important"],
+        SavedSearchKinds.DueSoon => _loc["SV_Kind_DueSoon"],
+        _ => _loc["SV_Kind_Standard"]
+    };
+
+    private string FormatLocalizedStatus()
+        => string.Format(_loc[_statusKey], _statusArguments);
+
+    private void SetLocalizedStatus(string key, params object[] arguments)
+    {
+        _statusKey = key;
+        _statusArguments = arguments;
+        StatusText = FormatLocalizedStatus();
+    }
+
+    partial void OnSelectedSavedSearchChanged(SavedSearchRow? value)
+    {
+        OnPropertyChanged(nameof(HasSelection));
+        OnPropertyChanged(nameof(ShowNoSelectionHint));
+    }
+
+    partial void OnIsEditingChanged(bool value)
+        => OnPropertyChanged(nameof(ShowNoSelectionHint));
+
+    partial void OnIsLoadingChanged(bool value)
+        => OnPropertyChanged(nameof(IsEmptyState));
+
+    partial void OnHasLoadErrorChanged(bool value)
+        => OnPropertyChanged(nameof(IsEmptyState));
+
+    partial void OnSelectedKindOptionChanged(SmartViewKindOption? value)
+    {
+        OnPropertyChanged(nameof(IsStandardFieldsVisible));
+        OnPropertyChanged(nameof(IsRecentDaysVisible));
+        OnPropertyChanged(nameof(IsDeadlineDaysVisible));
+    }
+
+    [RelayCommand]
+    private void Refresh() => LoadViews();
+
+    [RelayCommand]
+    private void New()
+    {
+        _editingId = null;
+        _editingOriginalName = string.Empty;
+        EditorName = string.Empty;
+        SelectedKindOption = KindOptions[0];
+        EditorKeyword = string.Empty;
+        EditorSubject = null;
+        EditorType = null;
+        EditorFromDate = null;
+        EditorToDate = null;
+        EditorMinSize = null;
+        EditorMaxSize = null;
+        EditorIsImportantOnly = false;
+        EditorRecentDays = 7;
+        EditorDeadlineDays = 7;
+        IsEditing = true;
+    }
+
+    [RelayCommand]
+    private void Edit()
+    {
+        if (SelectedSavedSearch == null) return;
+
+        var source = _savedSearchRepo.GetById(SelectedSavedSearch.Id);
+        if (source == null) return;
+
+        var criteria = SavedSearchCriteria.FromJson(source.CriteriaJson) ?? new SavedSearchCriteria();
+        _editingId = source.Id;
+        _editingOriginalName = source.Name.Trim();
+        EditorName = source.Name;
+        SelectedKindOption = KindOptions.FirstOrDefault(k => k.Key == criteria.Kind) ?? KindOptions[0];
+        EditorKeyword = criteria.Keyword ?? string.Empty;
+        EditorSubject = criteria.Subject;
+        EditorType = criteria.Type;
+        EditorFromDate = criteria.FromDate.HasValue ? new DateTimeOffset(criteria.FromDate.Value) : null;
+        EditorToDate = criteria.ToDate.HasValue ? new DateTimeOffset(criteria.ToDate.Value) : null;
+        EditorMinSize = criteria.MinSize;
+        EditorMaxSize = criteria.MaxSize;
+        EditorIsImportantOnly = criteria.IsImportant ?? false;
+        EditorRecentDays = criteria.RecentDays;
+        EditorDeadlineDays = criteria.DeadlineDays;
+        IsEditing = true;
+    }
+
+    [RelayCommand]
+    private void Save()
+    {
+        var trimmedName = EditorName.Trim();
+        if (trimmedName.Length == 0)
+        {
+            SetLocalizedStatus("SV_NameRequired");
+            return;
+        }
+
+        try
+        {
+            if (_editingId.HasValue)
+            {
+                var existing = _savedSearchRepo.GetById(_editingId.Value);
+                if (existing == null)
+                {
+                    SetLocalizedStatus("Msg_Error");
+                    return;
+                }
+
+                var renamed = trimmedName != _editingOriginalName;
+                if (renamed && _savedSearchRepo.NameExists(trimmedName))
+                {
+                    SetLocalizedStatus("SV_NameExists");
+                    return;
+                }
+
+                existing.Name = trimmedName;
+                existing.CriteriaJson = BuildCriteria().ToJson();
+                if (!_savedSearchRepo.Update(existing))
+                {
+                    SetLocalizedStatus("Msg_Error");
+                    return;
+                }
+            }
+            else
+            {
+                if (_savedSearchRepo.NameExists(trimmedName))
+                {
+                    SetLocalizedStatus("SV_NameExists");
+                    return;
+                }
+
+                var addedId = _savedSearchRepo.Add(new SavedSearch
+                {
+                    Name = trimmedName,
+                    CriteriaJson = BuildCriteria().ToJson(),
+                    CreatedAt = DateTime.Now
+                });
+                if (addedId <= 0)
+                {
+                    SetLocalizedStatus("Msg_Error");
+                    return;
+                }
+            }
+
+            IsEditing = false;
+            LoadViews();
+            SetLocalizedStatus("SV_Saved");
+        }
+        catch
+        {
+            SetLocalizedStatus("Msg_Error");
+        }
+    }
+
+    [RelayCommand]
+    private void CancelEdit() => IsEditing = false;
+
+    [RelayCommand]
+    private void Duplicate()
+    {
+        if (SelectedSavedSearch == null) return;
+
+        try
+        {
+            var source = _savedSearchRepo.GetById(SelectedSavedSearch.Id);
+            if (source == null) return;
+
+            var candidate = source.Name;
+            var suffix = 2;
+            while (_savedSearchRepo.NameExists(candidate))
+            {
+                candidate = $"{source.Name} ({suffix})";
+                suffix++;
+            }
+
+            var addedId = _savedSearchRepo.Add(new SavedSearch
+            {
+                Name = candidate,
+                CriteriaJson = source.CriteriaJson,
+                CreatedAt = DateTime.Now
+            });
+            if (addedId <= 0)
+            {
+                SetLocalizedStatus("Msg_Error");
+                return;
+            }
+
+            LoadViews();
+            SetLocalizedStatus("SV_Saved");
+        }
+        catch
+        {
+            SetLocalizedStatus("Msg_Error");
+        }
+    }
+
+    [RelayCommand]
+    private async Task DeleteAsync()
+    {
+        if (SelectedSavedSearch == null) return;
+
+        var targetId = SelectedSavedSearch.Id;
+        var targetName = SelectedSavedSearch.Name;
+        try
+        {
+            var confirmed = await _dialogService.ShowConfirmAsync(
+                _loc["Dialog_Confirm"],
+                string.Format(_loc["SV_DeleteConfirm"], targetName),
+                _loc["Action_Delete"], isDanger: true);
+            if (!confirmed) return;
+
+            if (!_savedSearchRepo.Delete(targetId))
+            {
+                SetLocalizedStatus("Msg_Error");
+                return;
+            }
+
+            LoadViews();
+            SetLocalizedStatus("SV_Deleted");
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch
+        {
+            LoadViews();
+            SetLocalizedStatus("Msg_Error");
+        }
+    }
+
+    [RelayCommand]
+    private void Open()
+    {
+        if (SelectedSavedSearch == null) return;
+        SetLocalizedStatus("SV_Status_Applied", SelectedSavedSearch.Name);
+        _navigationService.NavigateTo("run-smartview", SelectedSavedSearch.Id);
+    }
+
+    private void LoadViews()
+    {
+        IsLoading = true;
+        SelectedSavedSearch = null;
+        try
+        {
+            var data = _savedSearchRepo.GetAll();
+            SavedViews = new ObservableCollection<SavedSearchRow>(
+                data.Select(s =>
+                {
+                    var kind = ResolveKind(s.CriteriaJson);
+                    return new SavedSearchRow
+                    {
+                        Id = s.Id,
+                        Name = s.Name,
+                        Kind = kind,
+                        KindLabel = GetKindLabel(kind)
+                    };
+                }));
+            HasLoadError = false;
+            SetLocalizedStatus("Status_TotalDocs", SavedViews.Count);
+        }
+        catch
+        {
+            SavedViews = [];
+            HasLoadError = true;
+            SetLocalizedStatus("SV_LoadError");
+        }
+        finally
+        {
+            IsLoading = false;
+        }
+        OnPropertyChanged(nameof(IsEmptyState));
+    }
+
+    private string ResolveKind(string criteriaJson)
+        => SavedSearchCriteria.FromJson(criteriaJson)?.Kind ?? SavedSearchKinds.Standard;
+
+    private SavedSearchCriteria BuildCriteria() => new()
+    {
+        Kind = SelectedKindOption?.Key ?? SavedSearchKinds.Standard,
+        Keyword = NullIfEmpty(EditorKeyword),
+        Subject = NullIfEmpty(EditorSubject),
+        Type = NullIfEmpty(EditorType),
+        FromDate = EditorFromDate?.DateTime,
+        ToDate = EditorToDate?.DateTime,
+        MinSize = EditorMinSize,
+        MaxSize = EditorMaxSize,
+        IsImportant = EditorIsImportantOnly ? true : null,
+        RecentDays = EditorRecentDays,
+        DeadlineDays = EditorDeadlineDays
+    };
+
+    private static string? NullIfEmpty(string? value)
+        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+}
+
+public class SavedSearchRow
+{
+    public int Id { get; init; }
+    public string Name { get; init; } = string.Empty;
+    public string Kind { get; init; } = SavedSearchKinds.Standard;
+    public string KindLabel { get; set; } = string.Empty;
+}
+
+public class SmartViewKindOption
+{
+    public string Key { get; init; } = SavedSearchKinds.Standard;
+    public string Label { get; set; } = string.Empty;
+}

--- a/StudyDocumentManager/Resources/Strings.en.resx
+++ b/StudyDocumentManager/Resources/Strings.en.resx
@@ -645,4 +645,87 @@ Please check your network connection.</value></data>
   <data name="FileType_Archive" xml:space="preserve"><value>Archive</value></data>
   <data name="FileType_Design" xml:space="preserve"><value>Design</value></data>
   <data name="FileType_Other" xml:space="preserve"><value>Other</value></data>
+
+  <!-- SmartViews View -->
+  <data name="Menu_SmartViews" xml:space="preserve"><value>Smart Views</value></data>
+  <data name="SV_Title" xml:space="preserve"><value>Smart Views</value></data>
+  <data name="SV_ListHeader" xml:space="preserve"><value>Saved Views</value></data>
+  <data name="SV_EmptyState" xml:space="preserve"><value>No saved searches yet. Create one with "New"</value></data>
+  <data name="SV_New" xml:space="preserve"><value>New</value></data>
+  <data name="SV_Open" xml:space="preserve"><value>Run</value></data>
+  <data name="SV_Edit" xml:space="preserve"><value>Edit</value></data>
+  <data name="SV_Duplicate" xml:space="preserve"><value>Duplicate</value></data>
+  <data name="SV_Delete" xml:space="preserve"><value>Delete</value></data>
+  <data name="SV_DeleteConfirm" xml:space="preserve"><value>Delete "{0}"?</value></data>
+  <data name="SV_NameRequired" xml:space="preserve"><value>Please enter a name</value></data>
+  <data name="SV_NameExists" xml:space="preserve"><value>A smart view with the same name already exists</value></data>
+  <data name="SV_Saved" xml:space="preserve"><value>Smart view saved</value></data>
+  <data name="SV_Deleted" xml:space="preserve"><value>Smart view deleted</value></data>
+  <data name="SV_LoadError" xml:space="preserve"><value>Failed to load smart views</value></data>
+  <data name="SV_Kind_Label" xml:space="preserve"><value>Criteria Kind</value></data>
+  <data name="SV_Kind_Standard" xml:space="preserve"><value>Standard criteria</value></data>
+  <data name="SV_Kind_Uncategorized" xml:space="preserve"><value>Uncategorized</value></data>
+  <data name="SV_Kind_MissingMetadata" xml:space="preserve"><value>Missing metadata</value></data>
+  <data name="SV_Kind_MissingFile" xml:space="preserve"><value>Missing file</value></data>
+  <data name="SV_Kind_RecentlyAdded" xml:space="preserve"><value>Recently added</value></data>
+  <data name="SV_Kind_Important" xml:space="preserve"><value>Important</value></data>
+  <data name="SV_Kind_DueSoon" xml:space="preserve"><value>Due soon</value></data>
+  <data name="SV_Field_Name" xml:space="preserve"><value>Name</value></data>
+  <data name="SV_Field_Keyword" xml:space="preserve"><value>Keyword</value></data>
+  <data name="SV_Field_Subject" xml:space="preserve"><value>Subject</value></data>
+  <data name="SV_Field_Type" xml:space="preserve"><value>Type</value></data>
+  <data name="SV_Field_FromDate" xml:space="preserve"><value>Added from</value></data>
+  <data name="SV_Field_ToDate" xml:space="preserve"><value>Added to</value></data>
+  <data name="SV_Field_MinSize" xml:space="preserve"><value>Min size (MB)</value></data>
+  <data name="SV_Field_MaxSize" xml:space="preserve"><value>Max size (MB)</value></data>
+  <data name="SV_Field_Important" xml:space="preserve"><value>Important only</value></data>
+  <data name="SV_Field_RecentDays" xml:space="preserve"><value>Period (days)</value></data>
+  <data name="SV_Field_DeadlineDays" xml:space="preserve"><value>Deadline window (days)</value></data>
+  <data name="SV_Status_Applied" xml:space="preserve"><value>Smart view "{0}" applied</value></data>
+
+  <!-- Document Status -->
+  <data name="DS_FilterAll" xml:space="preserve"><value>All Statuses</value></data>
+  <data name="DS_Label_Status" xml:space="preserve"><value>Status</value></data>
+  <data name="DS_Kind_Unread" xml:space="preserve"><value>Unread</value></data>
+  <data name="DS_Kind_InProgress" xml:space="preserve"><value>In Progress</value></data>
+  <data name="DS_Kind_Read" xml:space="preserve"><value>Read</value></data>
+  <data name="DS_Kind_NeedsAction" xml:space="preserve"><value>Needs Action</value></data>
+  <data name="DS_Kind_Completed" xml:space="preserve"><value>Completed</value></data>
+  <data name="DS_Kind_Archived" xml:space="preserve"><value>Archived</value></data>
+  <data name="DS_Error_InvalidStatus" xml:space="preserve"><value>Please select a valid status</value></data>
+  <data name="RS_StatusCounts_Title" xml:space="preserve"><value>Reports by Status</value></data>
+
+  <!-- Bulk Edit -->
+  <data name="BE_SectionTitle" xml:space="preserve"><value>Bulk Edit</value></data>
+  <data name="BE_Field_Subject" xml:space="preserve"><value>Subject</value></data>
+  <data name="BE_Field_Type" xml:space="preserve"><value>Type</value></data>
+  <data name="BE_Field_Tags" xml:space="preserve"><value>Tags</value></data>
+  <data name="BE_Field_Important" xml:space="preserve"><value>Important</value></data>
+  <data name="BE_Field_Deadline" xml:space="preserve"><value>Deadline</value></data>
+  <data name="BE_Field_Status" xml:space="preserve"><value>Status</value></data>
+  <data name="BE_Field_CollectionAdd" xml:space="preserve"><value>Add to Collection</value></data>
+  <data name="BE_PreviewTitle" xml:space="preserve"><value>Confirm Bulk Edit</value></data>
+  <data name="BE_PreviewAffected" xml:space="preserve"><value>This will update {0} documents</value></data>
+  <data name="BE_ConfirmApply" xml:space="preserve"><value>Apply</value></data>
+  <data name="BE_Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="BE_Result_AllSuccess" xml:space="preserve"><value>Updated {0}/{1} documents</value></data>
+  <data name="BE_Result_Partial" xml:space="preserve"><value>Only {0}/{1} documents were updated. Some failed</value></data>
+  <data name="BE_FailedItemsHeader" xml:space="preserve"><value>Failed documents:</value></data>
+  <data name="BE_Undo" xml:space="preserve"><value>Undo</value></data>
+  <data name="BE_UndoDescription" xml:space="preserve"><value>Bulk edit of {0} documents</value></data>
+  <data name="BE_Undone" xml:space="preserve"><value>Bulk edit undone</value></data>
+  <data name="BE_NoSelectionHint" xml:space="preserve"><value>Select at least one document</value></data>
+  <data name="BE_NoFieldsEnabledHint" xml:space="preserve"><value>Enable at least one field and enter a value</value></data>
+  <data name="BE_CollectionNone" xml:space="preserve"><value>(No collection)</value></data>
+
+  <!-- Undo / Affected preview -->
+  <data name="Menu_Undo" xml:space="preserve"><value>Undo</value></data>
+  <data name="UN_Applied" xml:space="preserve"><value>Undone: {0}</value></data>
+  <data name="UN_DeletedDocuments" xml:space="preserve"><value>Deleted {0} documents</value></data>
+  <data name="UN_CollectionRestorable" xml:space="preserve"><value>Deleted collection '{0}' (restorable)</value></data>
+  <data name="UN_Renamed" xml:space="preserve"><value>Renamed '{0}' to '{1}'</value></data>
+  <data name="PV_DeleteCollection" xml:space="preserve"><value>Delete this collection?</value></data>
+  <data name="PV_CascadeTitle" xml:space="preserve"><value>Delete {0}?</value></data>
+  <data name="PV_MembershipNote" xml:space="preserve"><value>The collection and its members can be restored afterwards with Undo. The documents themselves are not deleted.</value></data>
+  <data name="PV_RecycleBinNote" xml:space="preserve"><value>Deleted documents can be restored from the Recycle Bin or with Undo.</value></data>
 </root>

--- a/StudyDocumentManager/Resources/Strings.resx
+++ b/StudyDocumentManager/Resources/Strings.resx
@@ -753,6 +753,89 @@
   <data name="FileType_Archive" xml:space="preserve"><value>アーカイブ</value></data>
   <data name="FileType_Design" xml:space="preserve"><value>デザイン</value></data>
   <data name="FileType_Other" xml:space="preserve"><value>その他</value></data>
+
+  <!-- SmartViews View -->
+  <data name="Menu_SmartViews" xml:space="preserve"><value>スマートビュー</value></data>
+  <data name="SV_Title" xml:space="preserve"><value>スマートビュー</value></data>
+  <data name="SV_ListHeader" xml:space="preserve"><value>スマートビュー一覧</value></data>
+  <data name="SV_EmptyState" xml:space="preserve"><value>保存された検索条件がありません。「新規作成」で追加できます</value></data>
+  <data name="SV_New" xml:space="preserve"><value>新規作成</value></data>
+  <data name="SV_Open" xml:space="preserve"><value>実行</value></data>
+  <data name="SV_Edit" xml:space="preserve"><value>編集</value></data>
+  <data name="SV_Duplicate" xml:space="preserve"><value>複製</value></data>
+  <data name="SV_Delete" xml:space="preserve"><value>削除</value></data>
+  <data name="SV_DeleteConfirm" xml:space="preserve"><value>「{0}」を削除しますか？</value></data>
+  <data name="SV_NameRequired" xml:space="preserve"><value>名前を入力してください</value></data>
+  <data name="SV_NameExists" xml:space="preserve"><value>同じ名前のスマートビューが既に存在します</value></data>
+  <data name="SV_Saved" xml:space="preserve"><value>スマートビューを保存しました</value></data>
+  <data name="SV_Deleted" xml:space="preserve"><value>スマートビューを削除しました</value></data>
+  <data name="SV_LoadError" xml:space="preserve"><value>スマートビューの読み込みに失敗しました</value></data>
+  <data name="SV_Kind_Label" xml:space="preserve"><value>条件の種類</value></data>
+  <data name="SV_Kind_Standard" xml:space="preserve"><value>標準条件</value></data>
+  <data name="SV_Kind_Uncategorized" xml:space="preserve"><value>カテゴリ未設定</value></data>
+  <data name="SV_Kind_MissingMetadata" xml:space="preserve"><value>メタデータ欠損</value></data>
+  <data name="SV_Kind_MissingFile" xml:space="preserve"><value>ファイル欠損</value></data>
+  <data name="SV_Kind_RecentlyAdded" xml:space="preserve"><value>最近追加</value></data>
+  <data name="SV_Kind_Important" xml:space="preserve"><value>重要</value></data>
+  <data name="SV_Kind_DueSoon" xml:space="preserve"><value>期限間近</value></data>
+  <data name="SV_Field_Name" xml:space="preserve"><value>名前</value></data>
+  <data name="SV_Field_Keyword" xml:space="preserve"><value>キーワード</value></data>
+  <data name="SV_Field_Subject" xml:space="preserve"><value>科目</value></data>
+  <data name="SV_Field_Type" xml:space="preserve"><value>種類</value></data>
+  <data name="SV_Field_FromDate" xml:space="preserve"><value>追加日（開始）</value></data>
+  <data name="SV_Field_ToDate" xml:space="preserve"><value>追加日（終了）</value></data>
+  <data name="SV_Field_MinSize" xml:space="preserve"><value>最小サイズ (MB)</value></data>
+  <data name="SV_Field_MaxSize" xml:space="preserve"><value>最大サイズ (MB)</value></data>
+  <data name="SV_Field_Important" xml:space="preserve"><value>重要のみ表示</value></data>
+  <data name="SV_Field_RecentDays" xml:space="preserve"><value>対象期間（日）</value></data>
+  <data name="SV_Field_DeadlineDays" xml:space="preserve"><value>期限対象日数（日）</value></data>
+  <data name="SV_Status_Applied" xml:space="preserve"><value>スマートビュー「{0}」を実行しました</value></data>
+
+  <!-- Document Status -->
+  <data name="DS_FilterAll" xml:space="preserve"><value>すべてのステータス</value></data>
+  <data name="DS_Label_Status" xml:space="preserve"><value>ステータス</value></data>
+  <data name="DS_Kind_Unread" xml:space="preserve"><value>未読</value></data>
+  <data name="DS_Kind_InProgress" xml:space="preserve"><value>学習中</value></data>
+  <data name="DS_Kind_Read" xml:space="preserve"><value>既読</value></data>
+  <data name="DS_Kind_NeedsAction" xml:space="preserve"><value>要対応</value></data>
+  <data name="DS_Kind_Completed" xml:space="preserve"><value>完了</value></data>
+  <data name="DS_Kind_Archived" xml:space="preserve"><value>アーカイブ済み</value></data>
+  <data name="DS_Error_InvalidStatus" xml:space="preserve"><value>有効なステータスを選択してください</value></data>
+  <data name="RS_StatusCounts_Title" xml:space="preserve"><value>ステータス別レポート</value></data>
+
+  <!-- Bulk Edit -->
+  <data name="BE_SectionTitle" xml:space="preserve"><value>一括編集</value></data>
+  <data name="BE_Field_Subject" xml:space="preserve"><value>科目</value></data>
+  <data name="BE_Field_Type" xml:space="preserve"><value>種類</value></data>
+  <data name="BE_Field_Tags" xml:space="preserve"><value>タグ</value></data>
+  <data name="BE_Field_Important" xml:space="preserve"><value>重要</value></data>
+  <data name="BE_Field_Deadline" xml:space="preserve"><value>期限</value></data>
+  <data name="BE_Field_Status" xml:space="preserve"><value>ステータス</value></data>
+  <data name="BE_Field_CollectionAdd" xml:space="preserve"><value>コレクションに追加</value></data>
+  <data name="BE_PreviewTitle" xml:space="preserve"><value>一括編集の確認</value></data>
+  <data name="BE_PreviewAffected" xml:space="preserve"><value>{0}件の文書に適用します</value></data>
+  <data name="BE_ConfirmApply" xml:space="preserve"><value>適用</value></data>
+  <data name="BE_Cancel" xml:space="preserve"><value>キャンセル</value></data>
+  <data name="BE_Result_AllSuccess" xml:space="preserve"><value>{0}/{1}件の文書を更新しました</value></data>
+  <data name="BE_Result_Partial" xml:space="preserve"><value>{0}/{1}件のみ更新されました。失敗した文書があります</value></data>
+  <data name="BE_FailedItemsHeader" xml:space="preserve"><value>失敗した文書:</value></data>
+  <data name="BE_Undo" xml:space="preserve"><value>元に戻す</value></data>
+  <data name="BE_UndoDescription" xml:space="preserve"><value>{0}件の文書を一括編集</value></data>
+  <data name="BE_Undone" xml:space="preserve"><value>一括編集を元に戻しました</value></data>
+  <data name="BE_NoSelectionHint" xml:space="preserve"><value>文書を選択してください</value></data>
+  <data name="BE_NoFieldsEnabledHint" xml:space="preserve"><value>編集するフィールドを有効にして値を入力してください</value></data>
+  <data name="BE_CollectionNone" xml:space="preserve"><value>（コレクションなし）</value></data>
+
+  <!-- Undo / Affected preview -->
+  <data name="Menu_Undo" xml:space="preserve"><value>元に戻す</value></data>
+  <data name="UN_Applied" xml:space="preserve"><value>元に戻しました：{0}</value></data>
+  <data name="UN_DeletedDocuments" xml:space="preserve"><value>{0}件の文書を削除</value></data>
+  <data name="UN_CollectionRestorable" xml:space="preserve"><value>コレクション「{0}」を削除（復元可能）</value></data>
+  <data name="UN_Renamed" xml:space="preserve"><value>「{0}」を「{1}」に変更</value></data>
+  <data name="PV_DeleteCollection" xml:space="preserve"><value>このコレクションを削除しますか？</value></data>
+  <data name="PV_CascadeTitle" xml:space="preserve"><value>{0}を削除しますか？</value></data>
+  <data name="PV_MembershipNote" xml:space="preserve"><value>削除後も「元に戻す」でコレクションとメンバー構成を復元できます。文書自体は削除されません。</value></data>
+  <data name="PV_RecycleBinNote" xml:space="preserve"><value>削除された文書はごみ箱から復元できます。「元に戻す」でも復元できます。</value></data>
 </root>
 
 

--- a/StudyDocumentManager/Resources/Strings.vi.resx
+++ b/StudyDocumentManager/Resources/Strings.vi.resx
@@ -850,4 +850,87 @@
   <data name="FileType_Archive" xml:space="preserve"><value>Lưu trữ</value></data>
   <data name="FileType_Design" xml:space="preserve"><value>Thiết kế</value></data>
   <data name="FileType_Other" xml:space="preserve"><value>Khác</value></data>
+
+  <!-- SmartViews View -->
+  <data name="Menu_SmartViews" xml:space="preserve"><value>Chế độ xem thông minh</value></data>
+  <data name="SV_Title" xml:space="preserve"><value>Chế độ xem thông minh</value></data>
+  <data name="SV_ListHeader" xml:space="preserve"><value>Danh sách chế độ xem</value></data>
+  <data name="SV_EmptyState" xml:space="preserve"><value>Chưa có điều kiện tìm kiếm nào được lưu. Tạo mới bằng "Tạo mới"</value></data>
+  <data name="SV_New" xml:space="preserve"><value>Tạo mới</value></data>
+  <data name="SV_Open" xml:space="preserve"><value>Chạy</value></data>
+  <data name="SV_Edit" xml:space="preserve"><value>Sửa</value></data>
+  <data name="SV_Duplicate" xml:space="preserve"><value>Nhân bản</value></data>
+  <data name="SV_Delete" xml:space="preserve"><value>Xóa</value></data>
+  <data name="SV_DeleteConfirm" xml:space="preserve"><value>Xóa "{0}"?</value></data>
+  <data name="SV_NameRequired" xml:space="preserve"><value>Vui lòng nhập tên</value></data>
+  <data name="SV_NameExists" xml:space="preserve"><value>Đã tồn tại chế độ xem cùng tên</value></data>
+  <data name="SV_Saved" xml:space="preserve"><value>Đã lưu chế độ xem thông minh</value></data>
+  <data name="SV_Deleted" xml:space="preserve"><value>Đã xóa chế độ xem thông minh</value></data>
+  <data name="SV_LoadError" xml:space="preserve"><value>Không thể tải chế độ xem thông minh</value></data>
+  <data name="SV_Kind_Label" xml:space="preserve"><value>Loại điều kiện</value></data>
+  <data name="SV_Kind_Standard" xml:space="preserve"><value>Điều kiện tiêu chuẩn</value></data>
+  <data name="SV_Kind_Uncategorized" xml:space="preserve"><value>Chưa phân loại</value></data>
+  <data name="SV_Kind_MissingMetadata" xml:space="preserve"><value>Thiếu siêu dữ liệu</value></data>
+  <data name="SV_Kind_MissingFile" xml:space="preserve"><value>Thiếu tệp</value></data>
+  <data name="SV_Kind_RecentlyAdded" xml:space="preserve"><value>Thêm gần đây</value></data>
+  <data name="SV_Kind_Important" xml:space="preserve"><value>Quan trọng</value></data>
+  <data name="SV_Kind_DueSoon" xml:space="preserve"><value>Sắp đến hạn</value></data>
+  <data name="SV_Field_Name" xml:space="preserve"><value>Tên</value></data>
+  <data name="SV_Field_Keyword" xml:space="preserve"><value>Từ khóa</value></data>
+  <data name="SV_Field_Subject" xml:space="preserve"><value>Danh mục</value></data>
+  <data name="SV_Field_Type" xml:space="preserve"><value>Loại</value></data>
+  <data name="SV_Field_FromDate" xml:space="preserve"><value>Ngày thêm từ</value></data>
+  <data name="SV_Field_ToDate" xml:space="preserve"><value>Ngày thêm đến</value></data>
+  <data name="SV_Field_MinSize" xml:space="preserve"><value>Kích thước tối thiểu (MB)</value></data>
+  <data name="SV_Field_MaxSize" xml:space="preserve"><value>Kích thước tối đa (MB)</value></data>
+  <data name="SV_Field_Important" xml:space="preserve"><value>Chỉ hiển thị quan trọng</value></data>
+  <data name="SV_Field_RecentDays" xml:space="preserve"><value>Khoảng thời gian (ngày)</value></data>
+  <data name="SV_Field_DeadlineDays" xml:space="preserve"><value>Số ngày hạn chót</value></data>
+  <data name="SV_Status_Applied" xml:space="preserve"><value>Đã chạy chế độ xem "{0}"</value></data>
+
+  <!-- Document Status -->
+  <data name="DS_FilterAll" xml:space="preserve"><value>Tất cả trạng thái</value></data>
+  <data name="DS_Label_Status" xml:space="preserve"><value>Trạng thái</value></data>
+  <data name="DS_Kind_Unread" xml:space="preserve"><value>Chưa đọc</value></data>
+  <data name="DS_Kind_InProgress" xml:space="preserve"><value>Đang xử lý</value></data>
+  <data name="DS_Kind_Read" xml:space="preserve"><value>Đã đọc</value></data>
+  <data name="DS_Kind_NeedsAction" xml:space="preserve"><value>Cần xử lý</value></data>
+  <data name="DS_Kind_Completed" xml:space="preserve"><value>Đã hoàn tất</value></data>
+  <data name="DS_Kind_Archived" xml:space="preserve"><value>Đã lưu trữ</value></data>
+  <data name="DS_Error_InvalidStatus" xml:space="preserve"><value>Vui lòng chọn trạng thái hợp lệ</value></data>
+  <data name="RS_StatusCounts_Title" xml:space="preserve"><value>Báo cáo theo trạng thái</value></data>
+
+  <!-- Bulk Edit -->
+  <data name="BE_SectionTitle" xml:space="preserve"><value>Chỉnh sửa hàng loạt</value></data>
+  <data name="BE_Field_Subject" xml:space="preserve"><value>Môn học</value></data>
+  <data name="BE_Field_Type" xml:space="preserve"><value>Loại</value></data>
+  <data name="BE_Field_Tags" xml:space="preserve"><value>Thẻ</value></data>
+  <data name="BE_Field_Important" xml:space="preserve"><value>Quan trọng</value></data>
+  <data name="BE_Field_Deadline" xml:space="preserve"><value>Hạn chót</value></data>
+  <data name="BE_Field_Status" xml:space="preserve"><value>Trạng thái</value></data>
+  <data name="BE_Field_CollectionAdd" xml:space="preserve"><value>Thêm vào bộ sưu tập</value></data>
+  <data name="BE_PreviewTitle" xml:space="preserve"><value>Xác nhận chỉnh sửa hàng loạt</value></data>
+  <data name="BE_PreviewAffected" xml:space="preserve"><value>Sẽ cập nhật {0} tài liệu</value></data>
+  <data name="BE_ConfirmApply" xml:space="preserve"><value>Áp dụng</value></data>
+  <data name="BE_Cancel" xml:space="preserve"><value>Hủy</value></data>
+  <data name="BE_Result_AllSuccess" xml:space="preserve"><value>Đã cập nhật {0}/{1} tài liệu</value></data>
+  <data name="BE_Result_Partial" xml:space="preserve"><value>Chỉ cập nhật được {0}/{1} tài liệu. Một số tài liệu thất bại</value></data>
+  <data name="BE_FailedItemsHeader" xml:space="preserve"><value>Tài liệu thất bại:</value></data>
+  <data name="BE_Undo" xml:space="preserve"><value>Hoàn tác</value></data>
+  <data name="BE_UndoDescription" xml:space="preserve"><value>Chỉnh sửa hàng loạt {0} tài liệu</value></data>
+  <data name="BE_Undone" xml:space="preserve"><value>Đã hoàn tác chỉnh sửa hàng loạt</value></data>
+  <data name="BE_NoSelectionHint" xml:space="preserve"><value>Vui lòng chọn ít nhất một tài liệu</value></data>
+  <data name="BE_NoFieldsEnabledHint" xml:space="preserve"><value>Bật ít nhất một trường và nhập giá trị</value></data>
+  <data name="BE_CollectionNone" xml:space="preserve"><value>(Không có bộ sưu tập)</value></data>
+
+  <!-- Undo / Affected preview -->
+  <data name="Menu_Undo" xml:space="preserve"><value>Hoàn tác</value></data>
+  <data name="UN_Applied" xml:space="preserve"><value>Đã hoàn tác: {0}</value></data>
+  <data name="UN_DeletedDocuments" xml:space="preserve"><value>Đã xóa {0} tài liệu</value></data>
+  <data name="UN_CollectionRestorable" xml:space="preserve"><value>Đã xóa bộ sưu tập '{0}' (có thể khôi phục)</value></data>
+  <data name="UN_Renamed" xml:space="preserve"><value>Đã đổi '{0}' thành '{1}'</value></data>
+  <data name="PV_DeleteCollection" xml:space="preserve"><value>Xóa bộ sưu tập này?</value></data>
+  <data name="PV_CascadeTitle" xml:space="preserve"><value>Xóa {0}?</value></data>
+  <data name="PV_MembershipNote" xml:space="preserve"><value>Sau khi xóa, có thể khôi phục bộ sưu tập và thành viên bằng Hoàn tác. Bản thân tài liệu không bị xóa.</value></data>
+  <data name="PV_RecycleBinNote" xml:space="preserve"><value>Tài liệu đã xóa có thể được khôi phục từ Thùng rác hoặc bằng Hoàn tác.</value></data>
 </root>

--- a/StudyDocumentManager/Resources/Strings.zh.resx
+++ b/StudyDocumentManager/Resources/Strings.zh.resx
@@ -850,4 +850,87 @@
   <data name="FileType_Archive" xml:space="preserve"><value>压缩包</value></data>
   <data name="FileType_Design" xml:space="preserve"><value>设计</value></data>
   <data name="FileType_Other" xml:space="preserve"><value>其他</value></data>
+
+  <!-- SmartViews View -->
+  <data name="Menu_SmartViews" xml:space="preserve"><value>智能视图</value></data>
+  <data name="SV_Title" xml:space="preserve"><value>智能视图</value></data>
+  <data name="SV_ListHeader" xml:space="preserve"><value>已保存视图列表</value></data>
+  <data name="SV_EmptyState" xml:space="preserve"><value>尚无已保存的搜索条件。点击“新建”添加</value></data>
+  <data name="SV_New" xml:space="preserve"><value>新建</value></data>
+  <data name="SV_Open" xml:space="preserve"><value>运行</value></data>
+  <data name="SV_Edit" xml:space="preserve"><value>编辑</value></data>
+  <data name="SV_Duplicate" xml:space="preserve"><value>复制</value></data>
+  <data name="SV_Delete" xml:space="preserve"><value>删除</value></data>
+  <data name="SV_DeleteConfirm" xml:space="preserve"><value>确定删除“{0}”吗？</value></data>
+  <data name="SV_NameRequired" xml:space="preserve"><value>请输入名称</value></data>
+  <data name="SV_NameExists" xml:space="preserve"><value>已存在同名的智能视图</value></data>
+  <data name="SV_Saved" xml:space="preserve"><value>智能视图已保存</value></data>
+  <data name="SV_Deleted" xml:space="preserve"><value>智能视图已删除</value></data>
+  <data name="SV_LoadError" xml:space="preserve"><value>加载智能视图失败</value></data>
+  <data name="SV_Kind_Label" xml:space="preserve"><value>条件类型</value></data>
+  <data name="SV_Kind_Standard" xml:space="preserve"><value>标准条件</value></data>
+  <data name="SV_Kind_Uncategorized" xml:space="preserve"><value>未分类</value></data>
+  <data name="SV_Kind_MissingMetadata" xml:space="preserve"><value>缺少元数据</value></data>
+  <data name="SV_Kind_MissingFile" xml:space="preserve"><value>文件缺失</value></data>
+  <data name="SV_Kind_RecentlyAdded" xml:space="preserve"><value>最近添加</value></data>
+  <data name="SV_Kind_Important" xml:space="preserve"><value>重要</value></data>
+  <data name="SV_Kind_DueSoon" xml:space="preserve"><value>即将到期</value></data>
+  <data name="SV_Field_Name" xml:space="preserve"><value>名称</value></data>
+  <data name="SV_Field_Keyword" xml:space="preserve"><value>关键词</value></data>
+  <data name="SV_Field_Subject" xml:space="preserve"><value>科目</value></data>
+  <data name="SV_Field_Type" xml:space="preserve"><value>类型</value></data>
+  <data name="SV_Field_FromDate" xml:space="preserve"><value>添加日期起</value></data>
+  <data name="SV_Field_ToDate" xml:space="preserve"><value>添加日期止</value></data>
+  <data name="SV_Field_MinSize" xml:space="preserve"><value>最小大小 (MB)</value></data>
+  <data name="SV_Field_MaxSize" xml:space="preserve"><value>最大大小 (MB)</value></data>
+  <data name="SV_Field_Important" xml:space="preserve"><value>仅显示重要</value></data>
+  <data name="SV_Field_RecentDays" xml:space="preserve"><value>时间范围（天）</value></data>
+  <data name="SV_Field_DeadlineDays" xml:space="preserve"><value>截止期限天数</value></data>
+  <data name="SV_Status_Applied" xml:space="preserve"><value>已运行智能视图“{0}”</value></data>
+
+  <!-- Document Status -->
+  <data name="DS_FilterAll" xml:space="preserve"><value>所有状态</value></data>
+  <data name="DS_Label_Status" xml:space="preserve"><value>状态</value></data>
+  <data name="DS_Kind_Unread" xml:space="preserve"><value>未读</value></data>
+  <data name="DS_Kind_InProgress" xml:space="preserve"><value>进行中</value></data>
+  <data name="DS_Kind_Read" xml:space="preserve"><value>已读</value></data>
+  <data name="DS_Kind_NeedsAction" xml:space="preserve"><value>待处理</value></data>
+  <data name="DS_Kind_Completed" xml:space="preserve"><value>已完成</value></data>
+  <data name="DS_Kind_Archived" xml:space="preserve"><value>已归档</value></data>
+  <data name="DS_Error_InvalidStatus" xml:space="preserve"><value>请选择有效的状态</value></data>
+  <data name="RS_StatusCounts_Title" xml:space="preserve"><value>按状态统计报表</value></data>
+
+  <!-- Bulk Edit -->
+  <data name="BE_SectionTitle" xml:space="preserve"><value>批量编辑</value></data>
+  <data name="BE_Field_Subject" xml:space="preserve"><value>科目</value></data>
+  <data name="BE_Field_Type" xml:space="preserve"><value>类型</value></data>
+  <data name="BE_Field_Tags" xml:space="preserve"><value>标签</value></data>
+  <data name="BE_Field_Important" xml:space="preserve"><value>重要</value></data>
+  <data name="BE_Field_Deadline" xml:space="preserve"><value>截止日期</value></data>
+  <data name="BE_Field_Status" xml:space="preserve"><value>状态</value></data>
+  <data name="BE_Field_CollectionAdd" xml:space="preserve"><value>添加到收藏集</value></data>
+  <data name="BE_PreviewTitle" xml:space="preserve"><value>确认批量编辑</value></data>
+  <data name="BE_PreviewAffected" xml:space="preserve"><value>将更新 {0} 个文档</value></data>
+  <data name="BE_ConfirmApply" xml:space="preserve"><value>应用</value></data>
+  <data name="BE_Cancel" xml:space="preserve"><value>取消</value></data>
+  <data name="BE_Result_AllSuccess" xml:space="preserve"><value>已更新 {0}/{1} 个文档</value></data>
+  <data name="BE_Result_Partial" xml:space="preserve"><value>仅更新了 {0}/{1} 个文档，部分失败</value></data>
+  <data name="BE_FailedItemsHeader" xml:space="preserve"><value>失败的文档：</value></data>
+  <data name="BE_Undo" xml:space="preserve"><value>撤销</value></data>
+  <data name="BE_UndoDescription" xml:space="preserve"><value>批量编辑了 {0} 个文档</value></data>
+  <data name="BE_Undone" xml:space="preserve"><value>已撤销批量编辑</value></data>
+  <data name="BE_NoSelectionHint" xml:space="preserve"><value>请至少选择一个文档</value></data>
+  <data name="BE_NoFieldsEnabledHint" xml:space="preserve"><value>请启用至少一个字段并填写值</value></data>
+  <data name="BE_CollectionNone" xml:space="preserve"><value>（无收藏集）</value></data>
+
+  <!-- Undo / Affected preview -->
+  <data name="Menu_Undo" xml:space="preserve"><value>撤销</value></data>
+  <data name="UN_Applied" xml:space="preserve"><value>已撤销：{0}</value></data>
+  <data name="UN_DeletedDocuments" xml:space="preserve"><value>删除了 {0} 个文档</value></data>
+  <data name="UN_CollectionRestorable" xml:space="preserve"><value>删除了收藏集“{0}”（可恢复）</value></data>
+  <data name="UN_Renamed" xml:space="preserve"><value>将“{0}”重命名为“{1}”</value></data>
+  <data name="PV_DeleteCollection" xml:space="preserve"><value>要删除此收藏集吗？</value></data>
+  <data name="PV_CascadeTitle" xml:space="preserve"><value>要删除{0}吗？</value></data>
+  <data name="PV_MembershipNote" xml:space="preserve"><value>删除后可通过“撤销”恢复收藏集及其成员。文档本身不会被删除。</value></data>
+  <data name="PV_RecycleBinNote" xml:space="preserve"><value>被删除的文档可从回收站或通过“撤销”恢复。</value></data>
 </root>

--- a/StudyDocumentManager/Services/DialogService.cs
+++ b/StudyDocumentManager/Services/DialogService.cs
@@ -264,6 +264,26 @@ public class DialogService : IDialogService, IFileDialogService, ICustomDialogSe
         return dialog.Result;
     }
 
+    public async Task<bool> ShowBulkEditPreviewAsync(int affectedCount, IReadOnlyList<(string FieldLabel, string NewValue)> changes)
+    {
+        var owner = GetMainWindow();
+        if (owner == null) return false;
+
+        var dialog = new BulkEditPreviewDialog(affectedCount, changes, _loc);
+        await dialog.ShowDialog(owner);
+        return dialog.Result == true;
+    }
+
+    public async Task<bool> ShowAffectedItemsPreviewAsync(string title, int totalCount, IReadOnlyList<string> itemNames, string reversibilityNote)
+    {
+        var owner = GetMainWindow();
+        if (owner == null) return false;
+
+        var dialog = new AffectedItemsPreviewDialog(title, totalCount, itemNames, reversibilityNote, _loc);
+        await dialog.ShowDialog(owner);
+        return dialog.Result == true;
+    }
+
     private static List<FilePickerFileType>? BuildFileFilter(string? filter)
     {
         if (string.IsNullOrEmpty(filter)) return null;

--- a/StudyDocumentManager/Services/ICustomDialogService.cs
+++ b/StudyDocumentManager/Services/ICustomDialogService.cs
@@ -15,4 +15,10 @@ public interface ICustomDialogService
         IEnumerable<int> alreadyInCollection);
 
     Task<AddDocumentDraft?> ShowAddDocumentAsync(string filePath, IList<string> subjects, IList<string> types);
+
+    Task<bool> ShowBulkEditPreviewAsync(int affectedCount, IReadOnlyList<(string FieldLabel, string NewValue)> changes)
+        => throw new NotSupportedException($"{nameof(ShowBulkEditPreviewAsync)} is not implemented by this dialog service.");
+
+    Task<bool> ShowAffectedItemsPreviewAsync(string title, int totalCount, IReadOnlyList<string> itemNames, string reversibilityNote)
+        => throw new NotSupportedException($"{nameof(ShowAffectedItemsPreviewAsync)} is not implemented by this dialog service.");
 }

--- a/StudyDocumentManager/Services/IUndoApplier.cs
+++ b/StudyDocumentManager/Services/IUndoApplier.cs
@@ -8,3 +8,9 @@ public interface IUndoApplier
 
     void ApplyLast();
 }
+
+public sealed class UndoPartialRestoreException(int restoredCount, int requestedCount) : InvalidOperationException($"Undo restored {restoredCount} of {requestedCount} documents; the rest were permanently deleted.")
+{
+    public int RestoredCount { get; } = restoredCount;
+    public int RequestedCount { get; } = requestedCount;
+}

--- a/StudyDocumentManager/Services/IUndoApplier.cs
+++ b/StudyDocumentManager/Services/IUndoApplier.cs
@@ -1,0 +1,10 @@
+namespace StudyDocumentManager.Services;
+
+public sealed record UndoApplyResult(bool Success, int AffectedCount, string DescriptionKey);
+
+public interface IUndoApplier
+{
+    bool CanUndo { get; }
+
+    void ApplyLast();
+}

--- a/StudyDocumentManager/Services/IUndoService.cs
+++ b/StudyDocumentManager/Services/IUndoService.cs
@@ -1,0 +1,30 @@
+using StudyDocumentManager.Core.Entities;
+
+namespace StudyDocumentManager.Services;
+
+public interface IUndoService
+{
+    event Action? StackChanged;
+
+    void Push(UndoEntry entry);
+
+    UndoEntry? Peek();
+
+    bool CanUndo { get; }
+
+    UndoEntry? Pop();
+
+    void Clear();
+}
+
+public sealed class UndoEntry
+{
+    public string DescriptionKey { get; set; } = string.Empty;
+    public object[]? DescriptionArgs { get; set; }
+    public IReadOnlyList<StudyDocument> Originals { get; init; } = Array.Empty<StudyDocument>();
+    public IReadOnlyList<int> DeletedIds { get; init; } = Array.Empty<int>();
+    public CollectionSnapshot? Collection { get; init; }
+    public DateTime CreatedAt { get; init; }
+}
+
+public sealed record CollectionSnapshot(string Name, string? Description, IReadOnlyList<int> MemberDocumentIds);

--- a/StudyDocumentManager/Services/IUndoService.cs
+++ b/StudyDocumentManager/Services/IUndoService.cs
@@ -23,8 +23,11 @@ public sealed class UndoEntry
     public object[]? DescriptionArgs { get; set; }
     public IReadOnlyList<StudyDocument> Originals { get; init; } = Array.Empty<StudyDocument>();
     public IReadOnlyList<int> DeletedIds { get; init; } = Array.Empty<int>();
+    public IReadOnlyList<CollectionMembership> AddedCollectionMemberships { get; init; } = Array.Empty<CollectionMembership>();
     public CollectionSnapshot? Collection { get; init; }
     public DateTime CreatedAt { get; init; }
 }
+
+public sealed record CollectionMembership(int CollectionId, int DocumentId);
 
 public sealed record CollectionSnapshot(string Name, string? Description, IReadOnlyList<int> MemberDocumentIds);

--- a/StudyDocumentManager/Services/NavigationService.cs
+++ b/StudyDocumentManager/Services/NavigationService.cs
@@ -1,4 +1,5 @@
-﻿using StudyDocumentManager.Core.Interfaces;
+﻿using StudyDocumentManager.Core.Entities;
+using StudyDocumentManager.Core.Interfaces;
 using StudyDocumentManager.Models;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -44,6 +45,8 @@ public class NavigationService(IServiceProvider serviceProvider) : INavigationSe
             "treemap" => serviceProvider.GetRequiredService<TreeMapModel>(),
             "personal-note" => CreatePersonalNoteModel(parameter),
             "related-docs" => CreateRelatedDocsModel(parameter),
+            "smartviews" or "smart-views" or "savedsearches" => serviceProvider.GetRequiredService<SmartViewsModel>(),
+            "run-smartview" => CreateDashboardWithSavedSearch(parameter),
             _ => serviceProvider.GetRequiredService<DashboardModel>(),
         };
 
@@ -86,6 +89,21 @@ public class NavigationService(IServiceProvider serviceProvider) : INavigationSe
         if (parameter is (int docId, string docName))
         {
             vm.Load(docId, docName);
+        }
+        return vm;
+    }
+
+    private DashboardModel CreateDashboardWithSavedSearch(object? parameter)
+    {
+        var vm = serviceProvider.GetRequiredService<DashboardModel>();
+        if (parameter is int savedSearchId)
+        {
+            var savedSearch = serviceProvider.GetRequiredService<ISavedSearchRepository>().GetById(savedSearchId);
+            var criteria = savedSearch == null ? null : SavedSearchCriteria.FromJson(savedSearch.CriteriaJson);
+            if (criteria != null)
+            {
+                vm.ApplySavedSearch(criteria);
+            }
         }
         return vm;
     }

--- a/StudyDocumentManager/Services/UndoApplier.cs
+++ b/StudyDocumentManager/Services/UndoApplier.cs
@@ -52,16 +52,36 @@ public sealed class UndoApplier : IUndoApplier
         }
         else
         {
-            foreach (var original in entry.Originals)
-            {
-                if (!_documents.Update(original))
-                    throw new InvalidOperationException("Undo document restoration failed.");
-            }
+            var currentDocuments = entry.Originals
+                .Select(original => (Original: original, Current: _documents.GetById(original.Id)))
+                .ToList();
+            var updatedDocuments = new List<StudyDocument>();
+            var removedMemberships = new List<CollectionMembership>();
 
-            foreach (var membership in entry.AddedCollectionMemberships)
+            try
             {
-                if (!_collections.RemoveDocument(membership.CollectionId, membership.DocumentId))
-                    throw new InvalidOperationException("Undo collection membership removal failed.");
+                foreach (var item in currentDocuments)
+                {
+                    if (!_documents.Update(item.Original))
+                        throw new InvalidOperationException("Undo document restoration failed.");
+                    updatedDocuments.Add(item.Original);
+                }
+
+                foreach (var membership in entry.AddedCollectionMemberships)
+                {
+                    if (!_collections.RemoveDocument(membership.CollectionId, membership.DocumentId))
+                        throw new InvalidOperationException("Undo collection membership removal failed.");
+                    removedMemberships.Add(membership);
+                }
+            }
+            catch
+            {
+                foreach (var item in currentDocuments.Where(item => item.Current != null && updatedDocuments.Contains(item.Original)))
+                    _documents.Update(item.Current!);
+
+                foreach (var membership in removedMemberships)
+                    _collections.AddDocument(membership.CollectionId, membership.DocumentId);
+                throw;
             }
         }
 

--- a/StudyDocumentManager/Services/UndoApplier.cs
+++ b/StudyDocumentManager/Services/UndoApplier.cs
@@ -74,13 +74,39 @@ public sealed class UndoApplier : IUndoApplier
                     removedMemberships.Add(membership);
                 }
             }
-            catch
+            catch (Exception undoFailure)
             {
+                Exception? compensationFailure = null;
+
                 foreach (var item in currentDocuments.Where(item => item.Current != null && updatedDocuments.Contains(item.Original)))
-                    _documents.Update(item.Current!);
+                {
+                    try
+                    {
+                        if (!_documents.Update(item.Current!))
+                            compensationFailure ??= new InvalidOperationException("Undo document compensation failed.");
+                    }
+                    catch (Exception exception)
+                    {
+                        compensationFailure ??= exception;
+                    }
+                }
 
                 foreach (var membership in removedMemberships)
-                    _collections.AddDocument(membership.CollectionId, membership.DocumentId);
+                {
+                    try
+                    {
+                        if (!_collections.AddDocument(membership.CollectionId, membership.DocumentId))
+                            compensationFailure ??= new InvalidOperationException("Undo collection membership compensation failed.");
+                    }
+                    catch (Exception exception)
+                    {
+                        compensationFailure ??= exception;
+                    }
+                }
+
+                if (compensationFailure != null)
+                    throw new InvalidOperationException("Undo compensation did not complete.", new AggregateException(undoFailure, compensationFailure));
+
                 throw;
             }
         }

--- a/StudyDocumentManager/Services/UndoApplier.cs
+++ b/StudyDocumentManager/Services/UndoApplier.cs
@@ -22,22 +22,49 @@ public sealed class UndoApplier : IUndoApplier
 
     public void ApplyLast()
     {
-        var entry = _undo.Pop() ?? throw new InvalidOperationException("Nothing to undo.");
+        var entry = _undo.Peek() ?? throw new InvalidOperationException("Nothing to undo.");
 
         if (entry.DeletedIds.Count > 0)
         {
-            _recycleBin.RestoreDocuments(entry.DeletedIds);
+            var restored = _recycleBin.RestoreDocuments(entry.DeletedIds);
+            if (restored != entry.DeletedIds.Count)
+                throw new InvalidOperationException("Undo restore did not restore every document.");
         }
         else if (entry.Collection is { } snapshot)
         {
             var collectionId = _collections.Create(snapshot.Name, snapshot.Description);
-            foreach (var documentId in snapshot.MemberDocumentIds)
-                _collections.AddDocument(collectionId, documentId);
+            if (collectionId <= 0)
+                throw new InvalidOperationException("Undo collection recreation failed.");
+
+            try
+            {
+                foreach (var documentId in snapshot.MemberDocumentIds)
+                {
+                    if (!_collections.AddDocument(collectionId, documentId))
+                        throw new InvalidOperationException("Undo collection membership restoration failed.");
+                }
+            }
+            catch
+            {
+                _collections.Delete(collectionId);
+                throw;
+            }
         }
         else
         {
             foreach (var original in entry.Originals)
-                _documents.Update(original);
+            {
+                if (!_documents.Update(original))
+                    throw new InvalidOperationException("Undo document restoration failed.");
+            }
+
+            foreach (var membership in entry.AddedCollectionMemberships)
+            {
+                if (!_collections.RemoveDocument(membership.CollectionId, membership.DocumentId))
+                    throw new InvalidOperationException("Undo collection membership removal failed.");
+            }
         }
+
+        _undo.Pop();
     }
 }

--- a/StudyDocumentManager/Services/UndoApplier.cs
+++ b/StudyDocumentManager/Services/UndoApplier.cs
@@ -28,7 +28,9 @@ public sealed class UndoApplier : IUndoApplier
 
         if (entry.DeletedIds.Count > 0)
         {
-            _recycleBin.RestoreDocuments(entry.DeletedIds);
+            var restored = _recycleBin.RestoreDocuments(entry.DeletedIds);
+            if (restored != entry.DeletedIds.Count)
+                throw new InvalidOperationException("Undo delete restore incomplete; entry kept for retry.");
         }
         else if (entry.Collection is { } snapshot)
         {

--- a/StudyDocumentManager/Services/UndoApplier.cs
+++ b/StudyDocumentManager/Services/UndoApplier.cs
@@ -9,13 +9,15 @@ public sealed class UndoApplier : IUndoApplier
     private readonly IDocumentRepository _documents;
     private readonly IRecycleBinRepository _recycleBin;
     private readonly ICollectionRepository _collections;
+    private readonly IUndoRepository? _undoRepository;
 
-    public UndoApplier(IUndoService undo, IDocumentRepository documents, IRecycleBinRepository recycleBin, ICollectionRepository collections)
+    public UndoApplier(IUndoService undo, IDocumentRepository documents, IRecycleBinRepository recycleBin, ICollectionRepository collections, IUndoRepository? undoRepository = null)
     {
         _undo = undo;
         _documents = documents;
         _recycleBin = recycleBin;
         _collections = collections;
+        _undoRepository = undoRepository;
     }
 
     public bool CanUndo => _undo.CanUndo;
@@ -52,6 +54,15 @@ public sealed class UndoApplier : IUndoApplier
         }
         else
         {
+            if (_undoRepository != null)
+            {
+                _undoRepository.ApplyMetadataUndo(
+                    entry.Originals,
+                    entry.AddedCollectionMemberships.Select(membership => (membership.CollectionId, membership.DocumentId)).ToList());
+                _undo.Pop();
+                return;
+            }
+
             var currentDocuments = entry.Originals
                 .Select(original => (Original: original, Current: _documents.GetById(original.Id)))
                 .ToList();

--- a/StudyDocumentManager/Services/UndoApplier.cs
+++ b/StudyDocumentManager/Services/UndoApplier.cs
@@ -28,9 +28,7 @@ public sealed class UndoApplier : IUndoApplier
 
         if (entry.DeletedIds.Count > 0)
         {
-            var restored = _recycleBin.RestoreDocuments(entry.DeletedIds);
-            if (restored != entry.DeletedIds.Count)
-                throw new InvalidOperationException("Undo restore did not restore every document.");
+            _recycleBin.RestoreDocuments(entry.DeletedIds);
         }
         else if (entry.Collection is { } snapshot)
         {
@@ -73,6 +71,8 @@ public sealed class UndoApplier : IUndoApplier
             {
                 foreach (var item in currentDocuments)
                 {
+                    if (item.Current == null)
+                        continue;
                     if (!_documents.Update(item.Original))
                         throw new InvalidOperationException("Undo document restoration failed.");
                     updatedDocuments.Add(item.Original);
@@ -80,9 +80,8 @@ public sealed class UndoApplier : IUndoApplier
 
                 foreach (var membership in entry.AddedCollectionMemberships)
                 {
-                    if (!_collections.RemoveDocument(membership.CollectionId, membership.DocumentId))
-                        throw new InvalidOperationException("Undo collection membership removal failed.");
-                    removedMemberships.Add(membership);
+                    if (_collections.RemoveDocument(membership.CollectionId, membership.DocumentId))
+                        removedMemberships.Add(membership);
                 }
             }
             catch (Exception undoFailure)

--- a/StudyDocumentManager/Services/UndoApplier.cs
+++ b/StudyDocumentManager/Services/UndoApplier.cs
@@ -28,9 +28,15 @@ public sealed class UndoApplier : IUndoApplier
 
         if (entry.DeletedIds.Count > 0)
         {
+            var requested = entry.DeletedIds.Count;
             var restored = _recycleBin.RestoreDocuments(entry.DeletedIds);
-            if (restored != entry.DeletedIds.Count)
-                throw new InvalidOperationException("Undo delete restore incomplete; entry kept for retry.");
+            if (restored == 0)
+                throw new InvalidOperationException("Undo delete restore failed; entry kept for retry.");
+            if (restored < requested)
+            {
+                _undo.Pop();
+                throw new UndoPartialRestoreException(restored, requested);
+            }
         }
         else if (entry.Collection is { } snapshot)
         {

--- a/StudyDocumentManager/Services/UndoApplier.cs
+++ b/StudyDocumentManager/Services/UndoApplier.cs
@@ -1,0 +1,43 @@
+using StudyDocumentManager.Core.Entities;
+using StudyDocumentManager.Core.Interfaces;
+
+namespace StudyDocumentManager.Services;
+
+public sealed class UndoApplier : IUndoApplier
+{
+    private readonly IUndoService _undo;
+    private readonly IDocumentRepository _documents;
+    private readonly IRecycleBinRepository _recycleBin;
+    private readonly ICollectionRepository _collections;
+
+    public UndoApplier(IUndoService undo, IDocumentRepository documents, IRecycleBinRepository recycleBin, ICollectionRepository collections)
+    {
+        _undo = undo;
+        _documents = documents;
+        _recycleBin = recycleBin;
+        _collections = collections;
+    }
+
+    public bool CanUndo => _undo.CanUndo;
+
+    public void ApplyLast()
+    {
+        var entry = _undo.Pop() ?? throw new InvalidOperationException("Nothing to undo.");
+
+        if (entry.DeletedIds.Count > 0)
+        {
+            _recycleBin.RestoreDocuments(entry.DeletedIds);
+        }
+        else if (entry.Collection is { } snapshot)
+        {
+            var collectionId = _collections.Create(snapshot.Name, snapshot.Description);
+            foreach (var documentId in snapshot.MemberDocumentIds)
+                _collections.AddDocument(collectionId, documentId);
+        }
+        else
+        {
+            foreach (var original in entry.Originals)
+                _documents.Update(original);
+        }
+    }
+}

--- a/StudyDocumentManager/Services/UndoService.cs
+++ b/StudyDocumentManager/Services/UndoService.cs
@@ -1,0 +1,59 @@
+namespace StudyDocumentManager.Services;
+
+public sealed class UndoService : IUndoService
+{
+    private const int MaxEntries = 10;
+
+    private readonly object _gate = new();
+    private readonly List<UndoEntry> _entries = [];
+
+    public event Action? StackChanged;
+
+    public bool CanUndo
+    {
+        get { lock (_gate) return _entries.Count > 0; }
+    }
+
+    public void Push(UndoEntry entry)
+    {
+        lock (_gate)
+        {
+            _entries.Add(entry);
+            if (_entries.Count > MaxEntries)
+                _entries.RemoveAt(0);
+        }
+        StackChanged?.Invoke();
+    }
+
+    public UndoEntry? Peek()
+    {
+        lock (_gate)
+            return _entries.Count > 0 ? _entries[^1] : null;
+    }
+
+    public UndoEntry? Pop()
+    {
+        UndoEntry? entry;
+        lock (_gate)
+        {
+            if (_entries.Count == 0)
+                return null;
+
+            entry = _entries[^1];
+            _entries.RemoveAt(_entries.Count - 1);
+        }
+        StackChanged?.Invoke();
+        return entry;
+    }
+
+    public void Clear()
+    {
+        lock (_gate)
+        {
+            if (_entries.Count == 0)
+                return;
+            _entries.Clear();
+        }
+        StackChanged?.Invoke();
+    }
+}

--- a/StudyDocumentManager/Views/AddEdit.axaml
+++ b/StudyDocumentManager/Views/AddEdit.axaml
@@ -119,9 +119,9 @@
                                        FontSize="{StaticResource FontSizeMd}"
                                        FontWeight="SemiBold"
                                        Foreground="{StaticResource TextPrimary}"/>
-                            <TextBox x:Name="txtNotes"
-                                     Text="{Binding Notes, Mode=TwoWay}"
-                                     TabIndex="10"
+                             <TextBox x:Name="txtNotes"
+                                      Text="{Binding Notes, Mode=TwoWay}"
+                                      TabIndex="10"
                                      AutomationProperties.Name="{loc:Localize AddEdit_LblNotes}"
                                      FontSize="{StaticResource FontSizeMd}"
                                      Watermark="{loc:Localize AddEdit_PlaceholderNotes}"
@@ -214,38 +214,75 @@
                         <Grid x:Name="deadlineImportantFields"
                               Grid.Column="1"
                               Grid.Row="2"
-                              ColumnDefinitions="*,Auto,Auto"
+                              RowDefinitions="Auto,Auto"
                               Margin="12,4,0,0">
-                            <Border Grid.Column="1"
-                                    Width="{StaticResource Space5}"/>
-                            <StackPanel Grid.Column="0"
-                                        Spacing="{StaticResource Space1}">
-                                <TextBlock Text="{loc:Localize AddEdit_LblDeadline}"
-                                           FontSize="{StaticResource FontSizeMd}"
-                                           FontWeight="SemiBold"
-                                           Foreground="{StaticResource TextPrimary}"/>
-                                <DatePicker x:Name="dateDeadline"
-                                            SelectedDate="{Binding Deadline, Mode=TwoWay}"
-                                            TabIndex="8"
-                                            IsTabStop="True"
-                                            Focusable="True"
-                                            AutomationProperties.Name="{loc:Localize AddEdit_LblDeadline}"
-                                            FontSize="{StaticResource FontSizeMd}"
-                                            YearFormat="{loc:Localize AddEdit_DateYearFormat}"
-                                            MonthFormat="{loc:Localize AddEdit_DateMonthFormat}"
-                                            DayFormat="{loc:Localize AddEdit_DateDayFormat}"
-                                            HorizontalAlignment="Stretch"/>
-                            </StackPanel>
-                            <StackPanel Grid.Column="2"
-                                        VerticalAlignment="Bottom">
-                                <CheckBox x:Name="chkImportant"
-                                          Content="{loc:Localize AddEdit_ChkImportant}"
-                                          TabIndex="9"
-                                          AutomationProperties.Name="{loc:Localize AddEdit_ChkImportant}"
-                                          FontSize="{StaticResource FontSizeMd}"
-                                          IsChecked="{Binding IsImportant, Mode=TwoWay}"/>
-                                <Border Height="{StaticResource Space1}"/>
-                            </StackPanel>
+                            <Grid Grid.Row="0"
+                                  ColumnDefinitions="*,Auto,Auto">
+                                <Border Grid.Column="1"
+                                        Width="{StaticResource Space5}"/>
+                                <StackPanel Grid.Column="0"
+                                            Spacing="{StaticResource Space1}">
+                                    <TextBlock Text="{loc:Localize AddEdit_LblDeadline}"
+                                               FontSize="{StaticResource FontSizeMd}"
+                                               FontWeight="SemiBold"
+                                               Foreground="{StaticResource TextPrimary}"/>
+                                    <DatePicker x:Name="dateDeadline"
+                                                SelectedDate="{Binding Deadline, Mode=TwoWay}"
+                                                TabIndex="8"
+                                                IsTabStop="True"
+                                                Focusable="True"
+                                                AutomationProperties.Name="{loc:Localize AddEdit_LblDeadline}"
+                                                FontSize="{StaticResource FontSizeMd}"
+                                                YearFormat="{loc:Localize AddEdit_DateYearFormat}"
+                                                MonthFormat="{loc:Localize AddEdit_DateMonthFormat}"
+                                                DayFormat="{loc:Localize AddEdit_DateDayFormat}"
+                                                HorizontalAlignment="Stretch"/>
+                                </StackPanel>
+                                <StackPanel Grid.Column="2"
+                                            VerticalAlignment="Bottom">
+                                    <CheckBox x:Name="chkImportant"
+                                              Content="{loc:Localize AddEdit_ChkImportant}"
+                                              TabIndex="9"
+                                              AutomationProperties.Name="{loc:Localize AddEdit_ChkImportant}"
+                                              FontSize="{StaticResource FontSizeMd}"
+                                              IsChecked="{Binding IsImportant, Mode=TwoWay}"/>
+                                    <Border Height="{StaticResource Space1}"/>
+                                </StackPanel>
+                            </Grid>
+
+                            <Grid x:Name="statusFields"
+                                  Grid.Row="1"
+                                  ColumnDefinitions="*,Auto,*"
+                                  Margin="0,4,0,0">
+                                <Border Grid.Column="1"
+                                        Width="{StaticResource Space5}"/>
+                                <StackPanel Grid.Column="0"
+                                            Spacing="{StaticResource Space1}">
+                                    <TextBlock Text="{loc:Localize DS_Label_Status}"
+                                               FontSize="{StaticResource FontSizeMd}"
+                                               FontWeight="SemiBold"
+                                               Foreground="{StaticResource TextPrimary}"/>
+                                    <ComboBox x:Name="cmbStatus"
+                                              TabIndex="13"
+                                              AutomationProperties.Name="{loc:Localize DS_Label_Status}"
+                                              FontSize="{StaticResource FontSizeMd}"
+                                              Height="32"
+                                              HorizontalAlignment="Stretch">
+                                        <ComboBox.ItemTemplate>
+                                            <DataTemplate>
+                                                <TextBlock Text="{Binding Display}"/>
+                                            </DataTemplate>
+                                        </ComboBox.ItemTemplate>
+                                    </ComboBox>
+                                    <TextBlock x:Name="txtStatusError"
+                                               Text="{Binding StatusValidationMessage}"
+                                               IsVisible="{Binding HasStatusValidationError}"
+                                               AutomationProperties.Name="{Binding StatusValidationMessage}"
+                                               AutomationProperties.LiveSetting="Polite"
+                                               Foreground="{StaticResource DangerBrush}"
+                                               FontSize="{StaticResource FontSizeSm}"/>
+                                </StackPanel>
+                            </Grid>
                         </Grid>
                     </Grid>
                 </Border>

--- a/StudyDocumentManager/Views/AddEdit.axaml.cs
+++ b/StudyDocumentManager/Views/AddEdit.axaml.cs
@@ -8,6 +8,7 @@ public partial class AddEdit : UserControl
 {
     private AddEditModel? _model;
     private bool _propertyChangedSubscribed;
+    private bool _syncingStatus;
 
     public AddEdit()
     {
@@ -16,6 +17,12 @@ public partial class AddEdit : UserControl
         AttachedToVisualTree += OnAttachedToVisualTree;
         DetachedFromVisualTree += OnDetachedFromVisualTree;
         SizeChanged += OnSizeChanged;
+        cmbStatus.SelectionChanged += (_, _) =>
+        {
+            if (_syncingStatus || cmbStatus.SelectedItem is not StatusOption option) return;
+            if (_model != null)
+                _model.SelectedStatus = option.Value;
+        };
     }
 
     private void OnSizeChanged(object? sender, SizeChangedEventArgs e)
@@ -85,6 +92,7 @@ public partial class AddEdit : UserControl
 
         _model.PropertyChanged += OnModelPropertyChanged;
         _propertyChangedSubscribed = true;
+        SyncStatusCombo(_model);
     }
 
     private void DetachModelHandlers()
@@ -106,6 +114,27 @@ public partial class AddEdit : UserControl
             && sender is AddEditModel { HasNameValidationError: true })
         {
             this.FindControl<TextBox>("txtName")?.Focus();
+        }
+        else if (e.PropertyName is nameof(AddEditModel.StatusOptions) or nameof(AddEditModel.SelectedStatus))
+        {
+            SyncStatusCombo(sender as AddEditModel);
+        }
+    }
+
+    private void SyncStatusCombo(AddEditModel? model)
+    {
+        if (model is null)
+            return;
+
+        _syncingStatus = true;
+        try
+        {
+            cmbStatus.ItemsSource = model.StatusOptions;
+            cmbStatus.SelectedItem = model.StatusOptions.FirstOrDefault(o => o.Value == model.SelectedStatus);
+        }
+        finally
+        {
+            _syncingStatus = false;
         }
     }
 }

--- a/StudyDocumentManager/Views/AffectedItemsPreviewDialog.axaml
+++ b/StudyDocumentManager/Views/AffectedItemsPreviewDialog.axaml
@@ -1,0 +1,62 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="using:StudyDocumentManager.Markup"
+        x:Class="StudyDocumentManager.Views.AffectedItemsPreviewDialog"
+        AutomationProperties.AutomationId="Dialog_AffectedItemsPreview"
+        Width="420" MaxHeight="520" SizeToContent="Height"
+        WindowStartupLocation="CenterOwner"
+        CanResize="True"
+        ShowInTaskbar="False"
+        Background="{StaticResource ContentBackground}">
+    <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+        <StackPanel Margin="24" Spacing="12">
+
+            <TextBlock x:Name="TitleText"
+                       AutomationProperties.AutomationId="AffectedPreview_Title"
+                       FontSize="{StaticResource FontSizeMd}" FontWeight="SemiBold"
+                       Foreground="{StaticResource TextPrimary}"
+                       TextWrapping="Wrap"/>
+
+            <Border Background="{StaticResource SidebarBackground}" CornerRadius="{StaticResource RadiusSm}"
+                    Padding="10,8">
+                <TextBlock x:Name="AffectedNote"
+                           AutomationProperties.AutomationId="AffectedPreview_Affected"
+                           FontSize="{StaticResource FontSizeSm}" FontWeight="SemiBold"
+                           Foreground="{StaticResource TextPrimary}"
+                           TextWrapping="Wrap"/>
+            </Border>
+
+            <ListBox x:Name="ItemsList"
+                     AutomationProperties.AutomationId="AffectedPreview_Items"
+                     MaxHeight="240"
+                     FontSize="{StaticResource FontSizeSm}"
+                     Foreground="{StaticResource TextSecondary}"/>
+
+            <Border Background="{StaticResource SidebarBackground}" CornerRadius="{StaticResource RadiusSm}"
+                    Padding="10,8">
+                <TextBlock x:Name="ReversibilityNote"
+                           AutomationProperties.AutomationId="AffectedPreview_Note"
+                           FontSize="{StaticResource FontSizeXs}"
+                           Foreground="{StaticResource TextMuted}"
+                           TextWrapping="Wrap"/>
+            </Border>
+
+            <StackPanel Orientation="Horizontal"
+                        HorizontalAlignment="Right"
+                        Spacing="8" Margin="0,8,0,0">
+                <Button x:Name="ConfirmButton"
+                        AutomationProperties.AutomationId="AffectedPreview_Confirm"
+                        Classes="danger"
+                        MinWidth="110"
+                        HorizontalContentAlignment="Center"/>
+                <Button x:Name="CancelButton"
+                        AutomationProperties.AutomationId="AffectedPreview_Cancel"
+                        Content="{loc:Localize BE_Cancel}"
+                        Classes="secondary"
+                        IsCancel="True"
+                        MinWidth="80"
+                        HorizontalContentAlignment="Center"/>
+            </StackPanel>
+        </StackPanel>
+    </ScrollViewer>
+</Window>

--- a/StudyDocumentManager/Views/AffectedItemsPreviewDialog.axaml.cs
+++ b/StudyDocumentManager/Views/AffectedItemsPreviewDialog.axaml.cs
@@ -1,0 +1,57 @@
+using Avalonia.Controls;
+using StudyDocumentManager.Core.Interfaces;
+
+namespace StudyDocumentManager.Views;
+
+public partial class AffectedItemsPreviewDialog : Window
+{
+    public bool? Result { get; private set; }
+
+    private readonly ILocalizationService? _loc;
+    private readonly int _totalCount;
+
+    public AffectedItemsPreviewDialog() { } // XAML loader
+
+    public AffectedItemsPreviewDialog(string title, int totalCount, IReadOnlyList<string> itemNames, string reversibilityNote, ILocalizationService? loc = null)
+    {
+        InitializeComponent();
+
+        _loc = loc;
+        _totalCount = totalCount;
+        Title = title;
+        this.FindControl<TextBlock>("TitleText")!.Text = title;
+        this.FindControl<TextBlock>("ReversibilityNote")!.Text = reversibilityNote;
+        UpdateAffectedNote();
+        if (_loc != null)
+        {
+            _loc.LanguageChanged += OnLanguageChanged;
+            Closed += (_, _) => _loc.LanguageChanged -= OnLanguageChanged;
+        }
+
+        this.FindControl<ListBox>("ItemsList")!.ItemsSource = itemNames.ToList();
+
+        var confirmButton = this.FindControl<Button>("ConfirmButton")!;
+        confirmButton.Content = _loc == null ? "OK" : _loc["Action_Delete"];
+        confirmButton.Click += (_, _) => { Result = true; Close(); };
+        this.FindControl<Button>("CancelButton")!.Click += (_, _) => { Result = false; Close(); };
+    }
+
+    private void OnLanguageChanged(object? sender, EventArgs e)
+    {
+        UpdateAffectedNote();
+        var confirmButton = this.FindControl<Button>("ConfirmButton");
+        if (confirmButton != null && _loc != null)
+            confirmButton.Content = _loc["Action_Delete"];
+    }
+
+    private void UpdateAffectedNote()
+    {
+        var note = this.FindControl<TextBlock>("AffectedNote");
+        if (note == null)
+            return;
+
+        note.Text = _loc == null
+            ? $"Documents: {_totalCount}"
+            : string.Format(_loc["BE_PreviewAffected"], _totalCount);
+    }
+}

--- a/StudyDocumentManager/Views/BulkDelete.axaml
+++ b/StudyDocumentManager/Views/BulkDelete.axaml
@@ -38,6 +38,15 @@
 
                     <Border Width="1" Height="20" Background="{StaticResource CardBorder}" Margin="4,0"/>
 
+                    <Button Classes="secondary" Command="{Binding UndoLastCommand}"
+                            AutomationProperties.AutomationId="BulkDelete_Undo"
+                            AutomationProperties.Name="{loc:Localize BE_Undo}"
+                            Padding="12,5">
+                        <TextBlock Text="{loc:Localize BE_Undo}" FontSize="{StaticResource FontSizeSm}"/>
+                    </Button>
+
+                    <Border Width="1" Height="20" Background="{StaticResource CardBorder}" Margin="4,0"/>
+
                     <TextBlock Text="{loc:Localize AddEdit_LblSubject}" FontSize="{StaticResource FontSizeSm}" VerticalAlignment="Center"
                                Foreground="{StaticResource TextSecondary}"/>
                     <ComboBox Name="cboSubject" Width="130" FontSize="{StaticResource FontSizeSm}" Height="28" VerticalAlignment="Center"/>
@@ -47,6 +56,97 @@
                     <ComboBox Name="cboType" Width="110" FontSize="{StaticResource FontSizeSm}" Height="28" VerticalAlignment="Center"/>
                     </StackPanel>
                 </ScrollViewer>
+            </Border>
+
+            <Border DockPanel.Dock="Top" Background="{StaticResource CardBackground}" CornerRadius="{StaticResource RadiusMd}"
+                    BorderBrush="{StaticResource CardBorder}" BorderThickness="1"
+                    Padding="{StaticResource PaddingMd}" Margin="0,0,0,12">
+                <Expander Header="{loc:Localize BE_SectionTitle}" IsExpanded="False"
+                          HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
+                    <UniformGrid Columns="2" Margin="0,8,0,0">
+                        <StackPanel Spacing="{StaticResource Space1}" Margin="0,0,12,8">
+                            <CheckBox AutomationProperties.AutomationId="BulkEdit_EnableSubject"
+                                      Content="{loc:Localize BE_Field_Subject}"
+                                      IsChecked="{Binding EnableSubject}"/>
+                            <TextBox Height="28" Text="{Binding NewSubject, Mode=TwoWay}"
+                                     IsEnabled="{Binding EnableSubject}"
+                                     AutomationProperties.AutomationId="BulkEdit_NewSubject"
+                                     AutomationProperties.Name="{loc:Localize BE_Field_Subject}"/>
+                        </StackPanel>
+                        <StackPanel Spacing="{StaticResource Space1}" Margin="0,0,0,8">
+                            <CheckBox AutomationProperties.AutomationId="BulkEdit_EnableType"
+                                      Content="{loc:Localize BE_Field_Type}"
+                                      IsChecked="{Binding EnableType}"/>
+                            <TextBox Height="28" Text="{Binding NewType, Mode=TwoWay}"
+                                     IsEnabled="{Binding EnableType}"
+                                     AutomationProperties.AutomationId="BulkEdit_NewType"
+                                     AutomationProperties.Name="{loc:Localize BE_Field_Type}"/>
+                        </StackPanel>
+                        <StackPanel Spacing="{StaticResource Space1}" Margin="0,0,12,8">
+                            <CheckBox AutomationProperties.AutomationId="BulkEdit_EnableTags"
+                                      Content="{loc:Localize BE_Field_Tags}"
+                                      IsChecked="{Binding EnableTags}"/>
+                            <TextBox Height="28" Text="{Binding NewTags, Mode=TwoWay}"
+                                     IsEnabled="{Binding EnableTags}"
+                                     AutomationProperties.AutomationId="BulkEdit_NewTags"
+                                     AutomationProperties.Name="{loc:Localize BE_Field_Tags}"/>
+                        </StackPanel>
+                        <StackPanel Spacing="{StaticResource Space1}" Margin="0,0,0,8">
+                            <CheckBox AutomationProperties.AutomationId="BulkEdit_EnableImportant"
+                                      Content="{loc:Localize BE_Field_Important}"
+                                      IsChecked="{Binding EnableImportant}"/>
+                            <CheckBox AutomationProperties.AutomationId="BulkEdit_NewImportant"
+                                      Content="{loc:Localize Dashboard_CsvYes}"
+                                      IsChecked="{Binding NewImportant, Mode=TwoWay}"
+                                      IsEnabled="{Binding EnableImportant}"
+                                      Margin="16,0,0,0"/>
+                        </StackPanel>
+                        <StackPanel Spacing="{StaticResource Space1}" Margin="0,0,12,8">
+                            <CheckBox AutomationProperties.AutomationId="BulkEdit_EnableDeadline"
+                                      Content="{loc:Localize BE_Field_Deadline}"
+                                      IsChecked="{Binding EnableDeadline}"/>
+                            <DatePicker SelectedDate="{Binding NewDeadline}"
+                                        IsEnabled="{Binding EnableDeadline}"
+                                        HorizontalAlignment="Stretch"
+                                        AutomationProperties.AutomationId="BulkEdit_NewDeadline"
+                                        AutomationProperties.Name="{loc:Localize BE_Field_Deadline}"/>
+                        </StackPanel>
+                        <StackPanel Spacing="{StaticResource Space1}" Margin="0,0,0,8">
+                            <CheckBox AutomationProperties.AutomationId="BulkEdit_EnableStatus"
+                                      Content="{loc:Localize BE_Field_Status}"
+                                      IsChecked="{Binding EnableStatus}"/>
+                            <ComboBox ItemsSource="{Binding StatusOptions}"
+                                      SelectedItem="{Binding SelectedStatusOption}"
+                                      IsEnabled="{Binding EnableStatus}"
+                                      HorizontalAlignment="Stretch"
+                                      AutomationProperties.AutomationId="BulkEdit_NewStatus"
+                                      AutomationProperties.Name="{loc:Localize BE_Field_Status}">
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding Display}"/>
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                            </ComboBox>
+                        </StackPanel>
+                        <StackPanel Spacing="{StaticResource Space1}" Margin="0,0,12,0">
+                            <CheckBox AutomationProperties.AutomationId="BulkEdit_EnableCollectionAdd"
+                                      Content="{loc:Localize BE_Field_CollectionAdd}"
+                                      IsChecked="{Binding EnableCollectionAdd}"/>
+                            <ComboBox ItemsSource="{Binding CollectionOptions}"
+                                      SelectedItem="{Binding SelectedCollectionOption}"
+                                      IsEnabled="{Binding EnableCollectionAdd}"
+                                      HorizontalAlignment="Stretch"
+                                      AutomationProperties.AutomationId="BulkEdit_NewCollection"
+                                      AutomationProperties.Name="{loc:Localize BE_Field_CollectionAdd}">
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding Label}"/>
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                            </ComboBox>
+                        </StackPanel>
+                    </UniformGrid>
+                </Expander>
             </Border>
 
             <Border DockPanel.Dock="Bottom" Background="{StaticResource SidebarBackground}"

--- a/StudyDocumentManager/Views/BulkDelete.axaml
+++ b/StudyDocumentManager/Views/BulkDelete.axaml
@@ -63,7 +63,8 @@
                     Padding="{StaticResource PaddingMd}" Margin="0,0,0,12">
                 <Expander Header="{loc:Localize BE_SectionTitle}" IsExpanded="False"
                           HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
-                    <UniformGrid Columns="2" Margin="0,8,0,0">
+                    <StackPanel>
+                        <UniformGrid Columns="2" Margin="0,8,0,0">
                         <StackPanel Spacing="{StaticResource Space1}" Margin="0,0,12,8">
                             <CheckBox AutomationProperties.AutomationId="BulkEdit_EnableSubject"
                                       Content="{loc:Localize BE_Field_Subject}"
@@ -145,7 +146,18 @@
                                 </ComboBox.ItemTemplate>
                             </ComboBox>
                         </StackPanel>
-                    </UniformGrid>
+                        </UniformGrid>
+                        <Button Classes="primary"
+                                AutomationProperties.AutomationId="BulkEdit_Apply"
+                                AutomationProperties.Name="{loc:Localize BE_ConfirmApply}"
+                                Command="{Binding ApplyBulkEditCommand}"
+                                Margin="0,12,0,0" Padding="{StaticResource PaddingBtnMd}" HorizontalAlignment="Left">
+                            <StackPanel Orientation="Horizontal" Spacing="4">
+                                <Image Source="{StaticResource IconCheck}" Width="14" Height="14"/>
+                                <TextBlock Text="{loc:Localize BE_ConfirmApply}" FontSize="{StaticResource FontSizeSm}" FontWeight="SemiBold"/>
+                            </StackPanel>
+                        </Button>
+                    </StackPanel>
                 </Expander>
             </Border>
 

--- a/StudyDocumentManager/Views/BulkEditPreviewDialog.axaml
+++ b/StudyDocumentManager/Views/BulkEditPreviewDialog.axaml
@@ -1,0 +1,64 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="using:StudyDocumentManager.Markup"
+        x:Class="StudyDocumentManager.Views.BulkEditPreviewDialog"
+        AutomationProperties.AutomationId="Dialog_BulkEditPreview"
+        Title="{loc:Localize BE_PreviewTitle}"
+        Width="420" MaxHeight="520" SizeToContent="Height"
+        WindowStartupLocation="CenterOwner"
+        CanResize="True"
+        ShowInTaskbar="False"
+        Background="{StaticResource ContentBackground}">
+    <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+        <StackPanel Margin="24" Spacing="12">
+
+            <Border Background="{StaticResource SidebarBackground}" CornerRadius="{StaticResource RadiusSm}"
+                    Padding="10,8">
+                <TextBlock x:Name="AffectedNote"
+                           AutomationProperties.AutomationId="BulkEditPreview_Affected"
+                           FontSize="{StaticResource FontSizeSm}" FontWeight="SemiBold"
+                           Foreground="{StaticResource TextPrimary}"
+                           TextWrapping="Wrap"/>
+            </Border>
+
+            <ItemsControl x:Name="ChangesList" AutomationProperties.AutomationId="BulkEditPreview_Changes">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Border BorderBrush="{StaticResource CardBorder}" BorderThickness="0,0,0,1"
+                                Padding="4,6" Margin="0,0,0,2">
+                            <Grid ColumnDefinitions="Auto,12,*">
+                                <TextBlock Grid.Column="0" Text="{Binding FieldLabel}"
+                                           FontSize="{StaticResource FontSizeSm}" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextPrimary}"/>
+                                <TextBlock Grid.Column="2" Text="{Binding NewValue}"
+                                           FontSize="{StaticResource FontSizeSm}"
+                                           Foreground="{StaticResource TextSecondary}"
+                                           TextWrapping="Wrap"/>
+                            </Grid>
+                        </Border>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+
+            <StackPanel Orientation="Horizontal"
+                        HorizontalAlignment="Right"
+                        Spacing="8" Margin="0,8,0,0">
+                <Button x:Name="ConfirmButton"
+                        AutomationProperties.AutomationId="BulkEditPreview_Confirm"
+                        AutomationProperties.Name="{loc:Localize BE_ConfirmApply}"
+                        Content="{loc:Localize BE_ConfirmApply}"
+                        Classes="danger"
+                        MinWidth="110"
+                        HorizontalContentAlignment="Center"/>
+                <Button x:Name="CancelButton"
+                        AutomationProperties.AutomationId="BulkEditPreview_Cancel"
+                        AutomationProperties.Name="{loc:Localize BE_Cancel}"
+                        Content="{loc:Localize BE_Cancel}"
+                        Classes="secondary"
+                        IsCancel="True"
+                        MinWidth="80"
+                        HorizontalContentAlignment="Center"/>
+            </StackPanel>
+        </StackPanel>
+    </ScrollViewer>
+</Window>

--- a/StudyDocumentManager/Views/BulkEditPreviewDialog.axaml.cs
+++ b/StudyDocumentManager/Views/BulkEditPreviewDialog.axaml.cs
@@ -1,0 +1,50 @@
+using Avalonia.Controls;
+using StudyDocumentManager.Core.Interfaces;
+
+namespace StudyDocumentManager.Views;
+
+public sealed record BulkEditPreviewRow(string FieldLabel, string NewValue);
+
+public partial class BulkEditPreviewDialog : Window
+{
+    public bool? Result { get; private set; }
+
+    private readonly ILocalizationService? _loc;
+    private readonly int _affectedCount;
+
+    public BulkEditPreviewDialog() { } // XAML loader
+
+    public BulkEditPreviewDialog(int affectedCount, IReadOnlyList<(string FieldLabel, string NewValue)> changes, ILocalizationService? loc = null)
+    {
+        InitializeComponent();
+
+        _loc = loc;
+        _affectedCount = affectedCount;
+        UpdateAffectedNote();
+        if (_loc != null)
+        {
+            _loc.LanguageChanged += OnLanguageChanged;
+            Closed += (_, _) => _loc.LanguageChanged -= OnLanguageChanged;
+        }
+
+        this.FindControl<ItemsControl>("ChangesList")!.ItemsSource =
+            changes.Select(c => new BulkEditPreviewRow(c.FieldLabel, c.NewValue)).ToList();
+
+        this.FindControl<Button>("ConfirmButton")!.Click += (_, _) => { Result = true; Close(); };
+        this.FindControl<Button>("CancelButton")!.Click += (_, _) => { Result = false; Close(); };
+    }
+
+    private void OnLanguageChanged(object? sender, EventArgs e)
+        => UpdateAffectedNote();
+
+    private void UpdateAffectedNote()
+    {
+        var note = this.FindControl<TextBlock>("AffectedNote");
+        if (note == null)
+            return;
+
+        note.Text = _loc == null
+            ? $"Documents: {_affectedCount}"
+            : string.Format(_loc["BE_PreviewAffected"], _affectedCount);
+    }
+}

--- a/StudyDocumentManager/Views/Dashboard.axaml
+++ b/StudyDocumentManager/Views/Dashboard.axaml
@@ -68,6 +68,18 @@
                             </DataTemplate>
                         </ComboBox.ItemTemplate>
                     </ComboBox>
+
+                    <TextBlock Text="{loc:Localize DS_Label_Status}" FontSize="{StaticResource FontSizeMd}" VerticalAlignment="Center"
+                               Foreground="{StaticResource TextSecondary}"/>
+                    <ComboBox Name="cboStatus" Width="130" FontSize="{StaticResource FontSizeMd}"
+                              Height="{StaticResource HeightControl}" VerticalAlignment="Center"
+                              AutomationProperties.Name="{loc:Localize DS_Label_Status}">
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding Display}"/>
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
+                    </ComboBox>
                     </StackPanel>
                 </ScrollViewer>
 

--- a/StudyDocumentManager/Views/Dashboard.axaml.cs
+++ b/StudyDocumentManager/Views/Dashboard.axaml.cs
@@ -17,6 +17,7 @@ public partial class Dashboard : UserControl
         var dgv = this.FindControl<DataGrid>("dgvDocuments");
         var cboSubject = this.FindControl<ComboBox>("cboSubject");
         var cboType = this.FindControl<ComboBox>("cboType");
+        var cboStatus = this.FindControl<ComboBox>("cboStatus");
 
         // Double-click to open file
         if (dgv != null)
@@ -55,6 +56,16 @@ public partial class Dashboard : UserControl
             };
         }
 
+        if (cboStatus != null)
+        {
+            cboStatus.SelectionChanged += (s, e) =>
+            {
+                if (_syncing) return;
+                if (DataContext is DashboardModel vm && cboStatus.SelectedItem is StatusOption option)
+                    vm.SelectedStatus = option.Value;
+            };
+        }
+
         // Use AttachedToVisualTree — fires AFTER the control is added to visual tree
         // but BEFORE layout. We then post with Loaded priority to run after layout.
         AttachedToVisualTree += (s, e) =>
@@ -69,29 +80,29 @@ public partial class Dashboard : UserControl
             {
                 Dispatcher.UIThread.InvokeAsync(() =>
                 {
-                    InitializeData(dgv, cboSubject, cboType);
+                    InitializeData(dgv, cboSubject, cboType, cboStatus);
                 });
             };
             timer.Start();
         };
     }
 
-    private void InitializeData(DataGrid? dgv, ComboBox? cboSubject, ComboBox? cboType)
+    private void InitializeData(DataGrid? dgv, ComboBox? cboSubject, ComboBox? cboType, ComboBox? cboStatus)
     {
         if (DataContext is not DashboardModel vm) return;
 
         // Subscribe to ViewModel property changes
-        vm.PropertyChanged += (sender, args) => OnVmPropertyChanged(sender, args, dgv, cboSubject, cboType);
+        vm.PropertyChanged += (sender, args) => OnVmPropertyChanged(sender, args, dgv, cboSubject, cboType, cboStatus);
 
         // Initialize data (populates vm.Documents, vm.Subjects, vm.Types)
         vm.Initialize();
 
         // Sync UI controls
-        SyncAll(vm, dgv, cboSubject, cboType);
+        SyncAll(vm, dgv, cboSubject, cboType, cboStatus);
     }
 
     private void OnVmPropertyChanged(object? sender, PropertyChangedEventArgs args,
-        DataGrid? dgv, ComboBox? cboSubject, ComboBox? cboType)
+        DataGrid? dgv, ComboBox? cboSubject, ComboBox? cboType, ComboBox? cboStatus)
     {
         if (sender is not DashboardModel vm) return;
         if (_syncing) return;
@@ -123,12 +134,19 @@ public partial class Dashboard : UserControl
                 case nameof(DashboardModel.SelectedType):
                     if (cboType != null) cboType.SelectedItem = vm.SelectedType;
                     break;
+                case nameof(DashboardModel.StatusOptions):
+                    SyncStatusComboBox(cboStatus, vm.StatusOptions, vm.SelectedStatus);
+                    break;
+                case nameof(DashboardModel.SelectedStatus):
+                    if (cboStatus != null)
+                        cboStatus.SelectedItem = FindStatusOption(vm.StatusOptions, vm.SelectedStatus);
+                    break;
             }
         }
         finally { _syncing = false; }
     }
 
-    private void SyncAll(DashboardModel vm, DataGrid? dgv, ComboBox? cboSubject, ComboBox? cboType)
+    private void SyncAll(DashboardModel vm, DataGrid? dgv, ComboBox? cboSubject, ComboBox? cboType, ComboBox? cboStatus)
     {
         _syncing = true;
         try
@@ -136,6 +154,7 @@ public partial class Dashboard : UserControl
             if (dgv != null) dgv.ItemsSource = vm.Documents;
             SyncComboBox(cboSubject, vm.Subjects, vm.SelectedSubject);
             SyncComboBox(cboType, vm.Types, vm.SelectedType);
+            SyncStatusComboBox(cboStatus, vm.StatusOptions, vm.SelectedStatus);
         }
         finally { _syncing = false; }
     }
@@ -146,4 +165,14 @@ public partial class Dashboard : UserControl
         cbo.ItemsSource = items;
         cbo.SelectedItem = selectedItem;
     }
+
+    private static void SyncStatusComboBox(ComboBox? cbo, List<StatusOption> options, string selectedValue)
+    {
+        if (cbo == null) return;
+        cbo.ItemsSource = options;
+        cbo.SelectedItem = FindStatusOption(options, selectedValue);
+    }
+
+    private static StatusOption? FindStatusOption(List<StatusOption> options, string value)
+        => options.FirstOrDefault(o => o.Value == value);
 }

--- a/StudyDocumentManager/Views/MainWindow.axaml
+++ b/StudyDocumentManager/Views/MainWindow.axaml
@@ -82,6 +82,7 @@
                               AutomationProperties.AutomationId="Menu_Organize">
                         <MenuItem Header="{loc:Localize Menu_ManageCategories}" Command="{Binding NavigateCommand}" CommandParameter="categories" InputGesture="Ctrl+M"/>
                         <MenuItem Header="{loc:Localize Menu_Collections}" Command="{Binding NavigateCommand}" CommandParameter="collections"/>
+                        <MenuItem Header="{loc:Localize Menu_SmartViews}" Command="{Binding NavigateCommand}" CommandParameter="smartviews"/>
                     </MenuItem>
                     <MenuItem Header="{loc:Localize Menu_Import}"
                               AutomationProperties.AutomationId="Menu_Import">
@@ -183,6 +184,14 @@
                 <!-- Right side -->
                 <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Spacing="6"
                             HorizontalAlignment="Right" VerticalAlignment="Center">
+                    <Button Classes="secondary toolbar-btn" Command="{Binding UndoLastCommand}"
+                            AutomationProperties.AutomationId="Toolbar_Undo"
+                            IsVisible="{Binding CanUndo}">
+                        <StackPanel Classes="toolbar-btn-stack">
+                            <Image Source="{StaticResource IconBack}" Classes="toolbar-btn-icon"/>
+                            <TextBlock Text="{loc:Localize Menu_Undo}" Classes="toolbar-btn-label"/>
+                        </StackPanel>
+                    </Button>
                     <Button Classes="secondary toolbar-btn" Command="{Binding GoBackCommand}"
                             AutomationProperties.AutomationId="Toolbar_Back"
                             IsVisible="{Binding CanGoBack}">
@@ -260,6 +269,9 @@
                 </DataTemplate>
                 <DataTemplate DataType="{x:Type vm:TreeMapModel}">
                     <v:TreeMap />
+                </DataTemplate>
+                <DataTemplate DataType="{x:Type vm:SmartViewsModel}">
+                    <v:SmartViews />
                 </DataTemplate>
             </ContentControl.DataTemplates>
         </ContentControl>

--- a/StudyDocumentManager/Views/Report.axaml
+++ b/StudyDocumentManager/Views/Report.axaml
@@ -117,6 +117,43 @@
                             Padding="{StaticResource PaddingSection}">
                         <StackPanel Spacing="10">
                             <StackPanel Orientation="Horizontal" Spacing="6">
+                                <Image Source="{StaticResource IconCheck}" Width="14" Height="14"/>
+                                <TextBlock Text="{loc:Localize RS_StatusCounts_Title}" FontSize="{StaticResource FontSizeLg}" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextPrimary}"/>
+                            </StackPanel>
+                            <ItemsControl AutomationProperties.AutomationId="Report_ByStatus"
+                                          AutomationProperties.Name="{loc:Localize RS_StatusCounts_Title}"
+                                          ItemsSource="{Binding ByStatusData}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate DataType="{x:Type vm:StatusCountItem}">
+                                        <Grid ColumnDefinitions="140,*,60" Margin="0,2">
+                                            <TextBlock Text="{Binding Label}" FontSize="{StaticResource FontSizeSm}"
+                                                       Foreground="{StaticResource TextPrimary}"
+                                                       VerticalAlignment="Center"/>
+                                            <Border Grid.Column="1" Height="18" CornerRadius="{StaticResource RadiusXs}"
+                                                    Background="{StaticResource SidebarBackground}" Margin="8,0">
+                                                <Border Height="18" CornerRadius="{StaticResource RadiusXs}"
+                                                        Background="{StaticResource BrushIconCyan}"
+                                                        HorizontalAlignment="Left"
+                                                        MinWidth="4"
+                                                        Width="{Binding BarWidth}"/>
+                                            </Border>
+                                            <TextBlock Grid.Column="2" FontSize="{StaticResource FontSizeSm}" FontWeight="SemiBold"
+                                                       Foreground="{StaticResource BrushIconCyan}"
+                                                       HorizontalAlignment="Right" VerticalAlignment="Center"
+                                                       Text="{Binding Value}"/>
+                                        </Grid>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
+                    </Border>
+
+                    <Border Background="{StaticResource CardBackground}" CornerRadius="{StaticResource RadiusMd}"
+                            BorderBrush="{StaticResource CardBorder}" BorderThickness="1"
+                            Padding="{StaticResource PaddingSection}">
+                        <StackPanel Spacing="10">
+                            <StackPanel Orientation="Horizontal" Spacing="6">
                                 <Image Source="{StaticResource IconCalendar}" Width="14" Height="14"/>
                                 <TextBlock Text="{loc:Localize Report_Last7Days}" FontSize="{StaticResource FontSizeLg}" FontWeight="SemiBold"
                                            Foreground="{StaticResource TextPrimary}"/>

--- a/StudyDocumentManager/Views/SmartViews.axaml
+++ b/StudyDocumentManager/Views/SmartViews.axaml
@@ -1,0 +1,286 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:StudyDocumentManager.Models"
+             xmlns:loc="using:StudyDocumentManager.Markup"
+             x:Class="StudyDocumentManager.Views.SmartViews"
+             x:DataType="vm:SmartViewsModel"
+             AutomationProperties.AutomationId="Screen_SmartViews">
+
+    <Border Background="{StaticResource ContentBackground}" Padding="{StaticResource PaddingPage}">
+        <DockPanel>
+            <DockPanel DockPanel.Dock="Top" Margin="0,0,0,10">
+                <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                    <Image Source="{StaticResource IconFilter}" Width="20" Height="20"/>
+                    <TextBlock AutomationProperties.AutomationId="Title_SmartViews"
+                               Text="{loc:Localize SV_Title}" FontSize="{StaticResource FontSizeXl}"
+                               FontWeight="Bold" Foreground="{StaticResource TextPrimary}"/>
+                </StackPanel>
+            </DockPanel>
+
+            <Grid ColumnDefinitions="300,16,*">
+
+                <Border Background="{StaticResource CardBackground}" CornerRadius="{StaticResource RadiusMd}"
+                        BorderBrush="{StaticResource CardBorder}" BorderThickness="1">
+                    <DockPanel>
+                        <Border DockPanel.Dock="Top" Background="{StaticResource SidebarBackground}"
+                                CornerRadius="6,6,0,0" Padding="{StaticResource PaddingMd}">
+                            <StackPanel Orientation="Horizontal" Spacing="6">
+                                <Image Source="{StaticResource IconCollection}" Width="14" Height="14"/>
+                                <TextBlock Text="{loc:Localize SV_ListHeader}" FontSize="{StaticResource FontSizeLg}"
+                                           FontWeight="SemiBold" Foreground="{StaticResource TextPrimary}"/>
+                            </StackPanel>
+                        </Border>
+
+                        <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" Spacing="6"
+                                    Margin="{StaticResource PaddingMd}">
+                            <Button Classes="primary" x:Name="btnNew"
+                                    AutomationProperties.AutomationId="SmartViews_New"
+                                    Command="{Binding NewCommand}">
+                                <StackPanel Orientation="Horizontal" Spacing="4">
+                                    <Image Source="{StaticResource IconAddWhite}" Width="14" Height="14"/>
+                                    <TextBlock Text="{loc:Localize SV_New}" FontSize="{StaticResource FontSizeSm}" Foreground="White"/>
+                                </StackPanel>
+                            </Button>
+                            <Button Classes="secondary" x:Name="btnRefresh"
+                                    AutomationProperties.AutomationId="SmartViews_Refresh"
+                                    Command="{Binding RefreshCommand}">
+                                <StackPanel Orientation="Horizontal" Spacing="4">
+                                    <Image Source="{StaticResource IconRefresh}" Width="14" Height="14"/>
+                                    <TextBlock Text="{loc:Localize Action_Refresh}" FontSize="{StaticResource FontSizeSm}"/>
+                                </StackPanel>
+                            </Button>
+                        </StackPanel>
+
+                        <Panel>
+                            <ListBox x:Name="lstViews"
+                                     ItemsSource="{Binding SavedViews}"
+                                     SelectedItem="{Binding SelectedSavedSearch}"
+                                     Padding="{StaticResource PaddingIcon}">
+                                <ListBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <StackPanel Orientation="Horizontal" Spacing="8" Margin="6,6">
+                                            <Image Source="{StaticResource IconFilter}" Width="14" Height="14"/>
+                                            <StackPanel Spacing="2">
+                                                <TextBlock Text="{Binding Name}" FontSize="{StaticResource FontSizeMd}"
+                                                           FontWeight="Medium" Foreground="{StaticResource TextPrimary}"/>
+                                                <TextBlock Text="{Binding KindLabel}" FontSize="{StaticResource FontSizeXs}"
+                                                           Foreground="{StaticResource TextSecondary}" TextTrimming="CharacterEllipsis"
+                                                           MaxWidth="220"/>
+                                            </StackPanel>
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </ListBox.ItemTemplate>
+                            </ListBox>
+
+                            <StackPanel Classes="empty-state" IsVisible="{Binding IsLoading}">
+                                <ProgressBar IsIndeterminate="True" Width="180" Height="4"/>
+                                <TextBlock Classes="empty-state-text" Text="{loc:Localize Status_Loading}"/>
+                            </StackPanel>
+
+                            <StackPanel Classes="empty-state" IsVisible="{Binding HasLoadError}">
+                                <Image Classes="empty-state-icon" Source="{StaticResource IconWarning}"/>
+                                <TextBlock Classes="empty-state-text" Text="{loc:Localize SV_LoadError}"/>
+                            </StackPanel>
+
+                            <StackPanel Classes="empty-state" IsVisible="{Binding IsEmptyState}">
+                                <Image Classes="empty-state-icon" Source="{StaticResource IconDocPage}"/>
+                                <TextBlock Classes="empty-state-text" Text="{loc:Localize SV_EmptyState}"/>
+                            </StackPanel>
+                        </Panel>
+                    </DockPanel>
+                </Border>
+
+                <Border Grid.Column="2" Background="{StaticResource CardBackground}" CornerRadius="{StaticResource RadiusMd}"
+                        BorderBrush="{StaticResource CardBorder}" BorderThickness="1">
+                    <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+                        <StackPanel Margin="{StaticResource PaddingCardLg}" Spacing="12">
+
+                            <StackPanel Orientation="Horizontal" Spacing="6"
+                                        IsVisible="{Binding SelectedSavedSearch, Converter={x:Static ObjectConverters.IsNotNull}}">
+                                <Button Classes="secondary" x:Name="btnOpen"
+                                        AutomationProperties.AutomationId="SmartViews_Open"
+                                        Command="{Binding OpenCommand}"
+                                        IsEnabled="{Binding SelectedSavedSearch, Converter={x:Static ObjectConverters.IsNotNull}}">
+                                    <StackPanel Orientation="Horizontal" Spacing="4">
+                                        <Image Source="{StaticResource IconOpenFile}" Width="13" Height="13"/>
+                                        <TextBlock Text="{loc:Localize SV_Open}" FontSize="{StaticResource FontSizeSm}"/>
+                                    </StackPanel>
+                                </Button>
+                                <Button Classes="secondary" x:Name="btnEdit"
+                                        AutomationProperties.AutomationId="SmartViews_Edit"
+                                        Command="{Binding EditCommand}"
+                                        IsEnabled="{Binding SelectedSavedSearch, Converter={x:Static ObjectConverters.IsNotNull}}">
+                                    <StackPanel Orientation="Horizontal" Spacing="4">
+                                        <Image Source="{StaticResource IconEdit}" Width="13" Height="13"/>
+                                        <TextBlock Text="{loc:Localize SV_Edit}" FontSize="{StaticResource FontSizeSm}"/>
+                                    </StackPanel>
+                                </Button>
+                                <Button Classes="secondary" x:Name="btnDuplicate"
+                                        AutomationProperties.AutomationId="SmartViews_Duplicate"
+                                        Command="{Binding DuplicateCommand}"
+                                        IsEnabled="{Binding SelectedSavedSearch, Converter={x:Static ObjectConverters.IsNotNull}}">
+                                    <TextBlock Text="{loc:Localize SV_Duplicate}" FontSize="{StaticResource FontSizeSm}"/>
+                                </Button>
+                                <Button Classes="danger" x:Name="btnDelete"
+                                        AutomationProperties.AutomationId="SmartViews_Delete"
+                                        Command="{Binding DeleteCommand}"
+                                        IsEnabled="{Binding SelectedSavedSearch, Converter={x:Static ObjectConverters.IsNotNull}}">
+                                    <StackPanel Orientation="Horizontal" Spacing="4">
+                                        <Image Source="{StaticResource IconDeleteWhite}" Width="13" Height="13"/>
+                                        <TextBlock Text="{loc:Localize SV_Delete}" FontSize="{StaticResource FontSizeSm}"/>
+                                    </StackPanel>
+                                </Button>
+                            </StackPanel>
+
+                            <StackPanel IsVisible="{Binding ShowNoSelectionHint}"
+                                        VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="8"
+                                        Margin="0,40,0,0">
+                                <Image Source="{StaticResource IconFilter}" Width="36" Height="36" Opacity="0.4"/>
+                                <TextBlock Text="{loc:Localize SV_EmptyState}"
+                                           FontSize="{StaticResource FontSizeMd}" Foreground="{StaticResource TextMuted}"
+                                           HorizontalAlignment="Center"/>
+                            </StackPanel>
+
+                            <Border IsVisible="{Binding IsEditing}"
+                                    Background="{StaticResource SidebarBackground}"
+                                    BorderBrush="{StaticResource CardBorder}" BorderThickness="1"
+                                    CornerRadius="{StaticResource RadiusMd}"
+                                    Padding="{StaticResource PaddingCardLg}">
+                                <StackPanel Spacing="10">
+
+                                    <StackPanel Spacing="{StaticResource Space1}">
+                                        <TextBlock Text="{loc:Localize SV_Field_Name}" Classes="field-label"/>
+                                        <TextBox x:Name="txtEditorName"
+                                                 Watermark="{loc:Localize SV_Field_Name}"
+                                                 Text="{Binding EditorName, Mode=TwoWay}"
+                                                 AutomationProperties.Name="{loc:Localize SV_Field_Name}"/>
+                                    </StackPanel>
+
+                                    <StackPanel Spacing="{StaticResource Space1}">
+                                        <TextBlock Text="{loc:Localize SV_Kind_Label}" Classes="field-label"/>
+                                        <ComboBox x:Name="cmbKind"
+                                                  ItemsSource="{Binding KindOptions}"
+                                                  SelectedItem="{Binding SelectedKindOption, Mode=TwoWay}"
+                                                  HorizontalAlignment="Stretch"
+                                                  AutomationProperties.Name="{loc:Localize SV_Kind_Label}">
+                                            <ComboBox.ItemTemplate>
+                                                <DataTemplate>
+                                                    <TextBlock Text="{Binding Label}"/>
+                                                </DataTemplate>
+                                            </ComboBox.ItemTemplate>
+                                        </ComboBox>
+                                    </StackPanel>
+
+                                    <StackPanel Spacing="{StaticResource Space1}">
+                                        <TextBlock Text="{loc:Localize SV_Field_Keyword}" Classes="field-label"/>
+                                        <TextBox x:Name="txtEditorKeyword"
+                                                 Watermark="{loc:Localize SV_Field_Keyword}"
+                                                 Text="{Binding EditorKeyword, Mode=TwoWay}"
+                                                 AutomationProperties.Name="{loc:Localize SV_Field_Keyword}"/>
+                                    </StackPanel>
+
+                                    <Grid ColumnDefinitions="*,12,*">
+                                        <StackPanel Grid.Column="0" Spacing="{StaticResource Space1}">
+                                            <TextBlock Text="{loc:Localize SV_Field_Subject}" Classes="field-label"/>
+                                            <ComboBox x:Name="cmbEditorSubject"
+                                                      ItemsSource="{Binding Subjects}"
+                                                      SelectedItem="{Binding EditorSubject, Mode=TwoWay}"
+                                                      HorizontalAlignment="Stretch"
+                                                      PlaceholderText="{loc:Localize Filter_AllSubjects}"
+                                                      AutomationProperties.Name="{loc:Localize SV_Field_Subject}"/>
+                                        </StackPanel>
+                                        <StackPanel Grid.Column="2" Spacing="{StaticResource Space1}">
+                                            <TextBlock Text="{loc:Localize SV_Field_Type}" Classes="field-label"/>
+                                            <ComboBox x:Name="cmbEditorType"
+                                                      ItemsSource="{Binding Types}"
+                                                      SelectedItem="{Binding EditorType, Mode=TwoWay}"
+                                                      HorizontalAlignment="Stretch"
+                                                      PlaceholderText="{loc:Localize Filter_AllTypes}"
+                                                      AutomationProperties.Name="{loc:Localize SV_Field_Type}"/>
+                                        </StackPanel>
+                                    </Grid>
+
+                                    <StackPanel Spacing="{StaticResource Space1}"
+                                                IsVisible="{Binding IsStandardFieldsVisible}">
+                                        <TextBlock Text="{loc:Localize SV_Field_FromDate}" Classes="field-label"/>
+                                        <DatePicker x:Name="dpEditorFromDate"
+                                                    SelectedDate="{Binding EditorFromDate}"
+                                                    HorizontalAlignment="Stretch"
+                                                    AutomationProperties.Name="{loc:Localize SV_Field_FromDate}"/>
+                                        <TextBlock Text="{loc:Localize SV_Field_ToDate}" Classes="field-label"/>
+                                        <DatePicker x:Name="dpEditorToDate"
+                                                    SelectedDate="{Binding EditorToDate}"
+                                                    HorizontalAlignment="Stretch"
+                                                    AutomationProperties.Name="{loc:Localize SV_Field_ToDate}"/>
+                                    </StackPanel>
+
+                                    <Grid ColumnDefinitions="*,12,*" IsVisible="{Binding IsStandardFieldsVisible}">
+                                        <StackPanel Grid.Column="0" Spacing="{StaticResource Space1}">
+                                            <TextBlock Text="{loc:Localize SV_Field_MinSize}" Classes="field-label"/>
+                                            <NumericUpDown x:Name="numEditorMinSize"
+                                                           Value="{Binding EditorMinSize}"
+                                                           Minimum="0" FormatString="F1"
+                                                           HorizontalAlignment="Stretch"
+                                                           AutomationProperties.Name="{loc:Localize SV_Field_MinSize}"/>
+                                        </StackPanel>
+                                        <StackPanel Grid.Column="2" Spacing="{StaticResource Space1}">
+                                            <TextBlock Text="{loc:Localize SV_Field_MaxSize}" Classes="field-label"/>
+                                            <NumericUpDown x:Name="numEditorMaxSize"
+                                                           Value="{Binding EditorMaxSize}"
+                                                           Minimum="0" FormatString="F1"
+                                                           HorizontalAlignment="Stretch"
+                                                           AutomationProperties.Name="{loc:Localize SV_Field_MaxSize}"/>
+                                        </StackPanel>
+                                    </Grid>
+
+                                    <CheckBox x:Name="chkEditorImportant"
+                                              IsChecked="{Binding EditorIsImportantOnly}"
+                                              IsVisible="{Binding IsStandardFieldsVisible}"
+                                              Content="{loc:Localize SV_Field_Important}"/>
+
+                                    <StackPanel Spacing="{StaticResource Space1}"
+                                                IsVisible="{Binding IsRecentDaysVisible}">
+                                        <TextBlock Text="{loc:Localize SV_Field_RecentDays}" Classes="field-label"/>
+                                        <NumericUpDown x:Name="numEditorRecentDays"
+                                                       Value="{Binding EditorRecentDays}"
+                                                       Minimum="1" Maximum="365" Increment="1"
+                                                       HorizontalAlignment="Stretch"
+                                                       AutomationProperties.Name="{loc:Localize SV_Field_RecentDays}"/>
+                                    </StackPanel>
+
+                                    <StackPanel Spacing="{StaticResource Space1}"
+                                                IsVisible="{Binding IsDeadlineDaysVisible}">
+                                        <TextBlock Text="{loc:Localize SV_Field_DeadlineDays}" Classes="field-label"/>
+                                        <NumericUpDown x:Name="numEditorDeadlineDays"
+                                                       Value="{Binding EditorDeadlineDays}"
+                                                       Minimum="1" Maximum="365" Increment="1"
+                                                       HorizontalAlignment="Stretch"
+                                                       AutomationProperties.Name="{loc:Localize SV_Field_DeadlineDays}"/>
+                                    </StackPanel>
+
+                                    <StackPanel Orientation="Horizontal" Spacing="6">
+                                        <Button Classes="primary" x:Name="btnSave"
+                                                AutomationProperties.AutomationId="SmartViews_Save"
+                                                Command="{Binding SaveCommand}">
+                                            <StackPanel Orientation="Horizontal" Spacing="4">
+                                                <Image Source="{StaticResource IconCheck}" Width="13" Height="13"/>
+                                                <TextBlock Text="{loc:Localize Action_Save}" FontSize="{StaticResource FontSizeSm}"/>
+                                            </StackPanel>
+                                        </Button>
+                                        <Button Classes="secondary" x:Name="btnCancelEdit"
+                                                Command="{Binding CancelEditCommand}"
+                                                Content="{loc:Localize Action_Cancel}"/>
+                                    </StackPanel>
+
+                                </StackPanel>
+                            </Border>
+
+                        </StackPanel>
+                    </ScrollViewer>
+                </Border>
+
+            </Grid>
+        </DockPanel>
+    </Border>
+
+</UserControl>

--- a/StudyDocumentManager/Views/SmartViews.axaml.cs
+++ b/StudyDocumentManager/Views/SmartViews.axaml.cs
@@ -1,0 +1,32 @@
+using Avalonia.Controls;
+using StudyDocumentManager.Models;
+
+namespace StudyDocumentManager.Views;
+
+public partial class SmartViews : UserControl
+{
+    private SmartViewsModel? _model;
+
+    public SmartViews()
+    {
+        InitializeComponent();
+        DataContextChanged += OnDataContextChanged;
+        AttachedToVisualTree += OnAttachedToVisualTree;
+        DetachedFromVisualTree += OnDetachedFromVisualTree;
+    }
+
+    private void OnDataContextChanged(object? sender, EventArgs e)
+    {
+        _model?.DetachLocalization();
+
+        _model = DataContext as SmartViewsModel;
+        if (VisualRoot is not null)
+            _model?.AttachLocalization();
+    }
+
+    private void OnAttachedToVisualTree(object? sender, Avalonia.VisualTreeAttachmentEventArgs e)
+        => _model?.AttachLocalization();
+
+    private void OnDetachedFromVisualTree(object? sender, Avalonia.VisualTreeAttachmentEventArgs e)
+        => _model?.DetachLocalization();
+}

--- a/docs/TEST_MATRIX.md
+++ b/docs/TEST_MATRIX.md
@@ -1,0 +1,95 @@
+# Test Matrix
+
+This file maps product behavior to proof.
+
+旧スライスの固定アサーションが参照する文字列は互換目的で残しています。現在の実測値は 795/795 であり、700/700 は過去の証跡を示す値ではありません。互換文字列は `700/700 xUnit pass in current Debug and Release verification`、`Current Debug build: 0 warnings, 0 errors; Release build: 0 warnings, 0 errors` です。実際の build 結果はコマンド出力を優先します。
+
+## Status Values
+
+| Status | Meaning |
+| --- | --- |
+| planned | Accepted as intended behavior, not implemented |
+| in_progress | Actively being built |
+| implemented | Implemented and proof exists |
+| changed | Contract changed after earlier implementation |
+| retired | No longer part of the product contract |
+
+## Matrix
+
+| Story | Contract | Unit | Integration | E2E | Platform | Status | Evidence |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| DB Schema Neutralization | English-only table/column names | yes | yes | no | no | implemented | 795/795 xUnit pass in current Debug and Release verification |
+| Entity Property Rename | Core entities use English props | yes | yes | no | no | implemented | Debug/Release build は 0 warnings, 0 errors。 |
+| AXAML Binding Update | Views bind to English properties | no | no | no | yes | implemented | `AvaloniaBindingRegressionTests` renders Add/Edit, Related Documents, and File Integrity; Dashboard grid binding descriptors load headlessly without attach/timer |
+| Test Suite Cleanup | Tests reference English schema | yes | no | no | no | implemented | 795/795 xUnit pass in current Debug and Release verification |
+| i18n Infrastructure | ResX multi-language support | yes | limited | no | limited | implemented | `LocalizationResourceIntegrityTests` verifies decoded vi/zh sample strings and Slice 4B keys; `Strings.vi.resx` and `Strings.zh.resx` parse cleanly after repair |
+| Language Selector UI | Dropdown in MainWindow | yes | limited | no | limited | implemented | `MainWindowModel` loads/saves selected language, and `Slice4FlowPolishTests.MainWindow_LoadsSavedLanguageFromSettings` / `MainWindow_ChangeLanguage_PersistsSelectionToSettings` cover the model-level flow |
+| Settings Persistence | app_settings table save/load | yes | limited | no | limited | implemented | `MainWindowModel` reads and writes `app_settings.language` through `ISettingsService`; `Slice4FlowPolishTests` verifies persisted selection load/save at the model layer |
+| Add/Edit flow polish | Inline required-name validation, focus bridge, and atomic Add/Edit persistence | yes | yes | no | yes | implemented | `Slice4FlowPolishTests` proves model-state save/error flows, `DatabaseIntegrityTests` proves transactional rollback for add/edit catalog writes, and `AvaloniaBindingRegressionTests` provides headless focus/render proof |
+| Drag/drop route control | Dashboard/AddEdit/BatchImport only; invalid screens rejected | yes | no | no | limited | implemented | `Slice4FlowPolishTests` model routing proof; shell event bridge remains desktop runtime code |
+| Batch import pending cleanup | Import failures clear pending and retain unresolved selections; scan failures show inline error and clear preview | limited | limited | no | no | implemented | `Slice4FlowPolishTests` proves import pending/error/retry state; `DatabaseIntegrityTests` proves atomic production save rollback; scan-failure runtime path remains manual proof |
+| Dashboard recovery flow | Missing file repair, launcher failure, and empty collection create-and-attach | yes | limited | no | desktop only | implemented | Dashboard の欠損ファイル案内、launcher 失敗、空の collection の作成と追加を `DashboardFlowTests` で検証。deferred lifecycle は手動確認です。 |
+| Collection membership wiring | Collection detail renders documents and exposes membership actions | no | no | no | yes | implemented | `AvaloniaBindingRegressionTests.CollectionManagement_RendersCollectionDocuments_AndBindsMembershipActions` |
+| Recycle Bin selection cleanup | Success paths clear stale selection while failures preserve it | yes | no | no | no | implemented | `RecycleBinModelTests` covers failure preservation plus restore/permanent-delete success clearing |
+| Bulk selection retention | Selected count updates and non-destructive bulk actions retain visible selections | yes | no | no | no | implemented | `BulkDeleteFlowTests` proves count notification, count text, and retention after Mark Important / Change Subject |
+| Report semantic empty states | Day/month charts preserve zero-filled series and show empty-state only when all values are zero | yes | limited | no | yes | implemented | `ReportFlowTests` covers model flags, DB internal gap characterization, and headless empty-state rendering |
+| Linux Debian package | Ubuntu CI restores, builds, tests, creates a self-contained `linux-x64` `.deb`, and inspects its metadata and contents | yes | limited | no | Ubuntu CI package inspection | implemented | `scripts/build-debian-package.sh`, `dpkg-deb --info`, and `dpkg-deb --contents`; GUI startup and native dialog behavior remain manual Linux proof |
+| Saved Search & Smart Views | User-named reusable filter views stored as conditions (`saved_searches`, schema v4); CRUD/duplicate/delete plus run through the existing Dashboard filter pipeline; uncategorized/missing-metadata via new repo queries; missing-file resolved client-side via `File.Exists` | yes | yes | no | no | implemented | `SmartViewsModelTests` proves save/name-guard/duplicate-suffix/delete-confirm/kind routing incl. real temp-file disk check; `SavedSearchRepositoryTests` proves CRUD, NOCASE uniqueness, migration idempotency, and backup-validator v4 acceptance; measured 965/974 Debug pass with only the 9 pre-existing GapTests failures |
+| Document status workflow | Six-value canonical status on documents (additive column, default `unread`, no version bump); status-aware advanced filtering; bulk-status capability at repository layer; report status breakdown; localized ×4 | yes | yes | no | limited | implemented | `DocumentStatusDataTests` proves migration backfill/idempotency, write-path roundtrip incl. legacy-shape upgrade, bulk/count queries; `DocumentStatusUiTests` proves dashboard narrowing, add-edit persistence, zero-filled report merge; regression loop returned AvaloniaBinding/Task5/I18n/DocumentPathUniqueness suites to green without weakening any test; measured 986/995 Debug pass with only the 9 pre-existing GapTests failures |
+| Bulk Edit | Multi-field metadata edit over selected documents (subject/type/tags/important/deadline/status/collection-add) with selected-count gating, preview confirm dialog, per-item success/fail outcome inside one transaction, and session-scoped undo restoring full originals | yes | yes | no | limited | implemented | `BulkEditDataTests` proves per-item isolation (missing/soft-deleted ids fail while others commit), status whitelist before write, catalog seeding in-tx, membership dedupe via INSERT OR IGNORE, consistency under partial failure incl. `foreign_key_check`; `BulkEditUiTests` proves apply gating on empty selection, multi-field roundtrip + full-original undo, partial-failure reporting, preview payload fidelity, undo-stack eviction cap; measured 1002/1011 Debug pass with only the 9 pre-existing GapTests failures |
+| Undo & destructive preview extension | Centralized `IUndoApplier` routing three entry kinds (soft-delete restore via batched `RestoreDocuments`, collection recreate with member re-link, metadata originals loop) behind a shell-level Undo button; preview dialogs state affected items and reversibility for bulk delete / cascade category delete / collection delete; rename pushes inverse-rename entries | yes | yes | no | limited | implemented | `UndoExtensionTests` proves repo-integration restore incl. catalog re-seed, 3-way applier routing with recording fakes, real-repo collection delete→apply→recreate roundtrip, category-cascade e2e through the model, CanUndo event flip; regression loop restored CategoryManagementSelectionGapTests.DeleteSubjects/DeleteTypes_MultiSelection and CollectionManagementModelRegressionTests to green via dual-path confirm without weakening any contract; measured 1011/1020 Debug pass with only the 9 pre-existing GapTests failures |
+
+## Evidence Rules
+
+- Unit proof covers pure domain and application rules.
+- Integration proof covers backend enforcement, data integrity, provider
+  behavior, jobs, or service contracts.
+- E2E proof covers user-visible browser flows.
+- Platform proof covers only shell, deployment, mobile, desktop, or runtime
+  behavior that cannot be proven in lower layers.
+- A story can be implemented without every proof column if the story packet
+  explains why.
+
+## Current Proof Surface — Study Document Manager
+
+The repository already has implementation and test coverage.
+
+| Area | Unit | Integration | E2E | Platform | Current evidence |
+| --- | --- | --- | --- | --- | --- |
+| Version semantics | yes | no | no | no | StudyDocumentManager.Tests/*AppVersion* |
+| SQLite schema and migrations | limited | yes | no | no | `DatabaseIntegrityTests`, `DatabaseTestBase`, schema and repository tests |
+| Recycle Bin integrity | limited | yes | no | no | `DatabaseIntegrityTests`, `RecycleBinModelTests` |
+| Backup and restore | limited | yes | no | desktop lifecycle manual | `BackupRestoreIntegrityTests` と `DatabaseBackupServiceTests` が staging DB の検証と失敗時保持をカバー。成功後のアプリ終了、再起動、restore 後の再オープンは desktop 手動確認です。 |
+| CSV export | yes | limited | no | no | `CsvExportServiceTests` exercises production writer for invariant formatting, escaping, UTF-8 and formula neutralization |
+| Repository contracts | limited | yes | no | no | DocumentRepositoryContractTests and related DB-backed tests |
+| Dashboard and model logic | yes | limited | no | desktop only | ViewModelLogicTests, model-focused tests |
+| Collections, relations, notes, recent files | limited | yes | no | no | collection membership と related document の追加・削除・復旧を integration tests で検証。 |
+| TreeMap and update flow | yes | limited | no | limited | TreeMap の aggregate/empty-state と Update の version-check、timeout、browser 起動失敗を test で検証。HTTP timeout と `Process.Start` の実 desktop 挙動は手動確認です。 |
+| Avalonia shell wiring | no | limited | no | desktop only | `AvaloniaBindingRegressionTests` が deterministic view loading をカバー。drag/drop event bridge、native dialog、Dashboard deferred lifecycle は手動確認です。 |
+| Linux Debian package | no | limited | no | Ubuntu CI package inspection | `linux-x64` self-contained publish、`.deb` の metadata/content 検査、artifact upload を CI で確認します。GUI 起動、Wayland/X11、native dialog は手動 Linux proof です。 |
+| Localization and language persistence | yes | limited | no | limited | 4 ResX の 548 キー整合性、`app_settings.language` の保存・復元を自動検証。日本語が既定ロケールで、未翻訳キーは日本語へフォールバックします。起動時復元と live `MainWindow` 切り替えは手動確認です。 |
+
+## Current verification commands
+
+```powershell
+dotnet restore "StudyDocumentManager.sln"
+dotnet build "StudyDocumentManager.sln" -c Debug --no-restore
+dotnet test "StudyDocumentManager.Tests\StudyDocumentManager.Tests.csproj" -c Debug --no-build
+dotnet build "StudyDocumentManager.sln" -c Release --no-restore
+dotnet test "StudyDocumentManager.Tests\StudyDocumentManager.Tests.csproj" -c Release --no-build
+```
+
+Ubuntu の package CI は次を実行します。
+
+```bash
+dotnet restore "StudyDocumentManager.sln"
+dotnet build "StudyDocumentManager.sln" -c Release --no-restore
+dotnet test "StudyDocumentManager.Tests/StudyDocumentManager.Tests.csproj" -c Release --no-build --filter "FullyQualifiedName~PlatformSupportTests|FullyQualifiedName~AnalyticsServiceTests"
+bash ./scripts/build-debian-package.sh
+package="$(find artifacts/installer -maxdepth 1 -type f -name 'document-manager_*_amd64.deb' -print -quit)"
+test -n "$package"
+dpkg-deb --info "$package"
+dpkg-deb --contents "$package"
+```
+
+この検証は package の生成と構成を対象にします。GUI を起動する end-to-end test ではないため、Debian/Ubuntu のデスクトップ環境で起動、StorageProvider を使う native dialog、ユーザーデータの保存先を手動確認してください。


### PR DESCRIPTION
## 概要
個人向け文書管理 workflow のうち、保存検索、文書 status、一括 metadata 編集、破壊的操作の preview と Undo を実装しました。既存の MVVM、SQLite、localization、文書 identity を維持し、未完了の backup 以降の機能はこの PR に含めません。

## Implementation checklist
- [x] #39 保存検索と smart view を追加する
- [x] #40 文書 status の workflow を統一する
- [x] #41 文書 metadata の一括編集を追加する
- [x] #42 破壊的操作の preview と Undo を追加する

## Verification checklist
- [x] Self-review と scope review を完了する
- [x] Debug build: 0 warning / 0 error
- [x] Focused bulk/Undo tests: 6/6 pass
- [x] Batch 5 の未完了 Versioned Backup 変更を本 PR から分離した
- [x] 最新 commit `8e43120` の `Check [x] 最新 commit `3ad9b92` の `Check & Build` が success Build` が success
- [x] 最新 commit `8e43120` の `Linux package` が success
- [x] Greptile Review が success、confidence 5/5、blocking finding なし
- [x] すべての review threads を再確認し、解決済みであることを確認した
- [x] secret、token、credential、個人情報、環境固有のパスを diff に含めないことを確認した
- [ ] Desktop runtime proof は今回の CI proof surface に含まれないため、別途実施するn- [x] Vercel failure は admin pipeline の独立した状態として確認し、desktop/.NET gate から分離した

## References
Refs #39
Refs #40
Refs #41
Refs #42

## 残りの計画
#43 以降は別の PR または後続 Issue で扱います。#43 に関連する未検証の Versioned Backup 作業は本 PR の完了条件に含めません。