### PR TITLE
Issue #60 の desktop UX とアクセシビリティを改善する

### DIFF
--- a/StudyDocumentManager.Tests/AvaloniaBindingRegressionTests.cs
+++ b/StudyDocumentManager.Tests/AvaloniaBindingRegressionTests.cs
@@ -757,7 +757,8 @@ public class AvaloniaBindingRegressionTests
         Assert.NotNull(grid);
         var nameColumn = Assert.IsType<DataGridTemplateColumn>(grid.Columns[0]);
         Assert.Equal("Name", nameColumn.SortMemberPath);
-        Assert.Equal("Subject", GetPath(Assert.IsType<DataGridTextColumn>(grid.Columns[1])));
+        var subjectColumn = Assert.IsType<DataGridTemplateColumn>(grid.Columns[1]);
+        Assert.Equal("Subject", subjectColumn.SortMemberPath);
         Assert.Equal("Type", GetPath(Assert.IsType<DataGridTextColumn>(grid.Columns[2])));
         Assert.Equal("CreatedAt", GetPath(Assert.IsType<DataGridTextColumn>(grid.Columns[3])));
         Assert.Equal("FileSize", GetPath(Assert.IsType<DataGridTextColumn>(grid.Columns[4])));

--- a/StudyDocumentManager.Tests/AvaloniaBindingRegressionTests.cs
+++ b/StudyDocumentManager.Tests/AvaloniaBindingRegressionTests.cs
@@ -943,6 +943,101 @@ public class AvaloniaBindingRegressionTests
 
 
     [AvaloniaFact]
+    public void AuditedWorkflowViews_RenderAtNarrowWidthWithStableRootContracts()
+    {
+        GetLocalization();
+
+        var views = new Control[]
+        {
+            new BatchImport(),
+            new StudyDocumentManager.Views.WatchedFolder(),
+            new RecoveryCenterView(),
+            new DuplicateDetection()
+        };
+        var expectedIds = new[]
+        {
+            "Screen_BatchImport",
+            "WatchedFolder_Screen",
+            "Screen_RecoveryCenter",
+            "Screen_DuplicateDetection"
+        };
+
+        foreach (var (view, expectedId) in views.Zip(expectedIds))
+        {
+            var window = new Window { Width = 520, Height = 600, Content = view };
+            try
+            {
+                window.Show();
+                FlushAvaloniaBindings();
+
+                Assert.Equal(expectedId, view.GetValue(AutomationProperties.AutomationIdProperty));
+                Assert.True(view.Bounds.Width <= 520);
+                Assert.True(view.Bounds.Height <= 600);
+            }
+            finally
+            {
+                window.Close();
+            }
+        }
+    }
+
+    [AvaloniaFact]
+    public void AuditedWorkflowViews_ExposeCriticalActionMetadata()
+    {
+        GetLocalization();
+
+        var cases = new (Control View, string[] AutomationIds)[]
+        {
+            (new BatchImport(), ["BatchImport_BrowseFolder", "BatchImport_ScanFolder", "BatchImport_Import"]),
+            (new StudyDocumentManager.Views.WatchedFolder(), ["WatchedFolder_Back", "WatchedFolder_Start", "WatchedFolder_Stop"]),
+            (new RecoveryCenterView(), ["Recovery_CreateBackup", "Recovery_RestoreSelected", "Recovery_OpenFolder"]),
+            (new DuplicateDetection(), ["DuplicateDetection_Scan"])
+        };
+
+        foreach (var (view, automationIds) in cases)
+        {
+            var window = new Window { Content = view };
+            try
+            {
+                window.Show();
+                FlushAvaloniaBindings();
+
+                foreach (var automationId in automationIds)
+                {
+                    var control = view.GetVisualDescendants().FirstOrDefault(candidate =>
+                        AutomationProperties.GetAutomationId(candidate) == automationId);
+                    Assert.NotNull(control);
+                }
+            }
+            finally
+            {
+                window.Close();
+            }
+        }
+    }
+
+    [AvaloniaFact]
+    public void RecoveryCenter_HasScrollableContentAtNarrowWidth()
+    {
+        GetLocalization();
+        var view = new RecoveryCenterView();
+        var window = new Window { Width = 520, Height = 600, Content = view };
+
+        try
+        {
+            window.Show();
+            FlushAvaloniaBindings();
+
+            Assert.Contains(view.GetVisualDescendants().OfType<ScrollViewer>(), scrollViewer =>
+                scrollViewer.Bounds.Width <= 520);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
     public void AppValidationPluginCleanup_RemovesOnlyDataAnnotationsPlugin()
     {
         var validators = Avalonia.Data.Core.Plugins.BindingPlugins.DataValidators;

--- a/StudyDocumentManager.Tests/FileSystemWatcherAdapterTests.cs
+++ b/StudyDocumentManager.Tests/FileSystemWatcherAdapterTests.cs
@@ -26,14 +26,19 @@ public class FileSystemWatcherAdapterTests : IDisposable
     {
         using var adapter = new FileSystemWatcherAdapter(_dir, false);
         var signal = new ManualResetEventSlim();
+        var withExt = Path.Combine(_dir, "a.txt");
+        var noExt = Path.Combine(_dir, "b");
         adapter.FileCreated += (_, e) =>
         {
-            lock (_seen) { _seen.Add(e.FullPath); if (_seen.Count >= 2) signal.Set(); }
+            lock (_seen)
+            {
+                _seen.Add(e.FullPath);
+                if (_seen.Contains(noExt) && _seen.Contains(withExt))
+                    signal.Set();
+            }
         };
         adapter.Start();
 
-        var withExt = Path.Combine(_dir, "a.txt");
-        var noExt = Path.Combine(_dir, "b");
         File.WriteAllText(withExt, "x");
         File.WriteAllText(noExt, "y");
         File.AppendAllText(withExt, "z"); // triggers a Changed event

--- a/StudyDocumentManager.Tests/ImportInboxModelTests.cs
+++ b/StudyDocumentManager.Tests/ImportInboxModelTests.cs
@@ -94,6 +94,36 @@ public sealed class ImportInboxModelTests : IDisposable
     }
 
     [Fact]
+    public void MissingSource_SetsErrorMessage_AndClearsOnRefresh()
+    {
+        var missing = Path.Combine(Path.GetTempPath(), $"missing-{Guid.NewGuid():N}.pdf");
+        var item = new ImportInboxItem { Id = 1, SourcePath = missing, DisplayName = "test", State = ImportInboxState.Failed };
+        _repository.Items.Add(item);
+        var model = new ImportInboxModel(_repository, new ModelLauncher(), new ModelNavigation(), new ModelLocalization(), new ModelImportService());
+        model.SelectedItem = item;
+
+        model.RetrySelectedCommand.Execute(null);
+
+        Assert.Equal("ImportInbox_SourceMissing", model.ErrorMessage);
+        Assert.NotEqual("ImportInbox_SourceMissing", model.StatusText);
+
+        model.RefreshCommand.Execute(null);
+        Assert.Equal(string.Empty, model.ErrorMessage);
+    }
+
+    [Fact]
+    public void Refresh_UpdatesStatusTextWithLoadedItemCount()
+    {
+        _repository.Items.Add(new ImportInboxItem { Id = 1, SourcePath = _source, DisplayName = "t", State = ImportInboxState.Held });
+        var model = new ImportInboxModel(_repository, new ModelLauncher(), new ModelNavigation(), new ModelLocalization(), new ModelImportService());
+        Assert.Equal("1", model.StatusText);
+
+        _repository.Items.Add(new ImportInboxItem { Id = 2, SourcePath = _source, DisplayName = "t2", State = ImportInboxState.Pending });
+        model.RefreshCommand.Execute(null);
+        Assert.Equal("2", model.StatusText);
+    }
+
+    [Fact]
     public void ApplyBulkMetadata_MixedSuccess_OnlySuccessfulBecomesProcessed()
     {
         var ok = new ImportInboxItem { Id = 1, SourcePath = _source, DisplayName = "ok", State = ImportInboxState.Held, DocumentId = 10, Subject = "Old" };

--- a/StudyDocumentManager.Tests/ImportInboxViewTests.cs
+++ b/StudyDocumentManager.Tests/ImportInboxViewTests.cs
@@ -1,0 +1,80 @@
+using System.Linq;
+using Avalonia.Automation;
+using Avalonia.Controls;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Microsoft.Extensions.DependencyInjection;
+using StudyDocumentManager.Core.Entities;
+using StudyDocumentManager.Core.Interfaces;
+using StudyDocumentManager.Models;
+using StudyDocumentManager.Services;
+using StudyDocumentManager.Views;
+using Xunit;
+
+namespace StudyDocumentManager.Tests;
+
+public sealed class ImportInboxViewTests
+{
+    private static T? FindByAutomationId<T>(Control root, string id) where T : Control
+    {
+        return root.GetVisualDescendants().OfType<T>()
+            .FirstOrDefault(c => AutomationProperties.GetAutomationId(c) == id);
+    }
+
+    [Avalonia.Headless.XUnit.AvaloniaFact]
+    public void RefreshButton_ResolvesLocalizedText_NotMissingKeyPlaceholder()
+    {
+        var loc = App.Services!.GetRequiredService<ILocalizationService>();
+        var repo = new FakeRepo();
+        var model = new ImportInboxModel(repo, new FakeLauncher(), new FakeNav(), loc);
+        var view = new ImportInbox { DataContext = model };
+        var window = new Window { Content = view };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var refresh = FindByAutomationId<Button>(view, "ImportInbox_Refresh");
+        Assert.NotNull(refresh);
+        Assert.NotNull(refresh!.Content);
+        Assert.NotEqual("[Btn_Refresh]", refresh.Content);
+        Assert.False(string.IsNullOrWhiteSpace(refresh.Content as string));
+
+        window.Close();
+    }
+
+    [Avalonia.Headless.XUnit.AvaloniaFact]
+    public void ActionPanel_HiddenWhenEmpty_VisibleWhenItems()
+    {
+        var loc = App.Services!.GetRequiredService<ILocalizationService>();
+        var repo = new FakeRepo();
+        var model = new ImportInboxModel(repo, new FakeLauncher(), new FakeNav(), loc);
+        var view = new ImportInbox { DataContext = model };
+        var window = new Window { Content = view };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var panel = FindByAutomationId<StackPanel>(view, "ImportInbox_ActionPanel");
+        Assert.NotNull(panel);
+        Assert.False(panel!.IsVisible);
+
+        repo.Items.Add(new ImportInboxItem { Id = 1, SourcePath = "x", DisplayName = "x", State = ImportInboxState.Pending });
+        model.RefreshCommand.Execute(null);
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(panel.IsVisible);
+
+        window.Close();
+    }
+
+    private sealed class FakeRepo : IImportInboxRepository
+    {
+        public List<ImportInboxItem> Items { get; } = new();
+        public IReadOnlyList<ImportInboxItem> GetAll(bool includeProcessed = false) => includeProcessed ? Items : Items.Where(i => i.State != ImportInboxState.Processed).ToList();
+        public ImportInboxItem? GetById(int id) => Items.FirstOrDefault(i => i.Id == id);
+        public int Add(ImportInboxItem item) { item.Id = Items.Count + 1; Items.Add(item); return item.Id; }
+        public bool Update(ImportInboxItem item) => true;
+        public bool UpdateState(int id, ImportInboxState state, string? failureCode = null) { var it = GetById(id); if (it is not null) { it.State = state; it.FailureCode = failureCode; } return true; }
+        public int BulkEditMetadata(IReadOnlyList<int> documentIds, BulkEditChanges changes) => documentIds.Count;
+    }
+
+    private sealed class FakeLauncher : IProcessLauncherService { public void OpenFile(string p) { } public void RevealInExplorer(string p) { } public void OpenUrl(string u) { } }
+    private sealed class FakeNav : INavigationService { public bool CanGoBack => true; public void NavigateTo(string v) { } public void NavigateTo(string v, object? p) { } public void GoBack() { } }
+}

--- a/StudyDocumentManager.Tests/Issue60ViewRenderSmokeTests.cs
+++ b/StudyDocumentManager.Tests/Issue60ViewRenderSmokeTests.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Avalonia.Automation;
+using Avalonia.Controls;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Microsoft.Extensions.DependencyInjection;
+using StudyDocumentManager.Core.Entities;
+using StudyDocumentManager.Core.Interfaces;
+using StudyDocumentManager.Models;
+using StudyDocumentManager.Services;
+using StudyDocumentManager.Views;
+using Xunit;
+
+namespace StudyDocumentManager.Tests;
+
+public sealed class Issue60ViewRenderSmokeTests
+{
+    private static T? FindByAutomationId<T>(Control root, string id) where T : Control =>
+        root.GetVisualDescendants().OfType<T>()
+            .FirstOrDefault(c => AutomationProperties.GetAutomationId(c) == id);
+
+    private static void RenderAt(Window window, Control view, double width, string screenId, string childId)
+    {
+        window.Width = width;
+        window.InvalidateMeasure();
+        window.InvalidateVisual();
+        Dispatcher.UIThread.RunJobs();
+        Assert.Equal(screenId, AutomationProperties.GetAutomationId(view));
+        Assert.NotNull(FindByAutomationId<Control>(view, childId));
+    }
+
+    [Avalonia.Headless.XUnit.AvaloniaFact]
+    public void BatchImport_Renders_AtNarrowAndWide_WithStatusAndGrid()
+    {
+        var s = App.Services!;
+        var model = new BatchImportModel(
+            s.GetRequiredService<IDialogService>(),
+            s.GetRequiredService<IFileDialogService>(),
+            s.GetRequiredService<INavigationService>(),
+            s.GetRequiredService<ILocalizationService>(),
+            s.GetRequiredService<IDroppedFileImportService>());
+        var view = new BatchImport { DataContext = model };
+        var window = new Window { Content = view };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.NotNull(FindByAutomationId<Button>(view, "BatchImport_Import"));
+        Assert.NotNull(FindByAutomationId<Button>(view, "BatchImport_Cancel"));
+        Assert.NotNull(FindByAutomationId<TextBlock>(view, "BatchImport_Status"));
+        Assert.NotNull(FindByAutomationId<DataGrid>(view, "BatchImport_FileGrid"));
+
+        RenderAt(window, view, 520, "Screen_BatchImport", "BatchImport_Import");
+        RenderAt(window, view, 1280, "Screen_BatchImport", "BatchImport_Import");
+        window.Close();
+    }
+
+    [Avalonia.Headless.XUnit.AvaloniaFact]
+    public void WatchedFolder_Renders_WithUiaNameStatus_AndReflowsAtNarrow()
+    {
+        var s = App.Services!;
+        var model = new WatchedFolderModel(
+            s.GetRequiredService<IFolderWatchService>(),
+            s.GetRequiredService<INavigationService>(),
+            s.GetRequiredService<ILocalizationService>(),
+            s.GetRequiredService<ILog>());
+        var view = new StudyDocumentManager.Views.WatchedFolder { DataContext = model };
+        var window = new Window { Content = view };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var path = FindByAutomationId<TextBox>(view, "WatchedFolder_Path");
+        Assert.NotNull(path);
+        Assert.False(string.IsNullOrWhiteSpace(AutomationProperties.GetName(path!)));
+
+        Assert.NotNull(FindByAutomationId<TextBlock>(view, "WatchedFolder_Status"));
+        Assert.NotNull(FindByAutomationId<Button>(view, "WatchedFolder_Add"));
+
+        RenderAt(window, view, 520, "WatchedFolder_Screen", "WatchedFolder_Path");
+        RenderAt(window, view, 1280, "WatchedFolder_Screen", "WatchedFolder_Path");
+        window.Close();
+    }
+
+    [Avalonia.Headless.XUnit.AvaloniaFact]
+    public void RecoveryCenterView_Renders_WithScrollAndStatus()
+    {
+        var s = App.Services!;
+        var model = new RecoveryCenterModel(
+            s.GetRequiredService<IVersionedBackupService>(),
+            s.GetRequiredService<IDialogService>(),
+            s.GetRequiredService<IFileDialogService>(),
+            s.GetRequiredService<INavigationService>(),
+            s.GetRequiredService<IApplicationLifecycleService>(),
+            s.GetRequiredService<IProcessLauncherService>(),
+            s.GetRequiredService<ILocalizationService>());
+        var view = new RecoveryCenterView { DataContext = model };
+        var window = new Window { Content = view };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.NotNull(FindByAutomationId<TextBlock>(view, "Recovery_LatestStatus"));
+        Assert.NotNull(FindByAutomationId<DataGrid>(view, "Recovery_VersionsGrid"));
+        Assert.True(view.GetVisualDescendants().OfType<ScrollViewer>().Any());
+
+        RenderAt(window, view, 520, "Screen_RecoveryCenter", "Recovery_VersionsGrid");
+        RenderAt(window, view, 1280, "Screen_RecoveryCenter", "Recovery_VersionsGrid");
+        window.Close();
+    }
+
+    [Avalonia.Headless.XUnit.AvaloniaFact]
+    public async Task DuplicateDetection_Renders_PerDocumentViewDeleteActions_AfterScan()
+    {
+        var s = App.Services!;
+        var docs = new List<StudyDocument>
+        {
+            new StudyDocument { Id = 1, Name = "Report.pdf", FilePath = "C:/docs/report.pdf" },
+            new StudyDocument { Id = 2, Name = "Report.pdf", FilePath = "C:/docs/report-copy.pdf" },
+        };
+        var model = new DuplicateDetectionModel(
+            new FakeScanRepository(docs),
+            s.GetRequiredService<IDialogService>(),
+            s.GetRequiredService<ILocalizationService>(),
+            s.GetRequiredService<IProcessLauncherService>());
+        var view = new DuplicateDetection { DataContext = model };
+        var window = new Window { Content = view };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.NotNull(FindByAutomationId<Button>(view, "DuplicateDetection_Scan"));
+
+        await model.ScanDuplicatesCommand.ExecuteAsync(null);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(model.HasResults);
+        Assert.NotNull(FindByAutomationId<Button>(view, "DuplicateDetection_View"));
+        Assert.NotNull(FindByAutomationId<Button>(view, "DuplicateDetection_Delete"));
+        Assert.NotNull(FindByAutomationId<Button>(view, "DuplicateDetection_Merge"));
+
+        RenderAt(window, view, 520, "Screen_DuplicateDetection", "DuplicateDetection_View");
+        RenderAt(window, view, 1280, "Screen_DuplicateDetection", "DuplicateDetection_View");
+        window.Close();
+    }
+
+    private sealed class FakeScanRepository : IDocumentRepository
+    {
+        private readonly List<StudyDocument> _docs;
+        public FakeScanRepository(List<StudyDocument> docs) => _docs = docs;
+        public List<StudyDocument> GetAll() => _docs;
+        public StudyDocument? GetById(int id) => _docs.FirstOrDefault(d => d.Id == id);
+        public List<StudyDocument> Search(string keyword) => _docs;
+        public List<StudyDocument> Filter(string subject, string type) => _docs;
+        public List<StudyDocument> SearchAdvanced(string keyword, string subject, string type, DateTime? fromDate, DateTime? toDate, double? minSize, double? maxSize, bool? isImportant) => _docs;
+        public bool Add(StudyDocument document) => true;
+        public bool AddWithCatalogs(StudyDocument document) => true;
+        public bool Update(StudyDocument document) => true;
+        public bool Delete(int id) => true;
+        public List<string> GetDistinctSubjects() => new();
+        public List<string> GetDistinctTypes() => new();
+        public List<string> GetDistinctTags() => new();
+        public List<StudyDocument> GetUpcomingDeadlines(int days) => new();
+        public List<StudyDocument> GetOverdueDocuments() => new();
+        public void EnsureSubjectExists(string subject) { }
+        public void EnsureTypeExists(string type) { }
+    }
+}

--- a/StudyDocumentManager.Tests/KeyboardEnterEscapeGapTests.cs
+++ b/StudyDocumentManager.Tests/KeyboardEnterEscapeGapTests.cs
@@ -1,4 +1,5 @@
 using Avalonia;
+using Avalonia.Automation;
 using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Headless.XUnit;
@@ -257,6 +258,77 @@ public class KeyboardEnterEscapeGapTests
             Assert.NotNull(cancelButton);
             Assert.True(confirmButton!.IsDefault);
             Assert.True(cancelButton!.IsCancel);
+        }
+        finally
+        {
+            dialog.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void AffectedItemsPreviewDialog_FocusesCancelButtonOnOpen()
+    {
+        var localization = GetLocalization();
+        var dialog = new AffectedItemsPreviewDialog("Title", 1, ["Doc"], "note", localization);
+        dialog.Show();
+
+        try
+        {
+            FlushAvaloniaBindings();
+
+            var cancelButton = dialog.FindControl<Button>("CancelButton");
+            Assert.NotNull(cancelButton);
+            Assert.Same(cancelButton, dialog.FocusManager?.GetFocusedElement());
+        }
+        finally
+        {
+            dialog.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void BulkEditPreviewDialog_FocusesCancelButtonOnOpen()
+    {
+        var localization = GetLocalization();
+        var dialog = new BulkEditPreviewDialog(1, [("Field", "Value")], localization);
+        dialog.Show();
+
+        try
+        {
+            FlushAvaloniaBindings();
+
+            var cancelButton = dialog.FindControl<Button>("CancelButton");
+            Assert.NotNull(cancelButton);
+            Assert.Same(cancelButton, dialog.FocusManager?.GetFocusedElement());
+        }
+        finally
+        {
+            dialog.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void AddDocumentDialog_NameValidationExposesHelpText()
+    {
+        var localization = GetLocalization();
+        var dialog = new AddDocumentDialog("C:/drop/test.pdf", ["Study"], ["PDF"]);
+        dialog.Show();
+
+        try
+        {
+            FlushAvaloniaBindings();
+
+            var saveButton = dialog.FindControl<Button>("btnSave");
+            var nameBox = dialog.FindControl<TextBox>("txtTen");
+            Assert.NotNull(saveButton);
+            Assert.NotNull(nameBox);
+
+            nameBox!.Text = string.Empty;
+            saveButton!.RaiseEvent(new Avalonia.Interactivity.RoutedEventArgs(Button.ClickEvent));
+            FlushAvaloniaBindings();
+
+            var helpText = nameBox.GetValue(AutomationProperties.HelpTextProperty) as string;
+            Assert.Equal(localization["AddEdit_NameRequired"], helpText);
         }
         finally
         {

--- a/StudyDocumentManager.Tests/PersonalNoteUiRegressionTests.cs
+++ b/StudyDocumentManager.Tests/PersonalNoteUiRegressionTests.cs
@@ -195,6 +195,43 @@ public sealed class PersonalNoteUiRegressionTests
         }
     }
 
+    [Fact]
+    public async Task PersonalNote_DirtyBack_ConfirmsBeforeNavigating()
+    {
+        var dialog = new DialogServiceStub { ConfirmResult = false };
+        var navigation = new NavigationServiceStub();
+        var model = new PersonalNoteModel(
+            new PersonalNoteRepositoryStub(), dialog, navigation, new LocalizationServiceStub());
+        model.Load(7, "Algebra");
+        model.NoteContent = "Draft note";
+
+        await model.GoBackCommand.ExecuteAsync(null);
+
+        Assert.Equal(1, dialog.ConfirmCount);
+        Assert.False(navigation.WentBack);
+
+        dialog.ConfirmResult = true;
+        await model.GoBackCommand.ExecuteAsync(null);
+
+        Assert.Equal(2, dialog.ConfirmCount);
+        Assert.True(navigation.WentBack);
+    }
+
+    [Fact]
+    public async Task PersonalNote_UnchangedBack_NavigatesWithoutConfirmation()
+    {
+        var dialog = new DialogServiceStub();
+        var navigation = new NavigationServiceStub();
+        var model = new PersonalNoteModel(
+            new PersonalNoteRepositoryStub(), dialog, navigation, new LocalizationServiceStub());
+        model.Load(7, "Algebra");
+
+        await model.GoBackCommand.ExecuteAsync(null);
+
+        Assert.Equal(0, dialog.ConfirmCount);
+        Assert.True(navigation.WentBack);
+    }
+
     private sealed class PersonalNoteRepositoryStub : IPersonalNoteRepository
     {
         public string? SavedContent { get; private set; }
@@ -209,19 +246,26 @@ public sealed class PersonalNoteUiRegressionTests
 
     private sealed class DialogServiceStub : IDialogService
     {
+        public bool ConfirmResult { get; set; }
+        public int ConfirmCount { get; private set; }
         public Task ShowMessageAsync(string title, string message) => Task.CompletedTask;
         public Task ShowErrorAsync(string title, string message) => Task.CompletedTask;
         public Task<bool> ShowConfirmAsync(string title, string message) => Task.FromResult(false);
-        public Task<bool> ShowConfirmAsync(string title, string message, string confirmText, bool isDanger = false) => Task.FromResult(false);
+        public Task<bool> ShowConfirmAsync(string title, string message, string confirmText, bool isDanger = false)
+        {
+            ConfirmCount++;
+            return Task.FromResult(ConfirmResult);
+        }
         public Task<string?> ShowInputAsync(string title, string label, string defaultValue = "", string watermark = "") => Task.FromResult<string?>(null);
     }
 
     private sealed class NavigationServiceStub : INavigationService
     {
         public bool CanGoBack => true;
+        public bool WentBack { get; private set; }
         public void NavigateTo(string viewKey) { }
         public void NavigateTo(string viewKey, object? parameter) { }
-        public void GoBack() { }
+        public void GoBack() => WentBack = true;
     }
 
     private sealed class LocalizationServiceStub : ILocalizationService

--- a/StudyDocumentManager.Tests/RecoveryCenterTests.cs
+++ b/StudyDocumentManager.Tests/RecoveryCenterTests.cs
@@ -576,6 +576,36 @@ public sealed class RecoveryCenterTests : IDisposable
     }
 
     [Fact]
+    public void SelectedVersion_Null_DisablesRestore()
+    {
+        var (model, _, _, _, _, _) = CreateModel();
+
+        model.SelectedVersion = null;
+
+        Assert.False(model.CanRestoreSelected);
+    }
+
+    [Fact]
+    public void SelectedVersion_Valid_EnablesRestore()
+    {
+        var (model, _, _, _, _, _) = CreateModel();
+        model.SelectedVersion = new BackupVersionInfo(
+            @"C:\\stub\\valid.db", DateTime.Now, 10, IsValid: true, IsLatest: true);
+
+        Assert.True(model.CanRestoreSelected);
+    }
+
+    [Fact]
+    public void SelectedVersion_Invalid_DisablesRestore()
+    {
+        var (model, _, _, _, _, _) = CreateModel();
+        model.SelectedVersion = new BackupVersionInfo(
+            @"C:\\stub\\invalid.db", DateTime.Now, 10, IsValid: false, IsLatest: false);
+
+        Assert.False(model.CanRestoreSelected);
+    }
+
+    [Fact]
     public async Task RestoreSelectedAsync_WhenConfirmationCancelled_DoesNotRestoreOrShutdown()
     {
         var version = SeedSingleVersionAndMutate();

--- a/StudyDocumentManager.Tests/RecoveryCenterTests.cs
+++ b/StudyDocumentManager.Tests/RecoveryCenterTests.cs
@@ -408,6 +408,55 @@ public sealed class RecoveryCenterTests : IDisposable
     }
 
     [Fact]
+    public async Task LoadedVersions_PopulateRecoverySummaryState()
+    {
+        var created = new DateTime(2026, 3, 4, 5, 6, 7);
+        var version = new BackupVersionInfo(@"C:\stub\v.db", created, 10, IsValid: true, IsLatest: true);
+        var stub = new StubVersionedBackupService { ListHandler = () => [version] };
+
+        var model = new RecoveryCenterModel(
+            stub,
+            new RecordingDialogService(),
+            new StubFileDialogService(),
+            new StubNavigationService(),
+            new RecordingLifecycleService(),
+            new StubProcessLauncherService(),
+            new KeyLocalizationService());
+
+        for (var i = 0; i < 500 && model.IsLoading; i++)
+            await Task.Delay(10);
+
+        Assert.False(model.IsLoading);
+        Assert.True(model.HasVersions);
+        Assert.Equal(version.CreatedAtLocal.ToString("yyyy-MM-dd HH:mm:ss"), model.LatestBackupText);
+        Assert.Equal("RC_StatusValid", model.LatestStatusText);
+        Assert.Equal(stub.BackupDirectory, model.BackupLocationText);
+    }
+
+    [Fact]
+    public async Task NoVersions_ShowsNoneStateForRecoverySummary()
+    {
+        var stub = new StubVersionedBackupService { ListHandler = () => [] };
+
+        var model = new RecoveryCenterModel(
+            stub,
+            new RecordingDialogService(),
+            new StubFileDialogService(),
+            new StubNavigationService(),
+            new RecordingLifecycleService(),
+            new StubProcessLauncherService(),
+            new KeyLocalizationService());
+
+        for (var i = 0; i < 500 && model.IsLoading; i++)
+            await Task.Delay(10);
+
+        Assert.False(model.HasVersions);
+        Assert.Equal("RC_LatestNone", model.LatestBackupText);
+        Assert.Equal("RC_StatusNone", model.LatestStatusText);
+        Assert.Equal(stub.BackupDirectory, model.BackupLocationText);
+    }
+
+    [Fact]
     public async Task ConcurrentCreateAndRetention_EachCallerGetsOwnOutcome()
     {
         var version = new BackupVersionInfo(@"C:\stub\c.db", DateTime.Now, 10, IsValid: true, IsLatest: true);

--- a/StudyDocumentManager.Tests/RecycleBinReproTests.cs
+++ b/StudyDocumentManager.Tests/RecycleBinReproTests.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using Avalonia.Controls;
+using Avalonia.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using StudyDocumentManager.Core.Entities;
+using StudyDocumentManager.Core.Interfaces;
+using StudyDocumentManager.Models;
+using StudyDocumentManager.Services;
+using StudyDocumentManager.Views;
+using Xunit;
+
+namespace StudyDocumentManager.Tests;
+
+public sealed class RecycleBinReproTests
+{
+    private sealed class FakeRecycleRepo : IRecycleBinRepository
+    {
+        private readonly List<StudyDocument> _docs;
+        public FakeRecycleRepo(List<StudyDocument> docs) => _docs = docs;
+        public List<StudyDocument> GetDeletedDocuments() => _docs;
+        public bool RestoreDocument(int id) => false;
+        public bool PermanentDeleteDocument(int id) => false;
+        public int EmptyRecycleBin() => 0;
+        public int GetDeletedDocumentCount() => _docs.Count;
+    }
+
+    [Avalonia.Headless.XUnit.AvaloniaFact]
+    public void RecycleBin_Renders_Without_Binding_Loop()
+    {
+        var services = App.Services!;
+        var dialog = services.GetRequiredService<IDialogService>();
+        var loc = services.GetRequiredService<ILocalizationService>();
+
+        var docs = new List<StudyDocument>
+        {
+            new() { Id = 1, Name = "doc-word", Type = "Word", Subject = "Project", CreatedAt = new DateTime(2026, 8, 12, 10, 22, 14) },
+            new() { Id = 2, Name = "doc-ppt", Type = "PowerPoint", Subject = "", CreatedAt = new DateTime(2026, 8, 12, 10, 22, 42) },
+            new() { Id = 3, Name = "doc-pdf", Type = "PDF", Subject = "ImportSubject", CreatedAt = new DateTime(2026, 8, 17, 5, 52, 13) },
+        };
+
+        var model = new RecycleBinModel(new FakeRecycleRepo(docs), dialog, loc);
+        Assert.Equal(3, model.DeletedDocuments.Count);
+
+        var view = new RecycleBin { DataContext = model };
+        var window = new Window { Content = view };
+
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(3, model.DeletedDocuments.Count);
+        window.Close();
+    }
+}

--- a/StudyDocumentManager.Tests/ScanRecoveryTests.cs
+++ b/StudyDocumentManager.Tests/ScanRecoveryTests.cs
@@ -3,6 +3,7 @@ using StudyDocumentManager.Core.Entities;
 using StudyDocumentManager.Core.Interfaces;
 using StudyDocumentManager.Models;
 using StudyDocumentManager.Services;
+using StudyDocumentManager.Tests.TestDoubles;
 using Xunit;
 
 namespace StudyDocumentManager.Tests;
@@ -286,6 +287,30 @@ public class ScanRecoveryTests
 
         Assert.Single(model.DuplicateGroups);
         Assert.Single(dialogs.Errors);
+    }
+
+    [Fact]
+    public void ViewDocumentCommand_OpensTheTargetDocumentFile()
+    {
+        var doc = new StudyDocument { Id = 7, Name = "dup.pdf", FilePath = Path.Combine(Path.GetTempPath(), "dup-view.pdf") };
+        var launcher = new StubProcessLauncherService();
+        var model = new DuplicateDetectionModel(new ThrowingDocumentRepository(), new RecordingDialogService(), new LocalizationServiceStub(), launcher);
+
+        model.ViewDocumentCommand.Execute(doc);
+
+        Assert.Contains(doc.FilePath, launcher.OpenedFiles);
+    }
+
+    [Fact]
+    public void ViewDocumentCommand_IgnoresNullDocumentAndEmptyPath()
+    {
+        var launcher = new StubProcessLauncherService();
+        var model = new DuplicateDetectionModel(new ThrowingDocumentRepository(), new RecordingDialogService(), new LocalizationServiceStub(), launcher);
+
+        model.ViewDocumentCommand.Execute(null);
+        model.ViewDocumentCommand.Execute(new StudyDocument { Id = 1 });
+
+        Assert.Empty(launcher.OpenedFiles);
     }
 
     [Fact]

--- a/StudyDocumentManager.Tests/Task5DashboardRecentFilesTests.cs
+++ b/StudyDocumentManager.Tests/Task5DashboardRecentFilesTests.cs
@@ -50,6 +50,43 @@ public sealed class Task5DashboardRecentFilesTests
     }
 
     [Fact]
+    public void Dashboard_UpcomingQuickFilter_UpdatesVisibleStateAndStatus()
+    {
+        var repository = new Task5DocumentRepository([new StudyDocument { Id = 1, Name = "All", IsImportant = true }])
+        {
+            UpcomingDocuments = [new StudyDocument { Id = 2, Name = "Due soon", IsImportant = true }]
+        };
+        var model = CreateDashboard(repository);
+        model.Initialize();
+
+        model.ShowUpcomingDeadlinesCommand.Execute(null);
+
+        Assert.Single(model.Documents);
+        Assert.Equal("Due soon", model.Documents[0].Name);
+        Assert.Equal(1, model.TotalDocuments);
+        Assert.Equal(1, model.ImportantDocuments);
+        Assert.False(model.IsEmptyState);
+        Assert.Contains("Status_UpcomingDeadlines", model.StatusText);
+    }
+
+    [Fact]
+    public void Dashboard_OverdueQuickFilter_UpdatesEmptyStateAndStats()
+    {
+        var repository = new Task5DocumentRepository([new StudyDocument { Id = 1, Name = "All", IsImportant = true }]);
+        var model = CreateDashboard(repository);
+        model.Initialize();
+
+        model.ShowOverdueCommand.Execute(null);
+
+        Assert.Empty(model.Documents);
+        Assert.Equal(0, model.TotalDocuments);
+        Assert.Equal(0, model.ImportantDocuments);
+        Assert.True(model.IsEmptyState);
+        Assert.Equal("empty", model.StateMessage);
+        Assert.Contains("Status_Overdue", model.StatusText);
+    }
+
+    [Fact]
     public void Dashboard_CollectionFilter_UpdatesStatsAndEmptyState()
     {
         var repository = new Task5DocumentRepository([new StudyDocument { Id = 1, Name = "All" }]);
@@ -107,6 +144,26 @@ public sealed class Task5DashboardRecentFilesTests
 
             Assert.Equal([path], launcher.OpenedFiles);
             Assert.Equal([7], recent.AddedIds);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void RecentFiles_OpenSuccess_RefreshesVisibleHistory()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            var openedAt = DateTime.UtcNow.AddMinutes(-5);
+            var recent = new Task5RecentRepository((11, "Refresh", "Math", "PDF", path, openedAt));
+            var model = CreateRecent(recent, new Task5Launcher());
+
+            model.OpenFileCommand.Execute(Assert.Single(model.RecentFiles));
+
+            Assert.True(model.RecentFiles.Single().OpenedAt > openedAt);
         }
         finally
         {
@@ -193,6 +250,8 @@ public sealed class Task5DashboardRecentFilesTests
     {
         private readonly List<StudyDocument> _documents = documents;
         public bool ThrowOnNextGetAll { get; set; }
+        public List<StudyDocument> UpcomingDocuments { get; set; } = [];
+        public List<StudyDocument> OverdueDocuments { get; set; } = [];
         public List<StudyDocument> GetAll() { if (ThrowOnNextGetAll) { ThrowOnNextGetAll = false; throw new IOException("load failed"); } return [.._documents]; }
         public StudyDocument? GetById(int id) => _documents.FirstOrDefault(d => d.Id == id);
         public List<StudyDocument> Search(string keyword) => [];
@@ -205,8 +264,8 @@ public sealed class Task5DashboardRecentFilesTests
         public List<string> GetDistinctSubjects() => [];
         public List<string> GetDistinctTypes() => [];
         public List<string> GetDistinctTags() => [];
-        public List<StudyDocument> GetUpcomingDeadlines(int days) => [];
-        public List<StudyDocument> GetOverdueDocuments() => [];
+        public List<StudyDocument> GetUpcomingDeadlines(int days) => [..UpcomingDocuments];
+        public List<StudyDocument> GetOverdueDocuments() => [..OverdueDocuments];
         public void EnsureSubjectExists(string subject) { }
         public void EnsureTypeExists(string type) { }
     }
@@ -215,7 +274,17 @@ public sealed class Task5DashboardRecentFilesTests
     {
         public List<int> AddedIds { get; } = [];
         public List<(int Id, string Name, string? Subject, string? Type, string? FilePath, DateTime OpenedAt)> GetAll() => [..items];
-        public bool Add(int documentId) { AddedIds.Add(documentId); return true; }
+        public bool Add(int documentId)
+        {
+            AddedIds.Add(documentId);
+            for (var i = 0; i < items.Length; i++)
+            {
+                if (items[i].Id == documentId)
+                    items[i].OpenedAt = DateTime.UtcNow;
+            }
+
+            return true;
+        }
         public void Clear() { }
     }
 

--- a/StudyDocumentManager/Models/DashboardModel.cs
+++ b/StudyDocumentManager/Models/DashboardModel.cs
@@ -1022,7 +1022,7 @@ public partial class DashboardModel : ModelBase, IDisposable
     private void ShowUpcomingDeadlines()
     {
         var docs = _repository.GetUpcomingDeadlines(7);
-        Documents = docs.ToList();
+        UpdateVisibleState(docs);
         SetLocalizedStatus("Status_UpcomingDeadlines", docs.Count);
     }
 
@@ -1030,7 +1030,7 @@ public partial class DashboardModel : ModelBase, IDisposable
     private void ShowOverdue()
     {
         var docs = _repository.GetOverdueDocuments();
-        Documents = docs.ToList();
+        UpdateVisibleState(docs);
         SetLocalizedStatus("Status_Overdue", docs.Count);
     }
 

--- a/StudyDocumentManager/Models/DuplicateDetectionModel.cs
+++ b/StudyDocumentManager/Models/DuplicateDetectionModel.cs
@@ -12,16 +12,18 @@ public partial class DuplicateDetectionModel : ModelBase
     private readonly IDocumentRepository _repository;
     private readonly IDialogService _dialogService;
     private readonly ILocalizationService _loc;
+    private readonly IProcessLauncherService? _processLauncher;
 
     [ObservableProperty] private ObservableCollection<DuplicateGroup> _duplicateGroups = new();
     [ObservableProperty] private bool _isScanning;
     [ObservableProperty] private int _totalGroups;
 
-    public DuplicateDetectionModel(IDocumentRepository repository, IDialogService dialogService, ILocalizationService loc)
+    public DuplicateDetectionModel(IDocumentRepository repository, IDialogService dialogService, ILocalizationService loc, IProcessLauncherService? processLauncher = null)
     {
         _repository = repository;
         _dialogService = dialogService;
         _loc = loc;
+        _processLauncher = processLauncher;
     }
 
     public bool HasResults => DuplicateGroups.Count > 0;
@@ -136,6 +138,14 @@ public partial class DuplicateDetectionModel : ModelBase
         {
             await _dialogService.ShowErrorAsync(_loc["Dialog_Error"], _loc["Msg_Error"]);
         }
+    }
+
+    [RelayCommand]
+    private void ViewDocument(StudyDocument? doc)
+    {
+        if (doc is null || _processLauncher is null || string.IsNullOrEmpty(doc.FilePath))
+            return;
+        _processLauncher.OpenFile(doc.FilePath);
     }
 }
 

--- a/StudyDocumentManager/Models/ImportInboxModel.cs
+++ b/StudyDocumentManager/Models/ImportInboxModel.cs
@@ -23,6 +23,7 @@ public partial class ImportInboxModel : ModelBase, IDisposable
     [ObservableProperty] private bool _includeProcessed;
     [ObservableProperty] private ImportInboxItem? _selectedItem;
     [ObservableProperty] private string _statusText = string.Empty;
+    [ObservableProperty] private string _errorMessage = string.Empty;
     [ObservableProperty] private string _bulkSubject = string.Empty;
     [ObservableProperty] private string _bulkType = string.Empty;
     public ObservableCollection<ImportInboxItem> SelectedItems { get; } = [];
@@ -101,6 +102,7 @@ public partial class ImportInboxModel : ModelBase, IDisposable
         SelectedItem = null;
         NotifyBulkEditState();
         StatusText = FormatStatus();
+        ErrorMessage = string.Empty;
         OnPropertyChanged(nameof(HasItems));
         OnPropertyChanged(nameof(IsEmpty));
     }
@@ -131,7 +133,7 @@ public partial class ImportInboxModel : ModelBase, IDisposable
         if (SelectedItem is null) return;
         if (!File.Exists(SelectedItem.SourcePath))
         {
-            StatusText = _loc["ImportInbox_SourceMissing"];
+            ErrorMessage = _loc["ImportInbox_SourceMissing"];
             return;
         }
         if (_importService is null) return;
@@ -185,7 +187,7 @@ public partial class ImportInboxModel : ModelBase, IDisposable
     {
         if (SelectedItem is null || !File.Exists(SelectedItem.SourcePath))
         {
-            StatusText = _loc["ImportInbox_SourceMissing"];
+            ErrorMessage = _loc["ImportInbox_SourceMissing"];
             return;
         }
         _processLauncher.RevealInExplorer(SelectedItem.SourcePath);

--- a/StudyDocumentManager/Models/PersonalNoteModel.cs
+++ b/StudyDocumentManager/Models/PersonalNoteModel.cs
@@ -97,5 +97,16 @@ public partial class PersonalNoteModel : ModelBase
     }
 
     [RelayCommand]
-    private void GoBack() => _navigationService.GoBack();
+    private async Task GoBackAsync()
+    {
+        if (string.Equals(NoteContent, SavedNoteContent, StringComparison.Ordinal))
+        {
+            _navigationService.GoBack();
+            return;
+        }
+
+        var confirmed = await _dialogService.ShowConfirmAsync(_loc["Dialog_Confirm"], _loc["Note_ConfirmDiscard"], _loc["Note_Discard"]);
+        if (confirmed)
+            _navigationService.GoBack();
+    }
 }

--- a/StudyDocumentManager/Models/RecentFilesModel.cs
+++ b/StudyDocumentManager/Models/RecentFilesModel.cs
@@ -72,7 +72,8 @@ public partial class RecentFilesModel : ModelBase
             return;
         }
 
-        _recentRepo.Add(item.DocumentId);
+        if (_recentRepo.Add(item.DocumentId))
+            LoadData();
     }
 
     [RelayCommand]

--- a/StudyDocumentManager/Models/RecoveryCenterModel.cs
+++ b/StudyDocumentManager/Models/RecoveryCenterModel.cs
@@ -54,7 +54,7 @@ public partial class RecoveryCenterModel : ModelBase, IDisposable
     private void OnLanguageChanged(object? sender, EventArgs e) => UpdateLatestSummary(Versions);
 
     partial void OnSelectedVersionChanged(BackupVersionInfo? value)
-        => CanRestoreSelected = value is not null;
+        => CanRestoreSelected = value is { IsValid: true };
 
     [RelayCommand]
     private Task LoadDataAsync() => QueueLoad();

--- a/StudyDocumentManager/Resources/Strings.en.resx
+++ b/StudyDocumentManager/Resources/Strings.en.resx
@@ -844,6 +844,7 @@ Please check your network connection.</value></data>
   <data name="SW_Deadline_DueSoon" xml:space="preserve"><value>Due soon</value></data>
   <data name="SW_Deadline_Scheduled" xml:space="preserve"><value>Scheduled</value></data>
   <data name="Btn_Back" xml:space="preserve"><value>Back</value></data>
+  <data name="Btn_Refresh" xml:space="preserve"><value>Refresh</value></data>
   <data name="WF_Title" xml:space="preserve"><value>Watched Folders</value></data>
   <data name="WF_Add" xml:space="preserve"><value>Add</value></data>
   <data name="WF_Remove" xml:space="preserve"><value>Remove</value></data>

--- a/StudyDocumentManager/Resources/Strings.en.resx
+++ b/StudyDocumentManager/Resources/Strings.en.resx
@@ -149,6 +149,8 @@
   <data name="Note_SaveSuccess" xml:space="preserve"><value>Note saved</value></data>
   <data name="Note_SaveError" xml:space="preserve"><value>Cannot save note</value></data>
   <data name="Note_ConfirmDelete" xml:space="preserve"><value>Delete this note?</value></data>
+  <data name="Note_ConfirmDiscard" xml:space="preserve"><value>Discard unsaved changes?</value></data>
+  <data name="Note_Discard" xml:space="preserve"><value>Discard</value></data>
   <data name="Note_DeleteSuccess" xml:space="preserve"><value>Note deleted</value></data>
   <data name="Recent_ConfirmClear" xml:space="preserve"><value>Clear all browsing history?</value></data>
   <data name="Recent_FileExists" xml:space="preserve"><value>✓</value></data>

--- a/StudyDocumentManager/Resources/Strings.resx
+++ b/StudyDocumentManager/Resources/Strings.resx
@@ -149,6 +149,8 @@
   <data name="Note_SaveSuccess" xml:space="preserve"><value>メモを保存しました</value></data>
   <data name="Note_SaveError" xml:space="preserve"><value>メモを保存できません</value></data>
   <data name="Note_ConfirmDelete" xml:space="preserve"><value>このメモを削除しますか？</value></data>
+  <data name="Note_ConfirmDiscard" xml:space="preserve"><value>保存していない変更を破棄しますか？</value></data>
+  <data name="Note_Discard" xml:space="preserve"><value>破棄する</value></data>
   <data name="Note_DeleteSuccess" xml:space="preserve"><value>メモを削除しました</value></data>
 
   <!-- RecentFiles -->

--- a/StudyDocumentManager/Resources/Strings.resx
+++ b/StudyDocumentManager/Resources/Strings.resx
@@ -952,6 +952,7 @@
   <data name="SW_Deadline_DueSoon" xml:space="preserve"><value>期限間近</value></data>
   <data name="SW_Deadline_Scheduled" xml:space="preserve"><value>予定あり</value></data>
   <data name="Btn_Back" xml:space="preserve"><value>戻る</value></data>
+  <data name="Btn_Refresh" xml:space="preserve"><value>更新</value></data>
   <data name="WF_Title" xml:space="preserve"><value>監視フォルダ</value></data>
   <data name="WF_Add" xml:space="preserve"><value>追加</value></data>
   <data name="WF_Remove" xml:space="preserve"><value>削除</value></data>

--- a/StudyDocumentManager/Resources/Strings.vi.resx
+++ b/StudyDocumentManager/Resources/Strings.vi.resx
@@ -1053,6 +1053,7 @@
   <data name="SW_Deadline_DueSoon" xml:space="preserve"><value>Sắp đến hạn</value></data>
   <data name="SW_Deadline_Scheduled" xml:space="preserve"><value>Đã lên lịch</value></data>
   <data name="Btn_Back" xml:space="preserve"><value>Quay lại</value></data>
+  <data name="Btn_Refresh" xml:space="preserve"><value>Làm mới</value></data>
   <data name="WF_Title" xml:space="preserve"><value>Thư mục theo dõi</value></data>
   <data name="WF_Add" xml:space="preserve"><value>Thêm</value></data>
   <data name="WF_Remove" xml:space="preserve"><value>Xóa</value></data>

--- a/StudyDocumentManager/Resources/Strings.vi.resx
+++ b/StudyDocumentManager/Resources/Strings.vi.resx
@@ -455,6 +455,8 @@
   <data name="Note_SaveSuccess" xml:space="preserve"><value>Đã lưu ghi chú</value></data>
   <data name="Note_SaveError" xml:space="preserve"><value>Không thể lưu ghi chú</value></data>
   <data name="Note_ConfirmDelete" xml:space="preserve"><value>Xóa ghi chú này?</value></data>
+  <data name="Note_ConfirmDiscard" xml:space="preserve"><value>Hủy các thay đổi chưa lưu?</value></data>
+  <data name="Note_Discard" xml:space="preserve"><value>Hủy thay đổi</value></data>
   <data name="Note_DeleteSuccess" xml:space="preserve"><value>Đã xóa ghi chú</value></data>
   <data name="Recent_ConfirmClear" xml:space="preserve"><value>Xóa toàn bộ lịch sử xem?</value></data>
   <data name="Recent_FileExists" xml:space="preserve"><value>✓</value></data>

--- a/StudyDocumentManager/Resources/Strings.zh.resx
+++ b/StudyDocumentManager/Resources/Strings.zh.resx
@@ -455,6 +455,8 @@
   <data name="Note_SaveSuccess" xml:space="preserve"><value>备注已保存</value></data>
   <data name="Note_SaveError" xml:space="preserve"><value>无法保存备注</value></data>
   <data name="Note_ConfirmDelete" xml:space="preserve"><value>要删除此备注吗？</value></data>
+  <data name="Note_ConfirmDiscard" xml:space="preserve"><value>要放弃未保存的更改吗？</value></data>
+  <data name="Note_Discard" xml:space="preserve"><value>放弃更改</value></data>
   <data name="Note_DeleteSuccess" xml:space="preserve"><value>备注已删除</value></data>
   <data name="Recent_ConfirmClear" xml:space="preserve"><value>要清除全部浏览历史吗？</value></data>
   <data name="Recent_FileExists" xml:space="preserve"><value>✓</value></data>

--- a/StudyDocumentManager/Resources/Strings.zh.resx
+++ b/StudyDocumentManager/Resources/Strings.zh.resx
@@ -1053,6 +1053,7 @@
   <data name="SW_Deadline_DueSoon" xml:space="preserve"><value>即将到期</value></data>
   <data name="SW_Deadline_Scheduled" xml:space="preserve"><value>已安排</value></data>
   <data name="Btn_Back" xml:space="preserve"><value>返回</value></data>
+  <data name="Btn_Refresh" xml:space="preserve"><value>刷新</value></data>
   <data name="WF_Title" xml:space="preserve"><value>监视文件夹</value></data>
   <data name="WF_Add" xml:space="preserve"><value>添加</value></data>
   <data name="WF_Remove" xml:space="preserve"><value>删除</value></data>

--- a/StudyDocumentManager/Views/AddDocumentDialog.axaml.cs
+++ b/StudyDocumentManager/Views/AddDocumentDialog.axaml.cs
@@ -3,6 +3,7 @@ using StudyDocumentManager.Core.DTOs;
 using System;
 using System.IO;
 using Avalonia;
+using Avalonia.Automation;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using StudyDocumentManager.Core.Interfaces;
@@ -50,14 +51,17 @@ public partial class AddDocumentDialog : Window
         var name = txtTen?.Text?.Trim();
         if (string.IsNullOrWhiteSpace(name))
         {
-            txtNameError.Text = GetNameRequiredMessage();
+            var msg = GetNameRequiredMessage();
+            txtNameError.Text = msg;
             txtNameError.IsVisible = true;
+            txtTen?.SetValue(AutomationProperties.HelpTextProperty, msg);
             txtTen?.Focus();
             return;
         }
 
         txtNameError.IsVisible = false;
         txtNameError.Text = string.Empty;
+        txtTen?.ClearValue(AutomationProperties.HelpTextProperty);
 
         Result = new AddDocumentDraft
         {

--- a/StudyDocumentManager/Views/AffectedItemsPreviewDialog.axaml.cs
+++ b/StudyDocumentManager/Views/AffectedItemsPreviewDialog.axaml.cs
@@ -43,6 +43,8 @@ public partial class AffectedItemsPreviewDialog : Window
         confirmButton.Content = _loc == null ? "OK" : _loc["Action_Delete"];
         confirmButton.Click += (_, _) => { Result = true; Close(); };
         this.FindControl<Button>("CancelButton")!.Click += (_, _) => { Result = false; Close(); };
+
+        this.Opened += (_, _) => this.FindControl<Button>("CancelButton")?.Focus();
     }
 
     private void OnLanguageChanged(object? sender, EventArgs e)

--- a/StudyDocumentManager/Views/BatchImport.axaml
+++ b/StudyDocumentManager/Views/BatchImport.axaml
@@ -90,11 +90,11 @@
                            Foreground="{StaticResource DangerBrush}"/>
             </StackPanel>
 
-            <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" Spacing="8"
+             <WrapPanel DockPanel.Dock="Bottom" Orientation="Horizontal"
                         HorizontalAlignment="Right" Margin="0,12,0,0">
                 <Button Classes="secondary" AutomationProperties.AutomationId="BatchImport_SelectAll"
                         AutomationProperties.Name="{loc:Localize Bulk_BtnSelectAll}"
-                        Command="{Binding SelectAllCommand}" Padding="{StaticResource PaddingBtnMd}">
+                        Command="{Binding SelectAllCommand}" Padding="{StaticResource PaddingBtnMd}" Margin="0,0,8,0">
                     <StackPanel Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
                         <Image Source="{StaticResource IconCheckNeutral}" Width="14" Height="14" VerticalAlignment="Center"/>
                         <TextBlock Text="{loc:Localize Bulk_BtnSelectAll}" FontSize="{StaticResource FontSizeSm}" VerticalAlignment="Center"/>
@@ -102,7 +102,7 @@
                 </Button>
                 <Button Classes="secondary" AutomationProperties.AutomationId="BatchImport_DeselectAll"
                         AutomationProperties.Name="{loc:Localize Bulk_BtnDeselectAll}"
-                        Command="{Binding DeselectAllCommand}" Padding="{StaticResource PaddingBtnMd}">
+                        Command="{Binding DeselectAllCommand}" Padding="{StaticResource PaddingBtnMd}" Margin="0,0,8,0">
                     <StackPanel Orientation="Horizontal" Spacing="4">
                         <Image Source="{StaticResource IconClose}" Width="14" Height="14"/>
                         <TextBlock Text="{loc:Localize Bulk_BtnDeselectAll}" FontSize="{StaticResource FontSizeSm}"/>
@@ -112,13 +112,13 @@
                         AutomationProperties.Name="{loc:Localize BatchImport_BtnRetryFailed}"
                         Command="{Binding RetryFailedCommand}" Padding="{StaticResource PaddingBtnMd}"
                         IsVisible="{Binding HasFailedItems}"
-                        IsEnabled="{Binding !IsImporting}">
+                        IsEnabled="{Binding !IsImporting}" Margin="0,0,8,0">
                     <TextBlock Text="{loc:Localize BatchImport_BtnRetryFailed}" FontSize="{StaticResource FontSizeSm}"/>
                 </Button>
                 <Button Classes="primary" AutomationProperties.AutomationId="BatchImport_Import"
                         AutomationProperties.Name="{loc:Localize BatchImport_BtnImport}"
                         Command="{Binding ImportCommand}" Padding="{StaticResource PaddingBtnLg}"
-                        IsEnabled="{Binding !IsImporting}">
+                        IsEnabled="{Binding !IsImporting}" Margin="0,0,8,0">
                     <StackPanel Orientation="Horizontal" Spacing="4">
                         <Image Source="{StaticResource IconImportWhite}" Width="16" Height="16"/>
                         <TextBlock Text="{loc:Localize BatchImport_BtnImport}" FontSize="{StaticResource FontSizeMd}" FontWeight="SemiBold"/>
@@ -127,9 +127,9 @@
                 <Button Classes="secondary" AutomationProperties.AutomationId="BatchImport_Cancel"
                         AutomationProperties.Name="{loc:Localize AddEdit_BtnCancel}"
                         Command="{Binding CancelCommand}" Padding="{StaticResource PaddingMd}">
-                    <TextBlock Text="{loc:Localize AddEdit_BtnCancel}" FontSize="{StaticResource FontSizeMd}"/>
+                        <TextBlock Text="{loc:Localize AddEdit_BtnCancel}" FontSize="{StaticResource FontSizeMd}"/>
                 </Button>
-            </StackPanel>
+             </WrapPanel>
 
             <Border Background="{StaticResource CardBackground}" CornerRadius="{StaticResource RadiusMd}"
                     BorderBrush="{StaticResource CardBorder}" BorderThickness="1" ClipToBounds="True">
@@ -142,11 +142,32 @@
                               GridLinesVisibility="Horizontal" HeadersVisibility="Column">
                         <DataGrid.Columns>
                             <DataGridCheckBoxColumn Header="✓" Binding="{Binding IsSelected}" Width="40"/>
-                            <DataGridTextColumn Header="{loc:Localize BatchImport_ColFileName}" Binding="{Binding FileName}" Width="*" MinWidth="200"/>
+                            <DataGridTemplateColumn Header="{loc:Localize BatchImport_ColFileName}" Width="*" MinWidth="200" SortMemberPath="FileName">
+                                <DataGridTemplateColumn.CellTemplate>
+                                    <DataTemplate x:DataType="vm:FileImportItem">
+                                        <TextBlock Text="{Binding FileName}" VerticalAlignment="Center" Margin="8,0"
+                                                   TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding FileName}"/>
+                                    </DataTemplate>
+                                </DataGridTemplateColumn.CellTemplate>
+                            </DataGridTemplateColumn>
                             <DataGridTextColumn Header="{loc:Localize AddEdit_LblType}" Binding="{Binding FileType}" Width="70"/>
                             <DataGridTextColumn Header="{loc:Localize BatchImport_ColSize}" Binding="{Binding FileSizeMB, StringFormat=\{0:F2\}}" Width="110"/>
-                            <DataGridTextColumn Header="{loc:Localize BatchImport_ColPath}" Binding="{Binding FilePath}" Width="300"/>
-                            <DataGridTextColumn Header="{loc:Localize BatchImport_ColFailure}" Binding="{Binding FailureReason}" Width="220"/>
+                            <DataGridTemplateColumn Header="{loc:Localize BatchImport_ColPath}" Width="300" SortMemberPath="FilePath">
+                                <DataGridTemplateColumn.CellTemplate>
+                                    <DataTemplate x:DataType="vm:FileImportItem">
+                                        <TextBlock Text="{Binding FilePath}" VerticalAlignment="Center" Margin="8,0"
+                                                   TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding FilePath}"/>
+                                    </DataTemplate>
+                                </DataGridTemplateColumn.CellTemplate>
+                            </DataGridTemplateColumn>
+                            <DataGridTemplateColumn Header="{loc:Localize BatchImport_ColFailure}" Width="220" SortMemberPath="FailureReason">
+                                <DataGridTemplateColumn.CellTemplate>
+                                    <DataTemplate x:DataType="vm:FileImportItem">
+                                        <TextBlock Text="{Binding FailureReason}" VerticalAlignment="Center" Margin="8,0"
+                                                   TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding FailureReason}"/>
+                                    </DataTemplate>
+                                </DataGridTemplateColumn.CellTemplate>
+                            </DataGridTemplateColumn>
                         </DataGrid.Columns>
                     </DataGrid>
 

--- a/StudyDocumentManager/Views/BulkDelete.axaml
+++ b/StudyDocumentManager/Views/BulkDelete.axaml
@@ -250,12 +250,20 @@
                                         <StackPanel Orientation="Horizontal" Spacing="8" Margin="8,0">
                                             <Image Source="{Binding Document.Type, Converter={x:Static conv:DocumentTypeIconConverter.Instance}}" 
                                                    Width="16" Height="16" VerticalAlignment="Center" />
-                                            <TextBlock Text="{Binding Document.Name}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
+                                            <TextBlock Text="{Binding Document.Name}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis"
+                                                       ToolTip.Tip="{Binding Document.Name}"/>
                                         </StackPanel>
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>
                             </DataGridTemplateColumn>
-                            <DataGridTextColumn Header="{loc:Localize AddEdit_LblSubject}" Binding="{Binding Document.Subject, Mode=OneWay}" Width="120"/>
+                            <DataGridTemplateColumn Header="{loc:Localize AddEdit_LblSubject}" Width="120" SortMemberPath="Document.Subject">
+                                <DataGridTemplateColumn.CellTemplate>
+                                    <DataTemplate x:DataType="vm:SelectableDocument">
+                                        <TextBlock Text="{Binding Document.Subject}" VerticalAlignment="Center" Margin="8,0"
+                                                   TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding Document.Subject}"/>
+                                    </DataTemplate>
+                                </DataGridTemplateColumn.CellTemplate>
+                            </DataGridTemplateColumn>
                             <DataGridTextColumn Header="{loc:Localize AddEdit_LblType}" Binding="{Binding Document.Type, Mode=OneWay}" Width="80"/>
                             <DataGridTextColumn Header="{loc:Localize BulkDelete_ColDateAdded}" Binding="{Binding Document.CreatedAt, Mode=OneWay, StringFormat=\{0:dd/MM/yyyy\}}" Width="100"/>
                             <DataGridCheckBoxColumn Header="★" Binding="{Binding Document.IsImportant, Mode=OneWay}" Width="40" IsReadOnly="True"/>

--- a/StudyDocumentManager/Views/BulkEditPreviewDialog.axaml.cs
+++ b/StudyDocumentManager/Views/BulkEditPreviewDialog.axaml.cs
@@ -32,6 +32,8 @@ public partial class BulkEditPreviewDialog : Window
 
         this.FindControl<Button>("ConfirmButton")!.Click += (_, _) => { Result = true; Close(); };
         this.FindControl<Button>("CancelButton")!.Click += (_, _) => { Result = false; Close(); };
+
+        this.Opened += (_, _) => this.FindControl<Button>("CancelButton")?.Focus();
     }
 
     private void OnLanguageChanged(object? sender, EventArgs e)

--- a/StudyDocumentManager/Views/Dashboard.axaml
+++ b/StudyDocumentManager/Views/Dashboard.axaml
@@ -530,12 +530,20 @@
                                             <StackPanel Orientation="Horizontal" Spacing="8" Margin="8,0">
                                                 <Image Source="{Binding Type, Converter={x:Static conv:DocumentTypeIconConverter.Instance}}"
                                                        Width="16" Height="16" VerticalAlignment="Center" />
-                                                <TextBlock Text="{Binding Name}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
+                                                <TextBlock Text="{Binding Name}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis"
+                                                           ToolTip.Tip="{Binding Name}"/>
                                             </StackPanel>
                                         </DataTemplate>
                                     </DataGridTemplateColumn.CellTemplate>
                                 </DataGridTemplateColumn>
-                                <DataGridTextColumn Header="{loc:Localize Dashboard_ColSubject}" Binding="{Binding Subject, Mode=OneWay}" Width="120"/>
+                                <DataGridTemplateColumn Header="{loc:Localize Dashboard_ColSubject}" Width="120" SortMemberPath="Subject">
+                                    <DataGridTemplateColumn.CellTemplate>
+                                        <DataTemplate x:DataType="core:StudyDocument">
+                                            <TextBlock Text="{Binding Subject}" VerticalAlignment="Center" Margin="8,0"
+                                                       TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding Subject}"/>
+                                        </DataTemplate>
+                                    </DataGridTemplateColumn.CellTemplate>
+                                </DataGridTemplateColumn>
                                 <DataGridTextColumn Header="{loc:Localize Dashboard_ColType}" Binding="{Binding Type, Mode=OneWay}" Width="80"/>
                                 <DataGridTextColumn Header="{loc:Localize Dashboard_ColDate}"
                                     Binding="{Binding CreatedAt, Mode=OneWay, StringFormat=\{0:dd/MM/yyyy\}}" Width="100"/>
@@ -620,8 +628,9 @@
                             <!-- Metadata -->
                             <StackPanel Grid.Column="1" Spacing="3" VerticalAlignment="Center">
                                 <TextBlock Text="{Binding SelectedDocument.Name}" FontSize="{StaticResource FontSizeLg}" FontWeight="Bold"
-                                           Foreground="{StaticResource TextPrimary}"
-                                           TextTrimming="CharacterEllipsis"/>
+                                            Foreground="{StaticResource TextPrimary}"
+                                            TextTrimming="CharacterEllipsis"
+                                            ToolTip.Tip="{Binding SelectedDocument.Name}"/>
                                 <StackPanel Orientation="Horizontal" Spacing="12">
                                     <StackPanel Orientation="Horizontal" Spacing="3">
                                         <Image Source="{StaticResource IconCategory}" Width="11" Height="11"/>
@@ -640,7 +649,8 @@
                                 <StackPanel Orientation="Horizontal" Spacing="3">
                                     <Image Source="{StaticResource IconOpenFile}" Width="10" Height="10"/>
                                     <TextBlock Text="{Binding SelectedDocument.FilePath}" FontSize="{StaticResource FontSizeXs}"
-                                               Foreground="{StaticResource TextMuted}" TextTrimming="CharacterEllipsis"/>
+                                                Foreground="{StaticResource TextMuted}" TextTrimming="CharacterEllipsis"
+                                                ToolTip.Tip="{Binding SelectedDocument.FilePath}"/>
                                 </StackPanel>
                                 <StackPanel Orientation="Horizontal" Spacing="12">
                                     <StackPanel Orientation="Horizontal" Spacing="3">
@@ -665,7 +675,8 @@
                                             IsVisible="{Binding SelectedDocument.Tags, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
                                     <Image Source="{StaticResource IconTag}" Width="10" Height="10"/>
                                     <TextBlock Text="{Binding SelectedDocument.Tags}" FontSize="{StaticResource FontSizeXs}"
-                                               Foreground="{StaticResource TextMuted}" TextTrimming="CharacterEllipsis"/>
+                                                Foreground="{StaticResource TextMuted}" TextTrimming="CharacterEllipsis"
+                                                ToolTip.Tip="{Binding SelectedDocument.Tags}"/>
                                 </StackPanel>
                             </StackPanel>
                         </Grid>

--- a/StudyDocumentManager/Views/DuplicateDetection.axaml
+++ b/StudyDocumentManager/Views/DuplicateDetection.axaml
@@ -86,31 +86,49 @@
                                 <DataTemplate>
                                     <Border Background="{StaticResource SidebarBackground}" CornerRadius="4"
                                             Padding="10,8" Margin="2,3">
-                                        <DockPanel>
-                                            <StackPanel Spacing="2">
-                                                <TextBlock Text="{Binding GroupTitle}" FontSize="{StaticResource FontSizeMd}"
-                                                           FontWeight="Medium" Foreground="{StaticResource TextPrimary}"/>
-                                                <TextBlock Text="{Binding MatchInfo}" FontSize="{StaticResource FontSizeXs}"
-                                                           Foreground="{StaticResource TextSecondary}"/>
-                                            </StackPanel>
-                                            <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Spacing="4"
-                                                        VerticalAlignment="Center" HorizontalAlignment="Right">
-                                                <Button Classes="secondary" AutomationProperties.Name="{loc:Localize DuplicateDetection_BtnView}"
-                                                        Command="{Binding ViewCommand}" Padding="{StaticResource PaddingSm}">
-                                                    <TextBlock Text="{loc:Localize DuplicateDetection_BtnView}" FontSize="{StaticResource FontSizeXs}"/>
-                                                </Button>
-                                                <Button Classes="danger" AutomationProperties.Name="{loc:Localize DuplicateDetection_Merge}"
+                                        <StackPanel Spacing="6">
+                                            <DockPanel>
+                                                <StackPanel Spacing="2">
+                                                    <TextBlock Text="{Binding GroupTitle}" FontSize="{StaticResource FontSizeMd}"
+                                                                FontWeight="Medium" Foreground="{StaticResource TextPrimary}"/>
+                                                    <TextBlock Text="{Binding MatchInfo}" FontSize="{StaticResource FontSizeXs}"
+                                                                Foreground="{StaticResource TextSecondary}"/>
+                                                </StackPanel>
+                                                <Button DockPanel.Dock="Right" Classes="danger" AutomationProperties.Name="{loc:Localize DuplicateDetection_Merge}"
                                                         Command="{Binding DataContext.MergeDuplicateCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                                         CommandParameter="{Binding}" Padding="{StaticResource PaddingSm}">
                                                     <TextBlock Text="{loc:Localize DuplicateDetection_Merge}" FontSize="{StaticResource FontSizeXs}"/>
                                                 </Button>
-                                                <Button Classes="secondary" AutomationProperties.Name="{loc:Localize DuplicateDetection_BtnDelete}"
-                                                        Command="{Binding DataContext.DeleteDuplicateCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                                        CommandParameter="{Binding Documents[1]}" Padding="{StaticResource PaddingSm}">
-                                                    <TextBlock Text="{loc:Localize DuplicateDetection_BtnDelete}" FontSize="{StaticResource FontSizeXs}"/>
-                                                </Button>
-                                            </StackPanel>
-                                        </DockPanel>
+                                            </DockPanel>
+                                            <ItemsControl ItemsSource="{Binding Documents}" Margin="0,2,0,0">
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate>
+                                                        <DockPanel Margin="0,2">
+                                                            <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Spacing="4"
+                                                                        VerticalAlignment="Center">
+                                                                <Button Classes="secondary" AutomationProperties.Name="{loc:Localize DuplicateDetection_BtnView}"
+                                                                        Command="{Binding DataContext.ViewDocumentCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                                        CommandParameter="{Binding}" Padding="{StaticResource PaddingSm}">
+                                                                    <TextBlock Text="{loc:Localize DuplicateDetection_BtnView}" FontSize="{StaticResource FontSizeXs}"/>
+                                                                </Button>
+                                                                <Button Classes="secondary" AutomationProperties.Name="{loc:Localize DuplicateDetection_BtnDelete}"
+                                                                        Command="{Binding DataContext.DeleteDuplicateCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                                        CommandParameter="{Binding}" Padding="{StaticResource PaddingSm}">
+                                                                    <TextBlock Text="{loc:Localize DuplicateDetection_BtnDelete}" FontSize="{StaticResource FontSizeXs}"/>
+                                                                </Button>
+                                                            </StackPanel>
+                                                            <StackPanel Spacing="1" VerticalAlignment="Center">
+                                                                <TextBlock Text="{Binding Name}" FontSize="{StaticResource FontSizeXs}"
+                                                                            FontWeight="Medium" Foreground="{StaticResource TextPrimary}"/>
+                                                                <TextBlock Text="{Binding FilePath}" FontSize="{StaticResource FontSizeXs}"
+                                                                            Foreground="{StaticResource TextMuted}" TextTrimming="CharacterEllipsis"
+                                                                            ToolTip.Tip="{Binding FilePath}"/>
+                                                            </StackPanel>
+                                                        </DockPanel>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+                                        </StackPanel>
                                     </Border>
                                 </DataTemplate>
                             </ListBox.ItemTemplate>

--- a/StudyDocumentManager/Views/DuplicateDetection.axaml
+++ b/StudyDocumentManager/Views/DuplicateDetection.axaml
@@ -94,7 +94,7 @@
                                                     <TextBlock Text="{Binding MatchInfo}" FontSize="{StaticResource FontSizeXs}"
                                                                 Foreground="{StaticResource TextSecondary}"/>
                                                 </StackPanel>
-                                                <Button DockPanel.Dock="Right" Classes="danger" AutomationProperties.Name="{loc:Localize DuplicateDetection_Merge}"
+                                                <Button DockPanel.Dock="Right" Classes="danger" AutomationProperties.AutomationId="DuplicateDetection_Merge" AutomationProperties.Name="{loc:Localize DuplicateDetection_Merge}"
                                                         Command="{Binding DataContext.MergeDuplicateCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                                         CommandParameter="{Binding}" Padding="{StaticResource PaddingSm}">
                                                     <TextBlock Text="{loc:Localize DuplicateDetection_Merge}" FontSize="{StaticResource FontSizeXs}"/>
@@ -106,12 +106,12 @@
                                                         <DockPanel Margin="0,2">
                                                             <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Spacing="4"
                                                                         VerticalAlignment="Center">
-                                                                <Button Classes="secondary" AutomationProperties.Name="{loc:Localize DuplicateDetection_BtnView}"
+                                                                <Button Classes="secondary" AutomationProperties.AutomationId="DuplicateDetection_View" AutomationProperties.Name="{loc:Localize DuplicateDetection_BtnView}"
                                                                         Command="{Binding DataContext.ViewDocumentCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                                                         CommandParameter="{Binding}" Padding="{StaticResource PaddingSm}">
                                                                     <TextBlock Text="{loc:Localize DuplicateDetection_BtnView}" FontSize="{StaticResource FontSizeXs}"/>
                                                                 </Button>
-                                                                <Button Classes="secondary" AutomationProperties.Name="{loc:Localize DuplicateDetection_BtnDelete}"
+                                                                <Button Classes="secondary" AutomationProperties.AutomationId="DuplicateDetection_Delete" AutomationProperties.Name="{loc:Localize DuplicateDetection_BtnDelete}"
                                                                         Command="{Binding DataContext.DeleteDuplicateCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                                                         CommandParameter="{Binding}" Padding="{StaticResource PaddingSm}">
                                                                     <TextBlock Text="{loc:Localize DuplicateDetection_BtnDelete}" FontSize="{StaticResource FontSizeXs}"/>

--- a/StudyDocumentManager/Views/FileIntegrityCheck.axaml
+++ b/StudyDocumentManager/Views/FileIntegrityCheck.axaml
@@ -87,8 +87,9 @@
                                     <TextBlock Text="{loc:Localize Integrity_DatabaseLocation}"
                                                FontSize="{StaticResource FontSizeXs}" Foreground="{StaticResource TextMuted}"/>
                                     <TextBlock AutomationProperties.AutomationId="FileIntegrity_DatabaseLocation"
-                                               Text="{Binding DatabaseLocation}" FontSize="{StaticResource FontSizeXs}"
-                                               Foreground="{StaticResource TextMuted}" TextTrimming="CharacterEllipsis"/>
+                                                Text="{Binding DatabaseLocation}" FontSize="{StaticResource FontSizeXs}"
+                                                Foreground="{StaticResource TextMuted}" TextTrimming="CharacterEllipsis"
+                                                ToolTip.Tip="{Binding DatabaseLocation}"/>
                                 </StackPanel>
                             </StackPanel>
                         </Border>
@@ -114,10 +115,12 @@
                                                        Margin="0,0,8,0" VerticalAlignment="Center"/>
                                                 <StackPanel Spacing="2">
                                                     <TextBlock Text="{Binding Document.Name}" FontSize="{StaticResource FontSizeMd}"
-                                                               FontWeight="Medium" Foreground="{StaticResource TextPrimary}"/>
+                                                                FontWeight="Medium" Foreground="{StaticResource TextPrimary}"
+                                                                TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding Document.Name}"/>
                                                     <TextBlock AutomationProperties.Name="{Binding FilePath}"
-                                                               Text="{Binding FilePath}" FontSize="{StaticResource FontSizeXs}"
-                                                               Foreground="{StaticResource TextSecondary}"/>
+                                                                Text="{Binding FilePath}" FontSize="{StaticResource FontSizeXs}"
+                                                                Foreground="{StaticResource TextSecondary}"
+                                                                TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding FilePath}"/>
                                                     <TextBlock AutomationProperties.LiveSetting="Polite"
                                                                Text="{Binding Status}" FontSize="{StaticResource FontSizeXs}"
                                                                Foreground="{StaticResource StatRedFg}"/>

--- a/StudyDocumentManager/Views/ImportInbox.axaml
+++ b/StudyDocumentManager/Views/ImportInbox.axaml
@@ -29,6 +29,7 @@
         <DataGridTextColumn Header="{loc:Localize ImportInbox_Source}" Binding="{Binding SourcePath}" Width="3*" />
       </DataGrid.Columns>
     </DataGrid>
+    <TextBlock DockPanel.Dock="Bottom" AutomationProperties.AutomationId="ImportInbox_Status" AutomationProperties.LiveSetting="Polite" Text="{Binding StatusText}" TextWrapping="Wrap" IsVisible="{Binding StatusText, Converter={x:Static ObjectConverters.IsNotNull}}" Margin="0,6,0,0" />
     <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" Spacing="8" Margin="0,10,0,0">
       <Button AutomationProperties.AutomationId="ImportInbox_Retry" Content="{loc:Localize ImportInbox_Retry}" Command="{Binding RetrySelectedCommand}" />
       <Button AutomationProperties.AutomationId="ImportInbox_Reveal" Content="{loc:Localize ImportInbox_Reveal}" Command="{Binding RevealSelectedCommand}" />

--- a/StudyDocumentManager/Views/ImportInbox.axaml
+++ b/StudyDocumentManager/Views/ImportInbox.axaml
@@ -29,7 +29,7 @@
         <DataGridTextColumn Header="{loc:Localize ImportInbox_Source}" Binding="{Binding SourcePath}" Width="3*" />
       </DataGrid.Columns>
     </DataGrid>
-    <TextBlock DockPanel.Dock="Bottom" AutomationProperties.AutomationId="ImportInbox_Status" AutomationProperties.LiveSetting="Polite" Text="{Binding StatusText}" TextWrapping="Wrap" IsVisible="{Binding StatusText, Converter={x:Static ObjectConverters.IsNotNull}}" Margin="0,6,0,0" />
+    <TextBlock DockPanel.Dock="Bottom" AutomationProperties.AutomationId="ImportInbox_Status" AutomationProperties.LiveSetting="Polite" Text="{Binding StatusText}" TextWrapping="Wrap" IsVisible="{Binding StatusText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" Margin="0,6,0,0" />
     <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" Spacing="8" Margin="0,10,0,0">
       <Button AutomationProperties.AutomationId="ImportInbox_Retry" Content="{loc:Localize ImportInbox_Retry}" Command="{Binding RetrySelectedCommand}" />
       <Button AutomationProperties.AutomationId="ImportInbox_Reveal" Content="{loc:Localize ImportInbox_Reveal}" Command="{Binding RevealSelectedCommand}" />

--- a/StudyDocumentManager/Views/ImportInbox.axaml
+++ b/StudyDocumentManager/Views/ImportInbox.axaml
@@ -30,7 +30,8 @@
       </DataGrid.Columns>
     </DataGrid>
     <TextBlock DockPanel.Dock="Bottom" AutomationProperties.AutomationId="ImportInbox_Status" AutomationProperties.LiveSetting="Polite" Text="{Binding StatusText}" TextWrapping="Wrap" IsVisible="{Binding StatusText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" Margin="0,6,0,0" />
-    <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" Spacing="8" Margin="0,10,0,0">
+    <TextBlock DockPanel.Dock="Bottom" AutomationProperties.AutomationId="ImportInbox_Error" AutomationProperties.LiveSetting="Assertive" Text="{Binding ErrorMessage}" Foreground="{StaticResource DangerBrush}" FontWeight="SemiBold" TextWrapping="Wrap" IsVisible="{Binding ErrorMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" Margin="0,6,0,0" />
+    <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" Spacing="8" Margin="0,10,0,0" AutomationProperties.AutomationId="ImportInbox_ActionPanel" IsVisible="{Binding HasItems}">
       <Button AutomationProperties.AutomationId="ImportInbox_Retry" Content="{loc:Localize ImportInbox_Retry}" Command="{Binding RetrySelectedCommand}" />
       <Button AutomationProperties.AutomationId="ImportInbox_Reveal" Content="{loc:Localize ImportInbox_Reveal}" Command="{Binding RevealSelectedCommand}" />
       <TextBox AutomationProperties.AutomationId="ImportInbox_Subject" Width="180" Text="{Binding BulkSubject}" Watermark="{loc:Localize ImportInbox_Subject}" />

--- a/StudyDocumentManager/Views/RecoveryCenterView.axaml
+++ b/StudyDocumentManager/Views/RecoveryCenterView.axaml
@@ -18,11 +18,11 @@
                                AutomationProperties.AutomationId="Title_RecoveryCenter"
                                Text="{loc:Localize RC_Title}"/>
                 </StackPanel>
-                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Spacing="8"
-                            HorizontalAlignment="Right">
+                <WrapPanel DockPanel.Dock="Right" Orientation="Horizontal"
+                           HorizontalAlignment="Right">
                     <Button Classes="primary" AutomationProperties.AutomationId="Recovery_CreateBackup"
                             AutomationProperties.Name="{loc:Localize RC_CreateBackup}"
-                            Command="{Binding CreateBackupCommand}" Padding="{StaticResource PaddingMd}">
+                            Command="{Binding CreateBackupCommand}" Padding="{StaticResource PaddingMd}" Margin="0,0,8,0">
                         <StackPanel Orientation="Horizontal" Spacing="4">
                             <Image Source="{StaticResource IconSave}" Width="16" Height="16"/>
                             <TextBlock Text="{loc:Localize RC_CreateBackup}" FontSize="{StaticResource FontSizeMd}"/>
@@ -30,7 +30,7 @@
                     </Button>
                     <Button Classes="danger" AutomationProperties.AutomationId="Recovery_RestoreSelected"
                             AutomationProperties.Name="{loc:Localize RC_Restore}"
-                            Command="{Binding RestoreSelectedCommand}" IsEnabled="{Binding CanRestoreSelected}" Padding="{StaticResource PaddingMd}">
+                            Command="{Binding RestoreSelectedCommand}" IsEnabled="{Binding CanRestoreSelected}" Padding="{StaticResource PaddingMd}" Margin="0,0,8,0">
                         <StackPanel Orientation="Horizontal" Spacing="4">
                             <Image Source="{StaticResource IconRestore}" Width="16" Height="16"/>
                             <TextBlock Text="{loc:Localize RC_Restore}" FontSize="{StaticResource FontSizeMd}"/>
@@ -38,7 +38,7 @@
                     </Button>
                     <Button Classes="secondary" AutomationProperties.AutomationId="Recovery_OpenFolder"
                             AutomationProperties.Name="{loc:Localize RC_OpenFolder}"
-                            Command="{Binding OpenBackupFolderCommand}" Padding="{StaticResource PaddingMd}">
+                            Command="{Binding OpenBackupFolderCommand}" Padding="{StaticResource PaddingMd}" Margin="0,0,8,0">
                         <StackPanel Orientation="Horizontal" Spacing="4">
                             <Image Source="{StaticResource IconHDD}" Width="16" Height="16"/>
                             <TextBlock Text="{loc:Localize RC_OpenFolder}" FontSize="{StaticResource FontSizeMd}"/>
@@ -49,10 +49,10 @@
                             Command="{Binding RestoreFromFileCommand}" Padding="{StaticResource PaddingMd}">
                         <StackPanel Orientation="Horizontal" Spacing="4">
                             <Image Source="{StaticResource IconOpenFile}" Width="16" Height="16"/>
-                            <TextBlock Text="{loc:Localize RC_RestoreFromFile}" FontSize="{StaticResource FontSizeMd}"/>
-                        </StackPanel>
-                    </Button>
-                </StackPanel>
+                             <TextBlock Text="{loc:Localize RC_RestoreFromFile}" FontSize="{StaticResource FontSizeMd}"/>
+                         </StackPanel>
+                     </Button>
+                 </WrapPanel>
             </DockPanel>
 
             <ScrollViewer>
@@ -72,11 +72,12 @@
                                            Text="{Binding LatestStatusText}" VerticalAlignment="Center"/>
                             </StackPanel>
                             <StackPanel Orientation="Horizontal" Spacing="8">
-                                <Image Source="{StaticResource IconFolderBase}" Width="16" Height="16" VerticalAlignment="Center"/>
+                                <Image Source="{StaticResource IconCategory}" Width="16" Height="16" VerticalAlignment="Center"/>
                                 <TextBlock Classes="caption" Text="{loc:Localize RC_Location}" VerticalAlignment="Center"/>
                                 <TextBlock Text="{Binding BackupLocationText}"
-                                           AutomationProperties.AutomationId="Recovery_Location"
-                                           TextTrimming="CharacterEllipsis" VerticalAlignment="Center"/>
+                                            AutomationProperties.AutomationId="Recovery_Location"
+                                            TextTrimming="CharacterEllipsis" VerticalAlignment="Center"
+                                            ToolTip.Tip="{Binding BackupLocationText}"/>
                             </StackPanel>
                             <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,4,0,0">
                                 <TextBlock Classes="caption" Text="{loc:Localize RC_Retention}" VerticalAlignment="Center"/>
@@ -102,7 +103,14 @@
                                       IsReadOnly="True"
                                       MinHeight="220">
                                 <DataGrid.Columns>
-                                    <DataGridTextColumn Header="{loc:Localize RC_ColName}" Binding="{Binding FilePath}" Width="*" MinWidth="260"/>
+                                    <DataGridTemplateColumn Header="{loc:Localize RC_ColName}" Width="*" MinWidth="260" SortMemberPath="FilePath">
+                                        <DataGridTemplateColumn.CellTemplate>
+                                            <DataTemplate x:DataType="core:BackupVersionInfo">
+                                                <TextBlock Text="{Binding FilePath}" VerticalAlignment="Center" Margin="8,0"
+                                                           TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding FilePath}"/>
+                                            </DataTemplate>
+                                        </DataGridTemplateColumn.CellTemplate>
+                                    </DataGridTemplateColumn>
                                     <DataGridTextColumn Header="{loc:Localize RC_ColCreated}" Binding="{Binding CreatedAtLocal, StringFormat=\{0:yyyy-MM-dd HH:mm:ss\}}" Width="170"/>
                                     <DataGridTextColumn Header="{loc:Localize RC_ColSize}" Binding="{Binding SizeBytes, Converter={x:Static conv:FileSizeConverter.Instance}}" Width="90"/>
                                     <DataGridTemplateColumn Header="{loc:Localize RC_ColStatus}" Width="110">

--- a/StudyDocumentManager/Views/RecycleBin.axaml
+++ b/StudyDocumentManager/Views/RecycleBin.axaml
@@ -53,8 +53,9 @@
                     <DataGrid Classes="std"
                               AutomationProperties.AutomationId="RecycleBin_DocumentGrid"
                               AutomationProperties.Name="{loc:Localize RecycleBin_Title}"
+                              IsReadOnly="True"
                               ItemsSource="{Binding DeletedDocuments}"
-                              SelectedItem="{Binding SelectedDocument}">
+                                  SelectedItem="{Binding SelectedDocument, Mode=OneWayToSource}">
                         <DataGrid.Columns>
                             <DataGridTemplateColumn Header="{loc:Localize RecycleBin_ColName}" Width="*" MinWidth="200" SortMemberPath="Name">
                                 <DataGridTemplateColumn.CellTemplate>
@@ -67,9 +68,9 @@
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>
                             </DataGridTemplateColumn>
-                            <DataGridTextColumn Header="{loc:Localize RecycleBin_ColSubject}" Binding="{Binding Subject}" Width="120"/>
-                            <DataGridTextColumn Header="{loc:Localize RecycleBin_ColType}" Binding="{Binding Type}" Width="80"/>
-                            <DataGridTextColumn Header="{loc:Localize RecycleBin_ColDate}" Binding="{Binding CreatedAt, StringFormat=\{0:dd/MM/yyyy\}}" Width="100"/>
+                            <DataGridTextColumn Header="{loc:Localize RecycleBin_ColSubject}" Binding="{Binding Subject, Mode=OneWay}" Width="120"/>
+                            <DataGridTextColumn Header="{loc:Localize RecycleBin_ColType}" Binding="{Binding Type, Mode=OneWay}" Width="80"/>
+                            <DataGridTextColumn Header="{loc:Localize RecycleBin_ColDate}" Binding="{Binding CreatedAt, Mode=OneWay, StringFormat=\{0:dd/MM/yyyy\}}" Width="100"/>
                         </DataGrid.Columns>
                     </DataGrid>
 

--- a/StudyDocumentManager/Views/StudentWorkspace.axaml
+++ b/StudyDocumentManager/Views/StudentWorkspace.axaml
@@ -16,12 +16,13 @@
                     <TextBox Grid.Column="2" Text="{Binding StudentContext.Course, Mode=TwoWay}" Watermark="{loc:Localize SW_ContextCourse}" automation:AutomationProperties.Name="{loc:Localize SW_ContextCourse}"/>
                     <TextBox Grid.Column="3" Text="{Binding StudentContext.Module, Mode=TwoWay}" Watermark="{loc:Localize SW_ContextModule}" automation:AutomationProperties.Name="{loc:Localize SW_ContextModule}"/>
                     <TextBox Grid.Column="4" Text="{Binding StudentContext.Owner, Mode=TwoWay}" Watermark="{loc:Localize SW_ContextOwner}" automation:AutomationProperties.Name="{loc:Localize SW_ContextOwner}"/>
-                    <Button Grid.Row="1" Grid.Column="0" Content="{loc:Localize SW_SaveContext}" Command="{Binding SaveContextCommand}" HorizontalAlignment="Left"/>
-                    <TextBlock Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="4" Text="{Binding StatusText}" VerticalAlignment="Center" Foreground="{StaticResource TextSecondary}"/>
+                    <Button Grid.Row="1" Grid.Column="0" Content="{loc:Localize SW_SaveContext}" Command="{Binding SaveContextCommand}" HorizontalAlignment="Left" automation:AutomationProperties.Name="{loc:Localize SW_SaveContext}"/>
+                    <TextBlock Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="4" Text="{Binding StatusText}" VerticalAlignment="Center" Foreground="{StaticResource TextSecondary}" automation:AutomationProperties.LiveSetting="Polite"/>
                 </Grid>
             </StackPanel>
 
-            <Grid ColumnDefinitions="220,220,*">
+            <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+                <Grid ColumnDefinitions="220,220,*">
                 <Border Grid.Column="0" Background="{StaticResource CardBackground}" BorderBrush="{StaticResource CardBorder}" BorderThickness="1" CornerRadius="6" Padding="10">
                     <DockPanel>
                         <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" Spacing="6" Margin="0,8,0,0">
@@ -50,10 +51,10 @@
                     <DockPanel>
                         <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Spacing="8" Margin="0,0,0,8">
                             <TextBlock Text="{loc:Localize SW_Assignments}" FontWeight="SemiBold" VerticalAlignment="Center"/>
-                            <CheckBox Content="{loc:Localize SW_ShowHistory}" IsChecked="{Binding ShowHistory}"/>
-                            <Button Content="{loc:Localize SW_NewAssignment}" Command="{Binding NewAssignmentCommand}"/>
-                            <Button Content="{loc:Localize Action_Edit}" Command="{Binding EditAssignmentCommand}" IsEnabled="{Binding HasSelection}"/>
-                            <Button Content="{loc:Localize Action_Refresh}" Command="{Binding RefreshCommand}"/>
+                            <CheckBox Content="{loc:Localize SW_ShowHistory}" IsChecked="{Binding ShowHistory}" automation:AutomationProperties.Name="{loc:Localize SW_ShowHistory}"/>
+                            <Button Content="{loc:Localize SW_NewAssignment}" Command="{Binding NewAssignmentCommand}" automation:AutomationProperties.Name="{loc:Localize SW_NewAssignment}"/>
+                            <Button Content="{loc:Localize Action_Edit}" Command="{Binding EditAssignmentCommand}" IsEnabled="{Binding HasSelection}" automation:AutomationProperties.Name="{loc:Localize Action_Edit}"/>
+                            <Button Content="{loc:Localize Action_Refresh}" Command="{Binding RefreshCommand}" automation:AutomationProperties.Name="{loc:Localize Action_Refresh}"/>
                         </StackPanel>
                         <Grid ColumnDefinitions="2*,3*">
                             <ListBox Grid.Column="0" ItemsSource="{Binding Assignments}" SelectedItem="{Binding SelectedAssignment, Mode=TwoWay}" automation:AutomationProperties.Name="{loc:Localize SW_Assignments}">
@@ -85,17 +86,18 @@
                                     <TextBox Text="{Binding EditorMilestone, Mode=TwoWay}" Watermark="{loc:Localize SW_Milestone}" automation:AutomationProperties.Name="{loc:Localize SW_Milestone}"/>
                                     <TextBox Text="{Binding EditorNotes, Mode=TwoWay}" Watermark="{loc:Localize SW_Notes}" AcceptsReturn="True" TextWrapping="Wrap" MinHeight="60" automation:AutomationProperties.Name="{loc:Localize SW_Notes}"/>
                                     <StackPanel Orientation="Horizontal" Spacing="6">
-                                        <Button Content="{loc:Localize Action_Save}" Command="{Binding SaveAssignmentCommand}"/>
-                                        <Button Content="{loc:Localize Action_Cancel}" Command="{Binding CancelEditCommand}"/>
-                                        <Button Content="{loc:Localize Action_Delete}" Command="{Binding DeleteAssignmentCommand}"/>
-                                        <Button Content="{loc:Localize SW_OpenRelatedDocument}" Command="{Binding OpenRelatedDocumentCommand}" IsEnabled="{Binding HasRelatedDocuments}"/>
+                                        <Button Content="{loc:Localize Action_Save}" Command="{Binding SaveAssignmentCommand}" automation:AutomationProperties.Name="{loc:Localize Action_Save}"/>
+                                        <Button Content="{loc:Localize Action_Cancel}" Command="{Binding CancelEditCommand}" automation:AutomationProperties.Name="{loc:Localize Action_Cancel}"/>
+                                        <Button Content="{loc:Localize Action_Delete}" Command="{Binding DeleteAssignmentCommand}" automation:AutomationProperties.Name="{loc:Localize Action_Delete}"/>
+                                        <Button Content="{loc:Localize SW_OpenRelatedDocument}" Command="{Binding OpenRelatedDocumentCommand}" IsEnabled="{Binding HasRelatedDocuments}" automation:AutomationProperties.Name="{loc:Localize SW_OpenRelatedDocument}"/>
                                     </StackPanel>
                                 </StackPanel>
                             </ScrollViewer>
                         </Grid>
                     </DockPanel>
                 </Border>
-            </Grid>
+                </Grid>
+            </ScrollViewer>
         </DockPanel>
     </Border>
 </UserControl>

--- a/StudyDocumentManager/Views/WatchedFolder.axaml
+++ b/StudyDocumentManager/Views/WatchedFolder.axaml
@@ -20,24 +20,25 @@
         <CheckBox AutomationProperties.AutomationId="WatchedFolder_IncludeSub" Content="{loc:Localize WF_IncludeSub}" IsChecked="{Binding NewFolderIncludeSubdirectories}" />
         <Button AutomationProperties.AutomationId="WatchedFolder_Add" Content="{loc:Localize WF_Add}" Command="{Binding AddNewFolderCommand}" />
       </StackPanel>
-      <TextBlock AutomationProperties.AutomationId="WatchedFolder_Status" Text="{Binding StatusMessage}" IsVisible="{Binding StatusMessage, Converter={x:Static ObjectConverters.IsNotNull}}" />
-      <TextBlock AutomationProperties.AutomationId="WatchedFolder_Error" Text="{Binding LastError}" Foreground="Red" IsVisible="{Binding LastError, Converter={x:Static ObjectConverters.IsNotNull}}" />
+      <TextBlock AutomationProperties.AutomationId="WatchedFolder_Status" AutomationProperties.LiveSetting="Polite" Text="{Binding StatusMessage}" IsVisible="{Binding StatusMessage, Converter={x:Static ObjectConverters.IsNotNull}}" />
+      <TextBlock AutomationProperties.AutomationId="WatchedFolder_Error" AutomationProperties.LiveSetting="Polite" Text="{Binding LastError}" Foreground="{StaticResource DangerBrush}" IsVisible="{Binding LastError, Converter={x:Static ObjectConverters.IsNotNull}}" />
       <TextBlock AutomationProperties.AutomationId="WatchedFolder_NoFolders" Text="{loc:Localize WF_NoFolders}" IsVisible="{Binding !HasFolders}" />
     </StackPanel>
     <ListBox AutomationProperties.AutomationId="WatchedFolder_List" ItemsSource="{Binding Folders}">
       <ListBox.ItemTemplate>
         <DataTemplate x:DataType="ent:WatchedFolder">
-          <Grid ColumnDefinitions="*,Auto,Auto" Margin="4">
+          <Grid ColumnDefinitions="*,Auto,Auto,Auto" Margin="4">
             <StackPanel Grid.Column="0" Spacing="2">
               <TextBlock Text="{Binding FolderPath}" FontWeight="Bold" />
               <StackPanel Orientation="Horizontal" Spacing="6">
                 <TextBlock Text="{Binding LastScanAt, StringFormat='{}{0:yyyy-MM-dd HH:mm}'}" FontSize="11" Opacity="0.7" />
                 <TextBlock Text="{Binding WatcherStatus, Converter={StaticResource WatcherStatusLabelConverter}}" FontSize="11" Opacity="0.7" />
               </StackPanel>
-              <TextBlock AutomationProperties.AutomationId="WatchedFolder_ItemError" Text="{Binding WatcherError}" FontSize="11" Foreground="Red" IsVisible="{Binding WatcherError, Converter={x:Static ObjectConverters.IsNotNull}}" />
+              <TextBlock AutomationProperties.AutomationId="WatchedFolder_ItemError" AutomationProperties.LiveSetting="Polite" Text="{Binding WatcherError}" FontSize="11" Foreground="{StaticResource DangerBrush}" IsVisible="{Binding WatcherError, Converter={x:Static ObjectConverters.IsNotNull}}" />
             </StackPanel>
             <CheckBox Grid.Column="1" Content="{loc:Localize WF_Enable}" IsChecked="{Binding Enabled}" Command="{Binding DataContext.ToggleEnabledCommand, RelativeSource={RelativeSource AncestorType=UserControl}}" CommandParameter="{Binding .}" />
-            <Button Grid.Column="2" Content="{loc:Localize WF_Remove}" Command="{Binding DataContext.RemoveFolderCommand, RelativeSource={RelativeSource AncestorType=UserControl}}" CommandParameter="{Binding Id}" />
+            <Button Grid.Column="2" AutomationProperties.AutomationId="WatchedFolder_Retry" AutomationProperties.Name="{loc:Localize ImportInbox_Retry}" Content="{loc:Localize ImportInbox_Retry}" Command="{Binding DataContext.RetryFolderCommand, RelativeSource={RelativeSource AncestorType=UserControl}}" CommandParameter="{Binding Id}" />
+            <Button Grid.Column="3" Content="{loc:Localize WF_Remove}" Command="{Binding DataContext.RemoveFolderCommand, RelativeSource={RelativeSource AncestorType=UserControl}}" CommandParameter="{Binding Id}" />
           </Grid>
         </DataTemplate>
       </ListBox.ItemTemplate>

--- a/StudyDocumentManager/Views/WatchedFolder.axaml
+++ b/StudyDocumentManager/Views/WatchedFolder.axaml
@@ -8,18 +8,18 @@
              AutomationProperties.AutomationId="WatchedFolder_Screen"
              x:DataType="vm:WatchedFolderModel">
   <DockPanel Margin="24">
-    <StackPanel DockPanel.Dock="Top" Spacing="10">
-      <StackPanel Orientation="Horizontal" Spacing="8">
-        <Button AutomationProperties.AutomationId="WatchedFolder_Back" Content="{loc:Localize Btn_Back}" Command="{Binding GoBackCommand}" />
-        <TextBlock Text="{loc:Localize WF_Title}" FontSize="24" />
-        <Button AutomationProperties.AutomationId="WatchedFolder_Start" Content="{loc:Localize WF_Start}" Command="{Binding StartWatchingCommand}" IsEnabled="{Binding !IsWatching}" />
+      <StackPanel DockPanel.Dock="Top" Spacing="10">
+        <WrapPanel Orientation="Horizontal">
+          <Button AutomationProperties.AutomationId="WatchedFolder_Back" Content="{loc:Localize Btn_Back}" Command="{Binding GoBackCommand}" Margin="0,0,8,0" />
+        <TextBlock Text="{loc:Localize WF_Title}" FontSize="24" Margin="0,0,8,0" />
+        <Button AutomationProperties.AutomationId="WatchedFolder_Start" Content="{loc:Localize WF_Start}" Command="{Binding StartWatchingCommand}" IsEnabled="{Binding !IsWatching}" Margin="0,0,8,0" />
         <Button AutomationProperties.AutomationId="WatchedFolder_Stop" Content="{loc:Localize WF_Stop}" Command="{Binding StopWatchingCommand}" IsEnabled="{Binding IsWatching}" />
-      </StackPanel>
-      <StackPanel Orientation="Horizontal" Spacing="8">
-        <TextBox AutomationProperties.AutomationId="WatchedFolder_Path" AutomationProperties.Name="{loc:Localize WF_FolderPath}" Width="420" Text="{Binding NewFolderPath}" />
-        <CheckBox AutomationProperties.AutomationId="WatchedFolder_IncludeSub" Content="{loc:Localize WF_IncludeSub}" IsChecked="{Binding NewFolderIncludeSubdirectories}" />
-        <Button AutomationProperties.AutomationId="WatchedFolder_Add" Content="{loc:Localize WF_Add}" Command="{Binding AddNewFolderCommand}" />
-      </StackPanel>
+      </WrapPanel>
+        <Grid ColumnDefinitions="*,Auto,Auto">
+          <TextBox Grid.Column="0" AutomationProperties.AutomationId="WatchedFolder_Path" AutomationProperties.Name="{loc:Localize WF_FolderPath}" MinWidth="160" Margin="0,0,8,0" Text="{Binding NewFolderPath}" Watermark="{loc:Localize WF_FolderPath}" />
+          <CheckBox Grid.Column="1" AutomationProperties.AutomationId="WatchedFolder_IncludeSub" Content="{loc:Localize WF_IncludeSub}" IsChecked="{Binding NewFolderIncludeSubdirectories}" VerticalAlignment="Center" Margin="0,0,8,0" />
+          <Button Grid.Column="2" AutomationProperties.AutomationId="WatchedFolder_Add" Content="{loc:Localize WF_Add}" Command="{Binding AddNewFolderCommand}" />
+        </Grid>
       <TextBlock AutomationProperties.AutomationId="WatchedFolder_Status" AutomationProperties.LiveSetting="Polite" Text="{Binding StatusMessage}" IsVisible="{Binding StatusMessage, Converter={x:Static ObjectConverters.IsNotNull}}" />
       <TextBlock AutomationProperties.AutomationId="WatchedFolder_Error" AutomationProperties.LiveSetting="Polite" Text="{Binding LastError}" Foreground="{StaticResource DangerBrush}" IsVisible="{Binding LastError, Converter={x:Static ObjectConverters.IsNotNull}}" />
       <TextBlock AutomationProperties.AutomationId="WatchedFolder_NoFolders" Text="{loc:Localize WF_NoFolders}" IsVisible="{Binding !HasFolders}" />
@@ -29,12 +29,12 @@
         <DataTemplate x:DataType="ent:WatchedFolder">
           <Grid ColumnDefinitions="*,Auto,Auto,Auto" Margin="4">
             <StackPanel Grid.Column="0" Spacing="2">
-              <TextBlock Text="{Binding FolderPath}" FontWeight="Bold" />
+              <TextBlock Text="{Binding FolderPath}" FontWeight="Bold" TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding FolderPath}" />
               <StackPanel Orientation="Horizontal" Spacing="6">
                 <TextBlock Text="{Binding LastScanAt, StringFormat='{}{0:yyyy-MM-dd HH:mm}'}" FontSize="11" Opacity="0.7" />
                 <TextBlock Text="{Binding WatcherStatus, Converter={StaticResource WatcherStatusLabelConverter}}" FontSize="11" Opacity="0.7" />
               </StackPanel>
-              <TextBlock AutomationProperties.AutomationId="WatchedFolder_ItemError" AutomationProperties.LiveSetting="Polite" Text="{Binding WatcherError}" FontSize="11" Foreground="{StaticResource DangerBrush}" IsVisible="{Binding WatcherError, Converter={x:Static ObjectConverters.IsNotNull}}" />
+              <TextBlock AutomationProperties.AutomationId="WatchedFolder_ItemError" AutomationProperties.LiveSetting="Polite" Text="{Binding WatcherError}" FontSize="11" Foreground="{StaticResource DangerBrush}" IsVisible="{Binding WatcherError, Converter={x:Static ObjectConverters.IsNotNull}}" TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding WatcherError}" />
             </StackPanel>
             <CheckBox Grid.Column="1" Content="{loc:Localize WF_Enable}" IsChecked="{Binding Enabled}" Command="{Binding DataContext.ToggleEnabledCommand, RelativeSource={RelativeSource AncestorType=UserControl}}" CommandParameter="{Binding .}" />
             <Button Grid.Column="2" AutomationProperties.AutomationId="WatchedFolder_Retry" AutomationProperties.Name="{loc:Localize ImportInbox_Retry}" Content="{loc:Localize ImportInbox_Retry}" Command="{Binding DataContext.RetryFolderCommand, RelativeSource={RelativeSource AncestorType=UserControl}}" CommandParameter="{Binding Id}" />


### PR DESCRIPTION
## Summary

Issue #60 の desktop UX/accessibility remediation を実装しました。Recovery Bin crash、Import Inbox の状態表示、Duplicate Detection の対象文書操作、長い値の可読性、狭幅 layout、destructive dialog の keyboard safety、Dashboard/Recent Files/Personal Note/Student Workspace の状態・操作フィードバックを対象にしています。MVVM、既存 command、binding、dialog result、localization、persistence semantics、database schema は変更していません。

## Implementation checklist

- [x] Implement #60 — 監査で確認した P0/P1 UI findings と最小限の regression proof

## Verification checklist

- [x] Self-review of the diff completed
- [x] Focused tests pass for every batch
- [x] Solution Debug build passes with 0 errors
- [x] Full headless test suite passes: 1403/1403
- [x] `git diff --check` passes
- [x] Runtime Dashboard and Maintenance menu verified in the correct application window
- [x] Narrow source-level proof completed for four audited workflow views: root bounds, critical AutomationIds, and Recovery ScrollViewer
- [x] Runtime smoke proof: isolated smoke 5/5 PASS and headless runtime checks 27/27 PASS
- [ ] Runtime evidence captured for the audited desktop workflow screens at the verified minimum-width and 100/150/200% DPI matrix
- [x] Keyboard-only verification completed for the audited screen matrix
- [ ] Screen-reader verification completed for the audited screen matrix
- [ ] Full 19-screen screenshot/keyboard/focus runtime matrix completed
- [x] UIA accessibility tree verification completed for names, automation IDs, control types and enabled states
- [x] GitNexus full re-index and change detection completed for head `f745069`; graph check cycleCount `0`
- [x] No secrets, tokens or private configuration added
- [x] No AI attribution or generated-by trailer added
- [ ] CI green for latest head `f745069` (previous CI run `33136225741` validated head `4d284f4`)

## Notes

- Recycle Bin crash was root-caused to read-only DataGrid columns using default two-way binding; display columns now use `Mode=OneWay`, while row selection remains `OneWayToSource`.
- Import Inbox now separates informational status from error feedback and hides inapplicable empty-state actions.
- Duplicate Detection now renders each duplicate document with its own View/Delete actions and passes the specific document as command parameter. The latest commit also adds UIA identifiers for the per-document actions and the group Merge action.
- Dashboard quick filters now update visible rows, statistics, and empty state through the canonical visible-state path.
- Recent Files reloads history after a successful open so OpenedAt, ordering, and status update immediately.
- Personal Note asks before discarding a changed draft; `Note_ConfirmDiscard` and `Note_Discard` are present in all four locales.
- Student Workspace uses an outer ScrollViewer, a polite live status region, and accessible names for primary assignment actions.
- Long paths and labels use ellipsis plus tooltip disclosure; action footers reflow at narrow widths.
- OpenCode added and verified `Issue60ViewRenderSmokeTests`: BatchImport, WatchedFolder, RecoveryCenterView, and DuplicateDetection render at widths 520 and 1280 with status/UIA/scroll assertions where applicable. Full headless suite is 1403/1403 and the change is committed as `f745069`.
- Runtime audit inventory covered 19 desktop routes, while direct runtime evidence is limited to 8 screens. Confirmed evidence is limited to minimum-width/source-level proof and DPI 96 / 100% baseline; 150/200% DPI, full screen-reader transcript, and the full 19-screen screenshot/keyboard/focus matrix remain incomplete.
- Runtime checks used an isolated database; no production data was modified.