### PR TITLE
個人業務向けメタデータとリマインダーを追加する

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -194,6 +194,29 @@
 
 - `UNIQUE(folder_path COLLATE NOCASE)`
 
+### `office_document_metadata`
+
+個人業務向け文書（請求書、契約書、報告書、領収書、申請書など）の拡張メタデータおよびリマインダー設定です。
+
+| カラム | 型 | 説明 |
+| --- | --- | --- |
+| `id` | INTEGER PRIMARY KEY AUTOINCREMENT | 主キー |
+| `document_id` | INTEGER NOT NULL UNIQUE | 対象文書ID (`documents.id` への外部キー) |
+| `document_number` | TEXT | 文書番号 |
+| `contact_name` | TEXT | 担当者・連絡先名 |
+| `organization_or_project` | TEXT | 会社・組織・プロジェクト名 |
+| `effective_date` | DATETIME | 発効日 |
+| `expiry_date` | DATETIME | 満了・期限日 |
+| `confidentiality_level` | TEXT NOT NULL DEFAULT 'internal' | 機密区分 (`public`, `internal`, `confidential`, `restricted`) |
+| `reminder_enabled` | INTEGER NOT NULL DEFAULT 1 | リマインダー有効フラグ (1: 有効, 0: 無効) |
+| `reminder_days_before` | INTEGER NOT NULL DEFAULT 3 | 期限何日前に通知するか |
+| `created_at` | DATETIME DEFAULT `datetime('now','localtime')` | 登録日時 |
+| `updated_at` | DATETIME DEFAULT `datetime('now','localtime')` | 更新日時 |
+
+制約:
+
+- `FOREIGN KEY (document_id) REFERENCES documents(id) ON DELETE CASCADE`
+
 ## インデックス
 
 - `idx_documents_subject`: `documents(subject)`
@@ -204,6 +227,8 @@
 - `idx_collection_items_document`: `collection_items(document_id)`
 - `idx_documents_deleted`: `documents(is_deleted)`
 - `idx_documents_important`: `documents(is_important)`
+- `idx_office_metadata_doc_id`: `office_document_metadata(document_id)`
+- `idx_office_metadata_expiry`: `office_document_metadata(expiry_date)`
 - `ux_documents_archive_export_key`: `archive_export_key IS NOT NULL AND archive_export_key <> ''` の行を対象にした、`documents(archive_export_key)` の部分一意インデックス。
 - `ux_watched_folders_path`: `watched_folders(folder_path COLLATE NOCASE)` の一意インデックス。
 - `idx_documents_file_path_unique` は、`file_path IS NOT NULL AND file_path <> ''` の行だけを対象に `documents(file_path)` の完全一致を一意にする部分インデックスです。削除済み文書も対象で、SQLite の既定 `BINARY` 比較を使用します。

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -227,7 +227,6 @@
 - `idx_collection_items_document`: `collection_items(document_id)`
 - `idx_documents_deleted`: `documents(is_deleted)`
 - `idx_documents_important`: `documents(is_important)`
-- `idx_office_metadata_doc_id`: `office_document_metadata(document_id)`
 - `idx_office_metadata_expiry`: `office_document_metadata(expiry_date)`
 - `ux_documents_archive_export_key`: `archive_export_key IS NOT NULL AND archive_export_key <> ''` の行を対象にした、`documents(archive_export_key)` の部分一意インデックス。
 - `ux_watched_folders_path`: `watched_folders(folder_path COLLATE NOCASE)` の一意インデックス。

--- a/StudyDocumentManager.Core/Entities/OfficeDocumentMetadata.cs
+++ b/StudyDocumentManager.Core/Entities/OfficeDocumentMetadata.cs
@@ -1,0 +1,66 @@
+namespace StudyDocumentManager.Core.Entities;
+
+/// <summary>
+/// 個人業務文書向け拡張メタデータ（請求書、契約書、報告書、領収書、申請書など）。
+/// </summary>
+public sealed class OfficeDocumentMetadata
+{
+    public int Id { get; set; }
+    public int DocumentId { get; set; }
+    public string? DocumentNumber { get; set; }
+    public string? ContactName { get; set; }
+    public string? OrganizationOrProject { get; set; }
+    public DateTime? EffectiveDate { get; set; }
+    public DateTime? ExpiryDate { get; set; }
+    public string ConfidentialityLevel { get; set; } = OfficeConfidentialityLevel.Internal;
+    public bool ReminderEnabled { get; set; } = true;
+    public int ReminderDaysBefore { get; set; } = 3;
+    public DateTime CreatedAt { get; set; } = DateTime.Now;
+    public DateTime UpdatedAt { get; set; } = DateTime.Now;
+}
+
+/// <summary>
+/// 個人業務文書の機密区分。
+/// </summary>
+public static class OfficeConfidentialityLevel
+{
+    public const string Public = "public";
+    public const string Internal = "internal";
+    public const string Confidential = "confidential";
+    public const string Restricted = "restricted";
+
+    public static readonly IReadOnlyList<string> All =
+    [
+        Public,
+        Internal,
+        Confidential,
+        Restricted
+    ];
+
+    public static bool IsValid(string? level)
+        => !string.IsNullOrEmpty(level) && All.Contains(level);
+}
+
+/// <summary>
+/// 期限状態の分類。
+/// </summary>
+public enum OfficeExpiryState
+{
+    None,
+    Active,
+    DueSoon,
+    Overdue
+}
+
+/// <summary>
+/// リマインダー・期限切迫表示用アイテム。
+/// </summary>
+public sealed record OfficeReminderItem(
+    int DocumentId,
+    string DocumentName,
+    string? DocumentNumber,
+    string? OrganizationOrProject,
+    DateTime? ExpiryDate,
+    OfficeExpiryState ExpiryState,
+    int DaysRemaining,
+    bool ReminderEnabled);

--- a/StudyDocumentManager.Core/Interfaces/IOfficeMetadataRepository.cs
+++ b/StudyDocumentManager.Core/Interfaces/IOfficeMetadataRepository.cs
@@ -1,0 +1,14 @@
+using StudyDocumentManager.Core.Entities;
+
+namespace StudyDocumentManager.Core.Interfaces;
+
+/// <summary>
+/// 個人業務向けメタデータリポジトリのインターフェース。
+/// </summary>
+public interface IOfficeMetadataRepository
+{
+    OfficeDocumentMetadata? GetByDocumentId(int documentId);
+    bool Save(OfficeDocumentMetadata metadata);
+    bool DeleteByDocumentId(int documentId);
+    IReadOnlyList<OfficeReminderItem> GetUpcomingReminders(DateTime asOfDate, int defaultDueSoonDays = 7);
+}

--- a/StudyDocumentManager.Data/Helpers/DatabaseHelper.cs
+++ b/StudyDocumentManager.Data/Helpers/DatabaseHelper.cs
@@ -1556,6 +1556,24 @@ public class DatabaseHelper
                 DateTime.Parse(recentFilesReader.GetString(0));
         }
 
+        if (hasOfficeMetadata)
+        {
+            using var officeCommand = connection.CreateCommand();
+            officeCommand.CommandText = "SELECT effective_date, expiry_date, reminder_days_before, confidentiality_level FROM office_document_metadata";
+            using var officeReader = officeCommand.ExecuteReader();
+            while (officeReader.Read())
+            {
+                if (!officeReader.IsDBNull(0))
+                    DateTime.Parse(officeReader.GetString(0));
+                if (!officeReader.IsDBNull(1))
+                    DateTime.Parse(officeReader.GetString(1));
+                if (officeReader.GetInt32(2) < 0)
+                    throw new InvalidOperationException("Backup database contains invalid office metadata reminder days.");
+                if (!OfficeConfidentialityLevel.IsValid(officeReader.GetString(3)))
+                    throw new InvalidOperationException("Backup database contains invalid office metadata confidentiality level.");
+            }
+        }
+
         using var integrityCommand = connection.CreateCommand();
         integrityCommand.CommandText = "PRAGMA integrity_check";
         if (!string.Equals(integrityCommand.ExecuteScalar()?.ToString(), "ok", StringComparison.OrdinalIgnoreCase))
@@ -1737,7 +1755,7 @@ private static void ValidateDocumentPathIndex(SqliteConnection connection, bool 
             },
             "office_document_metadata" => new HashSet<string>(StringComparer.Ordinal)
             {
-                "idx_office_metadata_doc_id", "idx_office_metadata_expiry"
+                "idx_office_metadata_expiry"
             },
             _ => new HashSet<string>(StringComparer.Ordinal)
         };

--- a/StudyDocumentManager.Data/Helpers/DatabaseHelper.cs
+++ b/StudyDocumentManager.Data/Helpers/DatabaseHelper.cs
@@ -1451,6 +1451,7 @@ public class DatabaseHelper
         var hasSavedSearches = actualTables.Contains("saved_searches");
         var hasImportInbox = actualTables.Contains("import_inbox");
         var hasWatchedFolders = actualTables.Contains("watched_folders");
+        var hasOfficeMetadata = actualTables.Contains("office_document_metadata");
         var metadataTables = new[] { "student_context", "courses", "semesters", "assignments", "assignment_documents" };
         var metadataTableCount = metadataTables.Count(actualTables.Contains);
         var hasStudentMetadata = metadataTableCount == metadataTables.Length;
@@ -1464,6 +1465,8 @@ public class DatabaseHelper
             expectedTables.Add("saved_searches");
         if (!hasWatchedFolders)
             expectedTables.Remove("watched_folders");
+        if (hasOfficeMetadata)
+            expectedTables.Add("office_document_metadata");
         if (hasStudentMetadata)
             expectedTables.AddRange(metadataTables);
 
@@ -1485,6 +1488,8 @@ public class DatabaseHelper
             ValidateRequiredColumns(connection, "watched_folders", ["id", "folder_path", "enabled", "include_subdirectories", "last_scan_at", "created_at"], []);
         if (hasSavedSearches)
             ValidateRequiredColumns(connection, "saved_searches", ["id", "name", "criteria_json", "created_at"]);
+        if (hasOfficeMetadata)
+            ValidateRequiredColumns(connection, "office_document_metadata", ["id", "document_id", "document_number", "contact_name", "organization_or_project", "effective_date", "expiry_date", "confidentiality_level", "reminder_enabled", "reminder_days_before", "created_at", "updated_at"], []);
         if (hasStudentMetadata)
         {
             ValidateRequiredColumns(connection, "student_context", ["id", "academic_year", "semester", "course", "module", "owner"]);
@@ -1500,6 +1505,8 @@ public class DatabaseHelper
         ValidateCascadeForeignKeys(connection, "personal_notes", [("document_id", "documents", "id")]);
         ValidateCascadeForeignKeys(connection, "recent_files", [("document_id", "documents", "id")]);
         ValidateCascadeForeignKeys(connection, "document_relations", [("doc_id_1", "documents", "id"), ("doc_id_2", "documents", "id")]);
+        if (hasOfficeMetadata)
+            ValidateCascadeForeignKeys(connection, "office_document_metadata", [("document_id", "documents", "id")]);
         if (hasStudentMetadata)
         {
             ValidateForeignKeys(connection, "assignments", [
@@ -1510,6 +1517,8 @@ public class DatabaseHelper
         ValidateUniqueConstraint(connection, "collection_items", ["collection_id", "document_id"]);
         ValidateUniqueConstraint(connection, "recent_files", ["document_id"]);
         ValidateUniqueConstraint(connection, "document_relations", ["doc_id_1", "doc_id_2"]);
+        if (hasOfficeMetadata)
+            ValidateUniqueConstraint(connection, "office_document_metadata", ["document_id"]);
         if (hasStudentMetadata)
             ValidateUniqueConstraint(connection, "assignment_documents", ["assignment_id", "document_id"]);
         ValidateDocumentPathIndex(connection, requireDocumentPathIndex);
@@ -1725,6 +1734,10 @@ private static void ValidateDocumentPathIndex(SqliteConnection connection, bool 
             "collection_items" => new HashSet<string>(StringComparer.Ordinal)
             {
                 "idx_collection_items_collection", "idx_collection_items_document"
+            },
+            "office_document_metadata" => new HashSet<string>(StringComparer.Ordinal)
+            {
+                "idx_office_metadata_doc_id", "idx_office_metadata_expiry"
             },
             _ => new HashSet<string>(StringComparer.Ordinal)
         };

--- a/StudyDocumentManager.Data/Helpers/DatabaseMigrator.cs
+++ b/StudyDocumentManager.Data/Helpers/DatabaseMigrator.cs
@@ -192,6 +192,22 @@ public static class DatabaseMigrator
                 FOREIGN KEY (document_id) REFERENCES documents(id) ON DELETE CASCADE
             );
 
+            CREATE TABLE IF NOT EXISTS office_document_metadata (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                document_id INTEGER NOT NULL UNIQUE,
+                document_number TEXT,
+                contact_name TEXT,
+                organization_or_project TEXT,
+                effective_date DATETIME,
+                expiry_date DATETIME,
+                confidentiality_level TEXT NOT NULL DEFAULT 'internal',
+                reminder_enabled INTEGER NOT NULL DEFAULT 1,
+                reminder_days_before INTEGER NOT NULL DEFAULT 3,
+                created_at DATETIME DEFAULT (datetime('now', 'localtime')),
+                updated_at DATETIME DEFAULT (datetime('now', 'localtime')),
+                FOREIGN KEY (document_id) REFERENCES documents(id) ON DELETE CASCADE
+            );
+
             CREATE INDEX IF NOT EXISTS idx_documents_subject ON documents(subject);
             CREATE INDEX IF NOT EXISTS idx_documents_type ON documents(type);
             CREATE INDEX IF NOT EXISTS idx_documents_created_at ON documents(created_at);
@@ -200,6 +216,8 @@ public static class DatabaseMigrator
             CREATE INDEX IF NOT EXISTS idx_collection_items_document ON collection_items(document_id);
             CREATE INDEX IF NOT EXISTS idx_documents_deleted ON documents(is_deleted);
             CREATE INDEX IF NOT EXISTS idx_documents_important ON documents(is_important);
+            CREATE INDEX IF NOT EXISTS idx_office_metadata_doc_id ON office_document_metadata(document_id);
+            CREATE INDEX IF NOT EXISTS idx_office_metadata_expiry ON office_document_metadata(expiry_date);
             """;
 
         using var conn = new SqliteConnection(connectionString);
@@ -466,7 +484,7 @@ public static class DatabaseMigrator
         {
             "documents", "collections", "collection_items", "personal_notes", "recent_files",
             "document_relations", "categories", "document_types", "app_settings", "saved_searches",
-            "student_context", "courses", "semesters", "assignments", "assignment_documents", "import_inbox", "watched_folders"
+            "student_context", "courses", "semesters", "assignments", "assignment_documents", "import_inbox", "watched_folders", "office_document_metadata"
         };
         var unsupportedTables = tables.Where(table => !supportedTables.Contains(table)).ToList();
         if (unsupportedTables.Count > 0)
@@ -488,6 +506,8 @@ public static class DatabaseMigrator
             RequireColumns(connection, "import_inbox", ["id", "document_id", "source_path", "display_name", "failure_code", "duplicate_candidate", "subject", "type", "state", "created_at", "updated_at"], ["subject", "type"]);
         if (TableExists(connection, "watched_folders"))
             RequireColumns(connection, "watched_folders", ["id", "folder_path", "enabled", "include_subdirectories", "last_scan_at", "created_at"], []);
+        if (TableExists(connection, "office_document_metadata"))
+            RequireColumns(connection, "office_document_metadata", ["id", "document_id", "document_number", "contact_name", "organization_or_project", "effective_date", "expiry_date", "confidentiality_level", "reminder_enabled", "reminder_days_before", "created_at", "updated_at"], []);
 
         var tablesToRebuild = new List<string>();
         ValidateChildTable(connection, "collection_items", ["id", "collection_id", "document_id", "added_at"],
@@ -731,6 +751,10 @@ public static class DatabaseMigrator
             "collection_items" => new HashSet<string>(StringComparer.Ordinal)
             {
                 "idx_collection_items_collection", "idx_collection_items_document"
+            },
+            "office_document_metadata" => new HashSet<string>(StringComparer.Ordinal)
+            {
+                "idx_office_metadata_doc_id", "idx_office_metadata_expiry"
             },
             _ => new HashSet<string>(StringComparer.Ordinal)
         };

--- a/StudyDocumentManager.Data/Helpers/DatabaseMigrator.cs
+++ b/StudyDocumentManager.Data/Helpers/DatabaseMigrator.cs
@@ -216,7 +216,6 @@ public static class DatabaseMigrator
             CREATE INDEX IF NOT EXISTS idx_collection_items_document ON collection_items(document_id);
             CREATE INDEX IF NOT EXISTS idx_documents_deleted ON documents(is_deleted);
             CREATE INDEX IF NOT EXISTS idx_documents_important ON documents(is_important);
-            CREATE INDEX IF NOT EXISTS idx_office_metadata_doc_id ON office_document_metadata(document_id);
             CREATE INDEX IF NOT EXISTS idx_office_metadata_expiry ON office_document_metadata(expiry_date);
             """;
 
@@ -225,6 +224,8 @@ public static class DatabaseMigrator
 
         if (HasAnyLegacyVietnameseTable(conn))
             MigrateLegacyVietnameseSchema(conn, createTablesQuery);
+
+        DropRedundantOfficeMetadataIndex(conn);
 
         var preflight = Preflight(conn);
 
@@ -507,7 +508,21 @@ public static class DatabaseMigrator
         if (TableExists(connection, "watched_folders"))
             RequireColumns(connection, "watched_folders", ["id", "folder_path", "enabled", "include_subdirectories", "last_scan_at", "created_at"], []);
         if (TableExists(connection, "office_document_metadata"))
+        {
             RequireColumns(connection, "office_document_metadata", ["id", "document_id", "document_number", "contact_name", "organization_or_project", "effective_date", "expiry_date", "confidentiality_level", "reminder_enabled", "reminder_days_before", "created_at", "updated_at"], []);
+            EnsureNoUnsupportedIndexesOrTriggers(connection, "office_document_metadata");
+            EnsureNoOrphans(connection, "office_document_metadata", [("document_id", "documents", "id")]);
+            if (!HasUniqueIndex(connection, "office_document_metadata", ["document_id"]))
+                throw new InvalidOperationException("Missing unique constraint in 'office_document_metadata'.");
+
+            var actualForeignKeys = GetForeignKeys(connection, "office_document_metadata");
+            if (actualForeignKeys.Count != 1 || !actualForeignKeys.Any(fk =>
+                fk.From == "document_id" && fk.ParentTable == "documents" && fk.ParentColumn == "id" &&
+                string.Equals(fk.OnDelete, "CASCADE", StringComparison.OrdinalIgnoreCase)))
+            {
+                throw new InvalidOperationException("Unsupported foreign key layout in 'office_document_metadata'.");
+            }
+        }
 
         var tablesToRebuild = new List<string>();
         ValidateChildTable(connection, "collection_items", ["id", "collection_id", "document_id", "added_at"],
@@ -754,7 +769,7 @@ public static class DatabaseMigrator
             },
             "office_document_metadata" => new HashSet<string>(StringComparer.Ordinal)
             {
-                "idx_office_metadata_doc_id", "idx_office_metadata_expiry"
+                "idx_office_metadata_expiry"
             },
             _ => new HashSet<string>(StringComparer.Ordinal)
         };
@@ -840,6 +855,16 @@ public static class DatabaseMigrator
             return;
 
         using var cmd = new SqliteCommand($"ALTER TABLE {table} ADD COLUMN {column} {type}", conn, transaction);
+        cmd.ExecuteNonQuery();
+    }
+
+    private static void DropRedundantOfficeMetadataIndex(SqliteConnection conn)
+    {
+        if (!TableExists(conn, "office_document_metadata"))
+            return;
+
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = "DROP INDEX IF EXISTS idx_office_metadata_doc_id;";
         cmd.ExecuteNonQuery();
     }
 

--- a/StudyDocumentManager.Data/Repositories/OfficeMetadataRepository.cs
+++ b/StudyDocumentManager.Data/Repositories/OfficeMetadataRepository.cs
@@ -1,0 +1,160 @@
+using Microsoft.Data.Sqlite;
+using StudyDocumentManager.Core.Entities;
+using StudyDocumentManager.Core.Interfaces;
+using StudyDocumentManager.Data.Helpers;
+
+namespace StudyDocumentManager.Data.Repositories;
+
+/// <summary>
+/// 個人業務文書メタデータおよびリマインダー永続化リポジトリ。
+/// </summary>
+public class OfficeMetadataRepository : IOfficeMetadataRepository
+{
+    private readonly DatabaseHelper _db;
+
+    public OfficeMetadataRepository(DatabaseHelper db)
+    {
+        _db = db;
+    }
+
+    public OfficeDocumentMetadata? GetByDocumentId(int documentId)
+    {
+        using var conn = _db.OpenConnection();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT id, document_id, document_number, contact_name, organization_or_project, effective_date, expiry_date, confidentiality_level, reminder_enabled, reminder_days_before, created_at, updated_at FROM office_document_metadata WHERE document_id = @docId LIMIT 1";
+        cmd.Parameters.AddWithValue("@docId", documentId);
+        using var reader = cmd.ExecuteReader();
+        if (reader.Read())
+            return MapReader(reader);
+        return null;
+    }
+
+    public bool Save(OfficeDocumentMetadata metadata)
+    {
+        using var conn = _db.OpenConnection();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            INSERT INTO office_document_metadata (
+                document_id, document_number, contact_name, organization_or_project,
+                effective_date, expiry_date, confidentiality_level,
+                reminder_enabled, reminder_days_before, created_at, updated_at
+            ) VALUES (
+                @documentId, @documentNumber, @contactName, @organizationOrProject,
+                @effectiveDate, @expiryDate, @confidentialityLevel,
+                @reminderEnabled, @reminderDaysBefore, @createdAt, @updatedAt
+            )
+            ON CONFLICT(document_id) DO UPDATE SET
+                document_number = excluded.document_number,
+                contact_name = excluded.contact_name,
+                organization_or_project = excluded.organization_or_project,
+                effective_date = excluded.effective_date,
+                expiry_date = excluded.expiry_date,
+                confidentiality_level = excluded.confidentiality_level,
+                reminder_enabled = excluded.reminder_enabled,
+                reminder_days_before = excluded.reminder_days_before,
+                updated_at = datetime('now', 'localtime');
+            """;
+        cmd.Parameters.AddWithValue("@documentId", metadata.DocumentId);
+        cmd.Parameters.AddWithValue("@documentNumber", (object?)metadata.DocumentNumber ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("@contactName", (object?)metadata.ContactName ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("@organizationOrProject", (object?)metadata.OrganizationOrProject ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("@effectiveDate", metadata.EffectiveDate.HasValue ? metadata.EffectiveDate.Value.ToString("yyyy-MM-dd HH:mm:ss") : DBNull.Value);
+        cmd.Parameters.AddWithValue("@expiryDate", metadata.ExpiryDate.HasValue ? metadata.ExpiryDate.Value.ToString("yyyy-MM-dd HH:mm:ss") : DBNull.Value);
+        cmd.Parameters.AddWithValue("@confidentialityLevel", metadata.ConfidentialityLevel);
+        cmd.Parameters.AddWithValue("@reminderEnabled", metadata.ReminderEnabled ? 1 : 0);
+        cmd.Parameters.AddWithValue("@reminderDaysBefore", metadata.ReminderDaysBefore);
+        cmd.Parameters.AddWithValue("@createdAt", metadata.CreatedAt.ToString("yyyy-MM-dd HH:mm:ss"));
+        cmd.Parameters.AddWithValue("@updatedAt", DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"));
+
+        return cmd.ExecuteNonQuery() > 0;
+    }
+
+    public bool DeleteByDocumentId(int documentId)
+    {
+        using var conn = _db.OpenConnection();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = "DELETE FROM office_document_metadata WHERE document_id = @docId";
+        cmd.Parameters.AddWithValue("@docId", documentId);
+        return cmd.ExecuteNonQuery() > 0;
+    }
+
+    public IReadOnlyList<OfficeReminderItem> GetUpcomingReminders(DateTime asOfDate, int defaultDueSoonDays = 7)
+    {
+        var items = new List<OfficeReminderItem>();
+        using var conn = _db.OpenConnection();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            SELECT m.document_id, d.name, m.document_number, m.organization_or_project, m.expiry_date, m.reminder_enabled, m.reminder_days_before
+            FROM office_document_metadata m
+            INNER JOIN documents d ON d.id = m.document_id
+            WHERE (d.is_deleted IS NULL OR d.is_deleted = 0)
+            ORDER BY m.expiry_date ASC, d.name ASC;
+            """;
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read())
+        {
+            int docId = reader.GetInt32(0);
+            string docName = reader.GetString(1);
+            string? docNum = reader.IsDBNull(2) ? null : reader.GetString(2);
+            string? org = reader.IsDBNull(3) ? null : reader.GetString(3);
+            DateTime? expiryDate = reader.IsDBNull(4) ? null : DateTime.Parse(reader.GetString(4));
+            bool reminderEnabled = reader.GetInt32(5) != 0;
+            int reminderDays = reader.GetInt32(6);
+            if (reminderDays <= 0)
+                reminderDays = defaultDueSoonDays;
+
+            OfficeExpiryState state;
+            int daysRemaining = 0;
+
+            if (!expiryDate.HasValue)
+            {
+                state = OfficeExpiryState.None;
+            }
+            else
+            {
+                var diff = (expiryDate.Value.Date - asOfDate.Date).TotalDays;
+                daysRemaining = (int)diff;
+                if (diff < 0)
+                {
+                    state = OfficeExpiryState.Overdue;
+                }
+                else if (diff <= reminderDays)
+                {
+                    state = OfficeExpiryState.DueSoon;
+                }
+                else
+                {
+                    state = OfficeExpiryState.Active;
+                }
+            }
+
+            items.Add(new OfficeReminderItem(
+                DocumentId: docId,
+                DocumentName: docName,
+                DocumentNumber: docNum,
+                OrganizationOrProject: org,
+                ExpiryDate: expiryDate,
+                ExpiryState: state,
+                DaysRemaining: daysRemaining,
+                ReminderEnabled: reminderEnabled));
+        }
+
+        return items;
+    }
+
+    private static OfficeDocumentMetadata MapReader(SqliteDataReader reader) => new()
+    {
+        Id = reader.GetInt32(0),
+        DocumentId = reader.GetInt32(1),
+        DocumentNumber = reader.IsDBNull(2) ? null : reader.GetString(2),
+        ContactName = reader.IsDBNull(3) ? null : reader.GetString(3),
+        OrganizationOrProject = reader.IsDBNull(4) ? null : reader.GetString(4),
+        EffectiveDate = reader.IsDBNull(5) ? null : DateTime.Parse(reader.GetString(5)),
+        ExpiryDate = reader.IsDBNull(6) ? null : DateTime.Parse(reader.GetString(6)),
+        ConfidentialityLevel = reader.GetString(7),
+        ReminderEnabled = reader.GetInt32(8) != 0,
+        ReminderDaysBefore = reader.GetInt32(9),
+        CreatedAt = DateTime.Parse(reader.GetString(10)),
+        UpdatedAt = DateTime.Parse(reader.GetString(11))
+    };
+}

--- a/StudyDocumentManager.Data/Repositories/OfficeMetadataRepository.cs
+++ b/StudyDocumentManager.Data/Repositories/OfficeMetadataRepository.cs
@@ -31,6 +31,11 @@ public class OfficeMetadataRepository : IOfficeMetadataRepository
 
     public bool Save(OfficeDocumentMetadata metadata)
     {
+        if (!OfficeConfidentialityLevel.IsValid(metadata.ConfidentialityLevel))
+        {
+            metadata.ConfidentialityLevel = OfficeConfidentialityLevel.Internal;
+        }
+
         using var conn = _db.OpenConnection();
         using var cmd = conn.CreateCommand();
         cmd.CommandText = """
@@ -88,6 +93,7 @@ public class OfficeMetadataRepository : IOfficeMetadataRepository
             FROM office_document_metadata m
             INNER JOIN documents d ON d.id = m.document_id
             WHERE (d.is_deleted IS NULL OR d.is_deleted = 0)
+              AND m.reminder_enabled = 1
             ORDER BY m.expiry_date ASC, d.name ASC;
             """;
         using var reader = cmd.ExecuteReader();

--- a/StudyDocumentManager.Tests/OfficeMetadataTests.cs
+++ b/StudyDocumentManager.Tests/OfficeMetadataTests.cs
@@ -1,6 +1,10 @@
 using System.Collections.ObjectModel;
+using System.IO;
+using Microsoft.Data.Sqlite;
+using StudyDocumentManager.Core;
 using StudyDocumentManager.Core.Entities;
 using StudyDocumentManager.Core.Interfaces;
+using StudyDocumentManager.Data.Helpers;
 using StudyDocumentManager.Data.Repositories;
 using StudyDocumentManager.Models;
 using StudyDocumentManager.Services;
@@ -282,6 +286,188 @@ public sealed class OfficeMetadataTests : DatabaseTestBase
         Assert.Equal("John Doe", reloaded.ContactName);
     }
 
+    [Fact]
+    public void GetUpcomingReminders_ExcludesDisabledReminders()
+    {
+        var today = new DateTime(2026, 9, 2);
+        var doc = new StudyDocument { Name = "Disabled Reminder Doc" };
+        _docRepo.Add(doc);
+        int docId = _docRepo.GetAll().Single(d => d.Name == "Disabled Reminder Doc").Id;
+
+        _officeRepo.Save(new OfficeDocumentMetadata
+        {
+            DocumentId = docId,
+            ExpiryDate = today.AddDays(2),
+            ReminderEnabled = false,
+            ReminderDaysBefore = 5
+        });
+
+        var reminders = _officeRepo.GetUpcomingReminders(today);
+        Assert.DoesNotContain(reminders, r => r.DocumentId == docId);
+    }
+
+    [Fact]
+    public void Save_InvalidConfidentialityLevel_CoercesToInternal()
+    {
+        var doc = new StudyDocument { Name = "Invalid Conf Doc" };
+        _docRepo.Add(doc);
+        int docId = _docRepo.GetAll().Single(d => d.Name == "Invalid Conf Doc").Id;
+
+        var meta = new OfficeDocumentMetadata
+        {
+            DocumentId = docId,
+            ConfidentialityLevel = "invalid_level_xyz"
+        };
+        bool saved = _officeRepo.Save(meta);
+        Assert.True(saved);
+
+        var loaded = _officeRepo.GetByDocumentId(docId);
+        Assert.NotNull(loaded);
+        Assert.Equal(OfficeConfidentialityLevel.Internal, loaded.ConfidentialityLevel);
+    }
+
+    [Fact]
+    public async Task OpenFileAsync_NonExistentFile_ShowsErrorDialog()
+    {
+        var fakePath = Path.Combine(Path.GetTempPath(), $"sdm_non_existent_{Guid.NewGuid():N}.pdf");
+        var doc = new StudyDocument { Name = "Missing File Doc", FilePath = fakePath };
+        _docRepo.Add(doc);
+
+        var dialog = new FakeDialogService();
+        var model = new OfficeWorkspaceModel(
+            _officeRepo, _docRepo, new FakeProcessLauncher(), dialog, new FakeNavigationService(), _loc);
+
+        model.SelectedRow = model.FilteredRows.Single(r => r.Name == "Missing File Doc");
+        await model.OpenFileAsync();
+
+        Assert.NotNull(dialog.LastErrorMessage);
+        Assert.Contains(fakePath, dialog.LastErrorMessage);
+    }
+
+    [Fact]
+    public void OfficeWorkspaceModel_LanguageChanged_RelocalizesFilterOptionsAndRows()
+    {
+        var today = new DateTime(2026, 9, 2);
+        var doc = new StudyDocument { Name = "I18n Doc", Status = DocumentStatus.Completed };
+        _docRepo.Add(doc);
+        int docId = _docRepo.GetAll().Single(d => d.Name == "I18n Doc").Id;
+
+        _officeRepo.Save(new OfficeDocumentMetadata
+        {
+            DocumentId = docId,
+            ConfidentialityLevel = OfficeConfidentialityLevel.Confidential,
+            ExpiryDate = today.AddDays(1),
+            ReminderDaysBefore = 3
+        });
+
+        _loc.SetLanguage(SupportedLanguage.Japanese);
+        var model = new OfficeWorkspaceModel(
+            _officeRepo, _docRepo, new FakeProcessLauncher(), new FakeDialogService(), new FakeNavigationService(), _loc, today);
+
+        var rowJp = model.FilteredRows.Single(r => r.DocumentId == docId);
+        Assert.Equal(_loc["OW_Conf_Confidential"], rowJp.ConfidentialityLabel);
+        Assert.Equal(_loc["DS_Kind_Completed"], rowJp.StatusLabel);
+
+        _loc.SetLanguage(SupportedLanguage.English);
+
+        var confOptionEn = model.ConfidentialityFilterOptions.Single(f => f.Key == OfficeConfidentialityLevel.Confidential);
+        Assert.Equal("Confidential", confOptionEn.Label);
+
+        var expiryOptionEn = model.ExpiryFilterOptions.Single(f => f.Key == "due-soon");
+        Assert.Equal("Due Soon", expiryOptionEn.Label);
+
+        var rowEn = model.FilteredRows.Single(r => r.DocumentId == docId);
+        Assert.Equal("Confidential", rowEn.ConfidentialityLabel);
+        Assert.Equal("Completed", rowEn.StatusLabel);
+
+        _loc.SetLanguage(SupportedLanguage.Japanese);
+    }
+
+    [Fact]
+    public void CanRestoreDatabase_WithOfficeMetadata_ValidatesRowData()
+    {
+        var doc = new StudyDocument { Name = "Office Backup Doc" };
+        _docRepo.Add(doc);
+        int docId = _docRepo.GetAll().Single(d => d.Name == "Office Backup Doc").Id;
+
+        _officeRepo.Save(new OfficeDocumentMetadata
+        {
+            DocumentId = docId,
+            ConfidentialityLevel = OfficeConfidentialityLevel.Confidential,
+            ReminderDaysBefore = 5,
+            EffectiveDate = new DateTime(2026, 1, 1),
+            ExpiryDate = new DateTime(2026, 12, 31)
+        });
+
+        var backupPath = Path.Combine(Path.GetTempPath(), $"office_backup_{Guid.NewGuid():N}.db");
+        try
+        {
+            Assert.True(Db.BackupDatabase(backupPath));
+            Assert.True(Db.CanRestoreDatabase(backupPath));
+
+            using (var conn = new SqliteConnection($"Data Source={backupPath};Pooling=False"))
+            {
+                conn.Open();
+                using var cmd = conn.CreateCommand();
+                cmd.CommandText = "UPDATE office_document_metadata SET reminder_days_before = -1;";
+                cmd.ExecuteNonQuery();
+            }
+            Assert.False(Db.CanRestoreDatabase(backupPath));
+
+            using (var conn = new SqliteConnection($"Data Source={backupPath};Pooling=False"))
+            {
+                conn.Open();
+                using var cmd = conn.CreateCommand();
+                cmd.CommandText = "UPDATE office_document_metadata SET reminder_days_before = 3, confidentiality_level = 'bogus';";
+                cmd.ExecuteNonQuery();
+            }
+            Assert.False(Db.CanRestoreDatabase(backupPath));
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            if (File.Exists(backupPath))
+                File.Delete(backupPath);
+        }
+    }
+
+    [Fact]
+    public void Preflight_OfficeMetadata_ValidatesUniqueAndCascadeForeignKey()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"sdm_preflight_office_{Guid.NewGuid():N}.db");
+        try
+        {
+            Assert.True(Db.BackupDatabase(dbPath));
+            using (var conn = new SqliteConnection($"Data Source={dbPath};Pooling=False"))
+            {
+                conn.Open();
+                using var cmd = conn.CreateCommand();
+                cmd.CommandText = """
+                    DROP TABLE office_document_metadata;
+                    CREATE TABLE office_document_metadata (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        document_id INTEGER NOT NULL,
+                        document_number TEXT, contact_name TEXT, organization_or_project TEXT,
+                        effective_date DATETIME, expiry_date DATETIME, confidentiality_level TEXT NOT NULL DEFAULT 'internal',
+                        reminder_enabled INTEGER NOT NULL DEFAULT 1, reminder_days_before INTEGER NOT NULL DEFAULT 3,
+                        created_at DATETIME, updated_at DATETIME,
+                        FOREIGN KEY (document_id) REFERENCES documents(id) ON DELETE CASCADE
+                    );
+                    """;
+                cmd.ExecuteNonQuery();
+            }
+
+            var ex = Assert.Throws<InvalidOperationException>(() => DatabaseMigrator.RunMigrations($"Data Source={dbPath};Pooling=False"));
+            Assert.Contains("Missing unique constraint in 'office_document_metadata'", ex.Message);
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            if (File.Exists(dbPath))
+                File.Delete(dbPath);
+        }
+    }
+
     private sealed class FakeProcessLauncher : IProcessLauncherService
     {
         public void OpenFile(string filePath) { }
@@ -292,8 +478,16 @@ public sealed class OfficeMetadataTests : DatabaseTestBase
 
     private sealed class FakeDialogService : IDialogService
     {
+        public string? LastErrorTitle { get; private set; }
+        public string? LastErrorMessage { get; private set; }
+
         public Task ShowMessageAsync(string title, string message) => Task.CompletedTask;
-        public Task ShowErrorAsync(string title, string message) => Task.CompletedTask;
+        public Task ShowErrorAsync(string title, string message)
+        {
+            LastErrorTitle = title;
+            LastErrorMessage = message;
+            return Task.CompletedTask;
+        }
         public Task<bool> ShowConfirmAsync(string title, string message) => Task.FromResult(true);
         public Task<bool> ShowConfirmAsync(string title, string message, string confirmText, bool isDanger = false) => Task.FromResult(true);
         public Task<string?> ShowInputAsync(string title, string label, string defaultValue = "", string watermark = "") => Task.FromResult<string?>(defaultValue);

--- a/StudyDocumentManager.Tests/OfficeMetadataTests.cs
+++ b/StudyDocumentManager.Tests/OfficeMetadataTests.cs
@@ -1,0 +1,309 @@
+using System.Collections.ObjectModel;
+using StudyDocumentManager.Core.Entities;
+using StudyDocumentManager.Core.Interfaces;
+using StudyDocumentManager.Data.Repositories;
+using StudyDocumentManager.Models;
+using StudyDocumentManager.Services;
+using Xunit;
+
+namespace StudyDocumentManager.Tests;
+
+public sealed class OfficeMetadataTests : DatabaseTestBase
+{
+    private readonly OfficeMetadataRepository _officeRepo;
+    private readonly DocumentRepository _docRepo;
+    private readonly LocalizationService _loc;
+
+    public OfficeMetadataTests()
+    {
+        _officeRepo = new OfficeMetadataRepository(Db);
+        _docRepo = new DocumentRepository(Db);
+        _loc = new LocalizationService();
+    }
+
+    [Fact]
+    public void Save_And_GetByDocumentId_PersistsAllFieldsCorrectly()
+    {
+        var doc = new StudyDocument { Name = "Contract Alpha" };
+        _docRepo.Add(doc);
+        int docId = _docRepo.GetAll().Single(d => d.Name == "Contract Alpha").Id;
+
+        var effectiveDate = new DateTime(2026, 1, 15, 10, 0, 0);
+        var expiryDate = new DateTime(2027, 1, 15, 18, 0, 0);
+
+        var meta = new OfficeDocumentMetadata
+        {
+            DocumentId = docId,
+            DocumentNumber = "CTR-2026-001",
+            ContactName = "Taro Yamada",
+            OrganizationOrProject = "Acme Corp",
+            EffectiveDate = effectiveDate,
+            ExpiryDate = expiryDate,
+            ConfidentialityLevel = OfficeConfidentialityLevel.Confidential,
+            ReminderEnabled = true,
+            ReminderDaysBefore = 14
+        };
+
+        bool saved = _officeRepo.Save(meta);
+        Assert.True(saved);
+
+        var loaded = _officeRepo.GetByDocumentId(docId);
+        Assert.NotNull(loaded);
+        Assert.Equal(docId, loaded.DocumentId);
+        Assert.Equal("CTR-2026-001", loaded.DocumentNumber);
+        Assert.Equal("Taro Yamada", loaded.ContactName);
+        Assert.Equal("Acme Corp", loaded.OrganizationOrProject);
+        Assert.Equal(effectiveDate, loaded.EffectiveDate);
+        Assert.Equal(expiryDate, loaded.ExpiryDate);
+        Assert.Equal(OfficeConfidentialityLevel.Confidential, loaded.ConfidentialityLevel);
+        Assert.True(loaded.ReminderEnabled);
+        Assert.Equal(14, loaded.ReminderDaysBefore);
+    }
+
+    [Fact]
+    public void Save_UpdateExistingMetadata_UpsertsCorrectly()
+    {
+        var doc = new StudyDocument { Name = "Invoice Beta" };
+        _docRepo.Add(doc);
+        int docId = _docRepo.GetAll().Single(d => d.Name == "Invoice Beta").Id;
+
+        var meta = new OfficeDocumentMetadata
+        {
+            DocumentId = docId,
+            DocumentNumber = "INV-001",
+            ConfidentialityLevel = OfficeConfidentialityLevel.Internal
+        };
+        _officeRepo.Save(meta);
+
+        // Update fields
+        meta.DocumentNumber = "INV-001-REV";
+        meta.ContactName = "Hanako Sato";
+        meta.ConfidentialityLevel = OfficeConfidentialityLevel.Restricted;
+        bool updated = _officeRepo.Save(meta);
+        Assert.True(updated);
+
+        var loaded = _officeRepo.GetByDocumentId(docId);
+        Assert.NotNull(loaded);
+        Assert.Equal("INV-001-REV", loaded.DocumentNumber);
+        Assert.Equal("Hanako Sato", loaded.ContactName);
+        Assert.Equal(OfficeConfidentialityLevel.Restricted, loaded.ConfidentialityLevel);
+    }
+
+    [Fact]
+    public void DeleteByDocumentId_RemovesMetadata()
+    {
+        var doc = new StudyDocument { Name = "Receipt Gamma" };
+        _docRepo.Add(doc);
+        int docId = _docRepo.GetAll().Single(d => d.Name == "Receipt Gamma").Id;
+
+        var meta = new OfficeDocumentMetadata
+        {
+            DocumentId = docId,
+            DocumentNumber = "REC-999"
+        };
+        _officeRepo.Save(meta);
+
+        bool deleted = _officeRepo.DeleteByDocumentId(docId);
+        Assert.True(deleted);
+
+        var loaded = _officeRepo.GetByDocumentId(docId);
+        Assert.Null(loaded);
+    }
+
+    [Fact]
+    public void GetUpcomingReminders_CalculatesOverdueDueSoonActiveCorrectly()
+    {
+        var today = new DateTime(2026, 9, 2);
+
+        var docOverdue = new StudyDocument { Name = "Overdue Doc" };
+        var docDueSoon = new StudyDocument { Name = "Due Soon Doc" };
+        var docActive = new StudyDocument { Name = "Active Doc" };
+        var docNoDate = new StudyDocument { Name = "No Date Doc" };
+
+        _docRepo.Add(docOverdue);
+        _docRepo.Add(docDueSoon);
+        _docRepo.Add(docActive);
+        _docRepo.Add(docNoDate);
+
+        var all = _docRepo.GetAll();
+        int idOverdue = all.Single(d => d.Name == "Overdue Doc").Id;
+        int idDueSoon = all.Single(d => d.Name == "Due Soon Doc").Id;
+        int idActive = all.Single(d => d.Name == "Active Doc").Id;
+        int idNoDate = all.Single(d => d.Name == "No Date Doc").Id;
+
+        _officeRepo.Save(new OfficeDocumentMetadata
+        {
+            DocumentId = idOverdue,
+            ExpiryDate = today.AddDays(-2),
+            ReminderDaysBefore = 3
+        });
+        _officeRepo.Save(new OfficeDocumentMetadata
+        {
+            DocumentId = idDueSoon,
+            ExpiryDate = today.AddDays(2),
+            ReminderDaysBefore = 5
+        });
+        _officeRepo.Save(new OfficeDocumentMetadata
+        {
+            DocumentId = idActive,
+            ExpiryDate = today.AddDays(30),
+            ReminderDaysBefore = 5
+        });
+        _officeRepo.Save(new OfficeDocumentMetadata
+        {
+            DocumentId = idNoDate,
+            ExpiryDate = null
+        });
+
+        var reminders = _officeRepo.GetUpcomingReminders(today);
+
+        var itemOverdue = reminders.Single(r => r.DocumentId == idOverdue);
+        Assert.Equal(OfficeExpiryState.Overdue, itemOverdue.ExpiryState);
+        Assert.True(itemOverdue.DaysRemaining < 0);
+
+        var itemDueSoon = reminders.Single(r => r.DocumentId == idDueSoon);
+        Assert.Equal(OfficeExpiryState.DueSoon, itemDueSoon.ExpiryState);
+        Assert.Equal(2, itemDueSoon.DaysRemaining);
+
+        var itemActive = reminders.Single(r => r.DocumentId == idActive);
+        Assert.Equal(OfficeExpiryState.Active, itemActive.ExpiryState);
+        Assert.Equal(30, itemActive.DaysRemaining);
+
+        var itemNoDate = reminders.Single(r => r.DocumentId == idNoDate);
+        Assert.Equal(OfficeExpiryState.None, itemNoDate.ExpiryState);
+    }
+
+    [Fact]
+    public void GetUpcomingReminders_HandlesTimezoneAndDateBoundariesPrecisely()
+    {
+        // 境界値テスト: 同日夜23:59:59の満了は当日扱い（DaysRemaining = 0、DueSoon）
+        var today = new DateTime(2026, 9, 2, 8, 30, 0);
+        var docSameDay = new StudyDocument { Name = "Same Day Expiry" };
+        _docRepo.Add(docSameDay);
+        int docId = _docRepo.GetAll().Single(d => d.Name == "Same Day Expiry").Id;
+
+        _officeRepo.Save(new OfficeDocumentMetadata
+        {
+            DocumentId = docId,
+            ExpiryDate = new DateTime(2026, 9, 2, 23, 59, 59),
+            ReminderDaysBefore = 3
+        });
+
+        var reminders = _officeRepo.GetUpcomingReminders(today);
+        var item = reminders.Single(r => r.DocumentId == docId);
+
+        Assert.Equal(OfficeExpiryState.DueSoon, item.ExpiryState);
+        Assert.Equal(0, item.DaysRemaining);
+    }
+
+    [Fact]
+    public void OfficeWorkspaceModel_EmptyState_InitializesSafely()
+    {
+        var model = new OfficeWorkspaceModel(
+            _officeRepo, _docRepo, new FakeProcessLauncher(), new FakeDialogService(), new FakeNavigationService(), _loc);
+
+        Assert.Empty(model.FilteredRows);
+        Assert.False(model.HasSelection);
+        Assert.Equal(0, model.TotalCount);
+        Assert.Equal(0, model.OverdueCount);
+        Assert.Equal(0, model.DueSoonCount);
+        Assert.Equal(0, model.ActiveCount);
+        Assert.Equal(0, model.NoExpiryCount);
+    }
+
+    [Fact]
+    public async Task OfficeWorkspaceModel_FilteringAndSaving_WorksEndToEnd()
+    {
+        var today = new DateTime(2026, 9, 2);
+
+        var doc1 = new StudyDocument { Name = "NDA Tech Inc", Status = "in-progress" };
+        var doc2 = new StudyDocument { Name = "Tax Report 2026", Status = "unread" };
+        _docRepo.Add(doc1);
+        _docRepo.Add(doc2);
+        int id1 = _docRepo.GetAll().Single(d => d.Name == "NDA Tech Inc").Id;
+        int id2 = _docRepo.GetAll().Single(d => d.Name == "Tax Report 2026").Id;
+
+        _officeRepo.Save(new OfficeDocumentMetadata
+        {
+            DocumentId = id1,
+            DocumentNumber = "NDA-001",
+            OrganizationOrProject = "Tech Inc",
+            ConfidentialityLevel = OfficeConfidentialityLevel.Restricted,
+            ExpiryDate = today.AddDays(1), // due soon
+            ReminderDaysBefore = 3
+        });
+
+        _officeRepo.Save(new OfficeDocumentMetadata
+        {
+            DocumentId = id2,
+            DocumentNumber = "TAX-2026",
+            OrganizationOrProject = "National Tax Agency",
+            ConfidentialityLevel = OfficeConfidentialityLevel.Public,
+            ExpiryDate = today.AddDays(-1) // overdue
+        });
+
+        var model = new OfficeWorkspaceModel(
+            _officeRepo, _docRepo, new FakeProcessLauncher(), new FakeDialogService(), new FakeNavigationService(), _loc, today);
+
+        Assert.Equal(2, model.TotalCount);
+        Assert.Equal(1, model.OverdueCount);
+        Assert.Equal(1, model.DueSoonCount);
+
+        // Filter: due-soon
+        model.SelectedExpiryFilter = model.ExpiryFilterOptions.Single(f => f.Key == "due-soon");
+        Assert.Single(model.FilteredRows);
+        Assert.Equal(id1, model.FilteredRows[0].DocumentId);
+
+        // Filter: restricted confidentiality
+        model.SelectedExpiryFilter = model.ExpiryFilterOptions.Single(f => f.Key == "all");
+        model.SelectedConfidentialityFilter = model.ConfidentialityFilterOptions.Single(f => f.Key == OfficeConfidentialityLevel.Restricted);
+        Assert.Single(model.FilteredRows);
+        Assert.Equal(id1, model.FilteredRows[0].DocumentId);
+
+        // Search text
+        model.SelectedConfidentialityFilter = model.ConfidentialityFilterOptions.Single(f => f.Key == "all");
+        model.SearchText = "National Tax";
+        Assert.Single(model.FilteredRows);
+        Assert.Equal(id2, model.FilteredRows[0].DocumentId);
+
+        // Select and Edit Metadata
+        model.SearchText = string.Empty;
+        model.SelectedRow = model.FilteredRows.Single(r => r.DocumentId == id1);
+        Assert.True(model.HasSelection);
+        Assert.Equal("NDA-001", model.EditingDocumentNumber);
+
+        model.EditingDocumentNumber = "NDA-001-APPROVED";
+        model.EditingContactName = "John Doe";
+        await model.SaveMetadataAsync();
+
+        var reloaded = _officeRepo.GetByDocumentId(id1);
+        Assert.NotNull(reloaded);
+        Assert.Equal("NDA-001-APPROVED", reloaded.DocumentNumber);
+        Assert.Equal("John Doe", reloaded.ContactName);
+    }
+
+    private sealed class FakeProcessLauncher : IProcessLauncherService
+    {
+        public void OpenFile(string filePath) { }
+        public void OpenFolder(string folderPath) { }
+        public void RevealInExplorer(string filePath) { }
+        public void OpenUrl(string url) { }
+    }
+
+    private sealed class FakeDialogService : IDialogService
+    {
+        public Task ShowMessageAsync(string title, string message) => Task.CompletedTask;
+        public Task ShowErrorAsync(string title, string message) => Task.CompletedTask;
+        public Task<bool> ShowConfirmAsync(string title, string message) => Task.FromResult(true);
+        public Task<bool> ShowConfirmAsync(string title, string message, string confirmText, bool isDanger = false) => Task.FromResult(true);
+        public Task<string?> ShowInputAsync(string title, string label, string defaultValue = "", string watermark = "") => Task.FromResult<string?>(defaultValue);
+    }
+
+    private sealed class FakeNavigationService : INavigationService
+    {
+        public bool CanGoBack => true;
+        public void NavigateTo(string viewKey) { }
+        public void NavigateTo(string viewKey, object? parameter) { }
+        public void GoBack() { }
+    }
+}

--- a/StudyDocumentManager/App.axaml.cs
+++ b/StudyDocumentManager/App.axaml.cs
@@ -178,6 +178,7 @@ public partial class App : Application
         services.AddSingleton<IAssignmentRepository, AssignmentRepository>();
         services.AddSingleton<ISettingsService, SettingsRepository>();
         services.AddSingleton<PersonalDocumentArchiveRepository>();
+        services.AddSingleton<IOfficeMetadataRepository, OfficeMetadataRepository>();
 
         // Services
         services.AddKeyedSingleton<HttpClient>("Analytics", (_, _) =>
@@ -250,6 +251,7 @@ services.AddTransient<RecoveryCenterModel>();
         services.AddTransient<FileIntegrityCheckModel>();
         services.AddTransient<SmartViewsModel>();
         services.AddTransient<StudentWorkspaceModel>();
+        services.AddTransient<OfficeWorkspaceModel>();
 
         // モデル — レポート
         services.AddTransient<ReportModel>();

--- a/StudyDocumentManager/Models/OfficeWorkspaceModel.cs
+++ b/StudyDocumentManager/Models/OfficeWorkspaceModel.cs
@@ -1,0 +1,344 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using StudyDocumentManager.Core.Entities;
+using StudyDocumentManager.Core.Interfaces;
+using StudyDocumentManager.Services;
+
+namespace StudyDocumentManager.Models;
+
+public sealed class OfficeDocumentRow
+{
+    public StudyDocument Document { get; init; } = new();
+    public OfficeDocumentMetadata Metadata { get; init; } = new();
+    public int DocumentId => Document.Id;
+    public string Name => Document.Name;
+    public string? DocumentNumber => Metadata.DocumentNumber;
+    public string? ContactName => Metadata.ContactName;
+    public string? OrganizationOrProject => Metadata.OrganizationOrProject;
+    public DateTime? EffectiveDate => Metadata.EffectiveDate;
+    public DateTime? ExpiryDate => Metadata.ExpiryDate;
+    public string ConfidentialityLevel => Metadata.ConfidentialityLevel;
+    public bool ReminderEnabled => Metadata.ReminderEnabled;
+    public int ReminderDaysBefore => Metadata.ReminderDaysBefore;
+    public OfficeExpiryState ExpiryState { get; init; }
+    public int DaysRemaining { get; init; }
+    public string ExpiryStateLabel { get; init; } = string.Empty;
+    public string ConfidentialityLabel { get; init; } = string.Empty;
+    public string DocumentStatus => Document.Status;
+    public string FilePath => Document.FilePath ?? string.Empty;
+}
+
+public sealed class FilterOption(string key, string label)
+{
+    public string Key { get; } = key;
+    public string Label { get; } = label;
+}
+
+public partial class OfficeWorkspaceModel : ModelBase, IDisposable
+{
+    private readonly IOfficeMetadataRepository _officeRepository;
+    private readonly IDocumentRepository _documentRepository;
+    private readonly IProcessLauncherService _processLauncher;
+    private readonly IDialogService _dialogService;
+    private readonly INavigationService _navigationService;
+    private readonly ILocalizationService _loc;
+    private readonly DateTime _today;
+    private bool _disposed;
+    private List<OfficeDocumentRow> _allRows = [];
+
+    [ObservableProperty] private ObservableCollection<OfficeDocumentRow> _filteredRows = [];
+    [ObservableProperty] private OfficeDocumentRow? _selectedRow;
+    [ObservableProperty] private string _searchText = string.Empty;
+    [ObservableProperty] private FilterOption? _selectedExpiryFilter;
+    [ObservableProperty] private FilterOption? _selectedConfidentialityFilter;
+    
+    // Overview metrics
+    [ObservableProperty] private int _overdueCount;
+    [ObservableProperty] private int _dueSoonCount;
+    [ObservableProperty] private int _activeCount;
+    [ObservableProperty] private int _noExpiryCount;
+    [ObservableProperty] private int _totalCount;
+
+    // Editor fields
+    [ObservableProperty] private string _editingDocumentNumber = string.Empty;
+    [ObservableProperty] private string _editingContactName = string.Empty;
+    [ObservableProperty] private string _editingOrganizationOrProject = string.Empty;
+    [ObservableProperty] private DateTimeOffset? _editingEffectiveDate;
+    [ObservableProperty] private DateTimeOffset? _editingExpiryDate;
+    [ObservableProperty] private string _editingConfidentialityLevel = OfficeConfidentialityLevel.Internal;
+    [ObservableProperty] private bool _editingReminderEnabled = true;
+    [ObservableProperty] private int _editingReminderDaysBefore = 3;
+    [ObservableProperty] private string _statusText = string.Empty;
+
+    public IReadOnlyList<FilterOption> ExpiryFilterOptions { get; private set; } = [];
+    public IReadOnlyList<FilterOption> ConfidentialityFilterOptions { get; private set; } = [];
+    public IReadOnlyList<string> ConfidentialityLevels { get; } = OfficeConfidentialityLevel.All;
+
+    public bool HasSelection => SelectedRow != null;
+
+    public OfficeWorkspaceModel(
+        IOfficeMetadataRepository officeRepository,
+        IDocumentRepository documentRepository,
+        IProcessLauncherService processLauncher,
+        IDialogService dialogService,
+        INavigationService navigationService,
+        ILocalizationService loc)
+        : this(officeRepository, documentRepository, processLauncher, dialogService, navigationService, loc, DateTime.Today)
+    {
+    }
+
+    internal OfficeWorkspaceModel(
+        IOfficeMetadataRepository officeRepository,
+        IDocumentRepository documentRepository,
+        IProcessLauncherService processLauncher,
+        IDialogService dialogService,
+        INavigationService navigationService,
+        ILocalizationService loc,
+        DateTime today)
+    {
+        _officeRepository = officeRepository;
+        _documentRepository = documentRepository;
+        _processLauncher = processLauncher;
+        _dialogService = dialogService;
+        _navigationService = navigationService;
+        _loc = loc;
+        _today = today.Date;
+
+        RefreshFilterOptions();
+        _loc.LanguageChanged += OnLanguageChanged;
+        Refresh();
+    }
+
+    private void RefreshFilterOptions()
+    {
+        ExpiryFilterOptions =
+        [
+            new FilterOption("all", _loc["Common_All"] ?? "すべて"),
+            new FilterOption("due-soon", _loc["OW_ExpiryState_DueSoon"] ?? "期限切迫"),
+            new FilterOption("overdue", _loc["OW_ExpiryState_Overdue"] ?? "期限超過"),
+            new FilterOption("active", _loc["OW_ExpiryState_Active"] ?? "有効"),
+            new FilterOption("no-expiry", _loc["OW_ExpiryState_None"] ?? "期限なし")
+        ];
+
+        ConfidentialityFilterOptions =
+        [
+            new FilterOption("all", _loc["Common_All"] ?? "すべて"),
+            new FilterOption(OfficeConfidentialityLevel.Public, "Public"),
+            new FilterOption(OfficeConfidentialityLevel.Internal, "Internal"),
+            new FilterOption(OfficeConfidentialityLevel.Confidential, "Confidential"),
+            new FilterOption(OfficeConfidentialityLevel.Restricted, "Restricted")
+        ];
+
+        SelectedExpiryFilter = ExpiryFilterOptions[0];
+        SelectedConfidentialityFilter = ConfidentialityFilterOptions[0];
+    }
+
+    private void OnLanguageChanged(object? sender, EventArgs e)
+    {
+        RefreshFilterOptions();
+        ApplyFilter();
+    }
+
+    partial void OnSearchTextChanged(string value) => ApplyFilter();
+    partial void OnSelectedExpiryFilterChanged(FilterOption? value) => ApplyFilter();
+    partial void OnSelectedConfidentialityFilterChanged(FilterOption? value) => ApplyFilter();
+
+    partial void OnSelectedRowChanged(OfficeDocumentRow? value)
+    {
+        OnPropertyChanged(nameof(HasSelection));
+        if (value == null)
+        {
+            EditingDocumentNumber = string.Empty;
+            EditingContactName = string.Empty;
+            EditingOrganizationOrProject = string.Empty;
+            EditingEffectiveDate = null;
+            EditingExpiryDate = null;
+            EditingConfidentialityLevel = OfficeConfidentialityLevel.Internal;
+            EditingReminderEnabled = true;
+            EditingReminderDaysBefore = 3;
+            return;
+        }
+
+        var meta = value.Metadata;
+        EditingDocumentNumber = meta.DocumentNumber ?? string.Empty;
+        EditingContactName = meta.ContactName ?? string.Empty;
+        EditingOrganizationOrProject = meta.OrganizationOrProject ?? string.Empty;
+        EditingEffectiveDate = meta.EffectiveDate.HasValue ? new DateTimeOffset(meta.EffectiveDate.Value) : null;
+        EditingExpiryDate = meta.ExpiryDate.HasValue ? new DateTimeOffset(meta.ExpiryDate.Value) : null;
+        EditingConfidentialityLevel = string.IsNullOrWhiteSpace(meta.ConfidentialityLevel)
+            ? OfficeConfidentialityLevel.Internal
+            : meta.ConfidentialityLevel;
+        EditingReminderEnabled = meta.ReminderEnabled;
+        EditingReminderDaysBefore = meta.ReminderDaysBefore > 0 ? meta.ReminderDaysBefore : 3;
+    }
+
+    [RelayCommand]
+    public void Refresh()
+    {
+        var documents = _documentRepository.GetAll();
+        var rows = new List<OfficeDocumentRow>();
+        int overdue = 0;
+        int dueSoon = 0;
+        int active = 0;
+        int noExpiry = 0;
+
+        foreach (var doc in documents)
+        {
+            var meta = _officeRepository.GetByDocumentId(doc.Id) ?? new OfficeDocumentMetadata
+            {
+                DocumentId = doc.Id,
+                ConfidentialityLevel = OfficeConfidentialityLevel.Internal,
+                ReminderEnabled = true,
+                ReminderDaysBefore = 3
+            };
+
+            OfficeExpiryState state;
+            int daysRemaining = 0;
+            if (!meta.ExpiryDate.HasValue)
+            {
+                state = OfficeExpiryState.None;
+                noExpiry++;
+            }
+            else
+            {
+                var diff = (meta.ExpiryDate.Value.Date - _today).TotalDays;
+                daysRemaining = (int)diff;
+                if (diff < 0)
+                {
+                    state = OfficeExpiryState.Overdue;
+                    overdue++;
+                }
+                else if (diff <= (meta.ReminderDaysBefore > 0 ? meta.ReminderDaysBefore : 7))
+                {
+                    state = OfficeExpiryState.DueSoon;
+                    dueSoon++;
+                }
+                else
+                {
+                    state = OfficeExpiryState.Active;
+                    active++;
+                }
+            }
+
+            string stateLabel = state switch
+            {
+                OfficeExpiryState.Overdue => _loc["OW_ExpiryState_Overdue"] ?? "期限超過",
+                OfficeExpiryState.DueSoon => _loc["OW_ExpiryState_DueSoon"] ?? "期限切迫",
+                OfficeExpiryState.Active => _loc["OW_ExpiryState_Active"] ?? "有効",
+                _ => _loc["OW_ExpiryState_None"] ?? "期限なし"
+            };
+
+            rows.Add(new OfficeDocumentRow
+            {
+                Document = doc,
+                Metadata = meta,
+                ExpiryState = state,
+                DaysRemaining = daysRemaining,
+                ExpiryStateLabel = stateLabel,
+                ConfidentialityLabel = meta.ConfidentialityLevel
+            });
+        }
+
+        _allRows = rows;
+        TotalCount = rows.Count;
+        OverdueCount = overdue;
+        DueSoonCount = dueSoon;
+        ActiveCount = active;
+        NoExpiryCount = noExpiry;
+
+        ApplyFilter();
+    }
+
+    private void ApplyFilter()
+    {
+        var query = _allRows.AsEnumerable();
+
+        if (!string.IsNullOrWhiteSpace(SearchText))
+        {
+            var term = SearchText.Trim();
+            query = query.Where(r =>
+                r.Name.Contains(term, StringComparison.OrdinalIgnoreCase) ||
+                (r.DocumentNumber != null && r.DocumentNumber.Contains(term, StringComparison.OrdinalIgnoreCase)) ||
+                (r.ContactName != null && r.ContactName.Contains(term, StringComparison.OrdinalIgnoreCase)) ||
+                (r.OrganizationOrProject != null && r.OrganizationOrProject.Contains(term, StringComparison.OrdinalIgnoreCase)));
+        }
+
+        if (SelectedExpiryFilter != null && SelectedExpiryFilter.Key != "all")
+        {
+            query = SelectedExpiryFilter.Key switch
+            {
+                "due-soon" => query.Where(r => r.ExpiryState == OfficeExpiryState.DueSoon),
+                "overdue" => query.Where(r => r.ExpiryState == OfficeExpiryState.Overdue),
+                "active" => query.Where(r => r.ExpiryState == OfficeExpiryState.Active),
+                "no-expiry" => query.Where(r => r.ExpiryState == OfficeExpiryState.None),
+                _ => query
+            };
+        }
+
+        if (SelectedConfidentialityFilter != null && SelectedConfidentialityFilter.Key != "all")
+        {
+            query = query.Where(r => string.Equals(r.ConfidentialityLevel, SelectedConfidentialityFilter.Key, StringComparison.OrdinalIgnoreCase));
+        }
+
+        FilteredRows = new ObservableCollection<OfficeDocumentRow>(query.ToList());
+    }
+
+    [RelayCommand]
+    public async Task SaveMetadataAsync()
+    {
+        if (SelectedRow == null)
+            return;
+
+        var meta = SelectedRow.Metadata;
+        meta.DocumentNumber = string.IsNullOrWhiteSpace(EditingDocumentNumber) ? null : EditingDocumentNumber.Trim();
+        meta.ContactName = string.IsNullOrWhiteSpace(EditingContactName) ? null : EditingContactName.Trim();
+        meta.OrganizationOrProject = string.IsNullOrWhiteSpace(EditingOrganizationOrProject) ? null : EditingOrganizationOrProject.Trim();
+        meta.EffectiveDate = EditingEffectiveDate?.DateTime;
+        meta.ExpiryDate = EditingExpiryDate?.DateTime;
+        meta.ConfidentialityLevel = string.IsNullOrWhiteSpace(EditingConfidentialityLevel)
+            ? OfficeConfidentialityLevel.Internal
+            : EditingConfidentialityLevel;
+        meta.ReminderEnabled = EditingReminderEnabled;
+        meta.ReminderDaysBefore = EditingReminderDaysBefore > 0 ? EditingReminderDaysBefore : 3;
+
+        bool saved = _officeRepository.Save(meta);
+        if (saved)
+        {
+            StatusText = _loc["Message_SavedSuccessfully"] ?? "保存しました。";
+            int selectedId = SelectedRow.DocumentId;
+            Refresh();
+            SelectedRow = FilteredRows.FirstOrDefault(r => r.DocumentId == selectedId);
+        }
+        else
+        {
+            await _dialogService.ShowMessageAsync(
+                _loc["Common_Error"] ?? "エラー",
+                _loc["Error_SaveFailed"] ?? "保存に失敗しました。");
+        }
+    }
+
+    [RelayCommand]
+    public void OpenFile()
+    {
+        if (SelectedRow != null && !string.IsNullOrWhiteSpace(SelectedRow.FilePath))
+        {
+            _processLauncher.OpenFile(SelectedRow.FilePath);
+        }
+    }
+
+    [RelayCommand]
+    public void GoBack()
+    {
+        _navigationService.GoBack();
+    }
+
+    public void Dispose()
+    {
+        if (!_disposed)
+        {
+            _loc.LanguageChanged -= OnLanguageChanged;
+            _disposed = true;
+        }
+    }
+}

--- a/StudyDocumentManager/Models/OfficeWorkspaceModel.cs
+++ b/StudyDocumentManager/Models/OfficeWorkspaceModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.IO;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using StudyDocumentManager.Core.Entities;
@@ -26,6 +27,7 @@ public sealed class OfficeDocumentRow
     public string ExpiryStateLabel { get; init; } = string.Empty;
     public string ConfidentialityLabel { get; init; } = string.Empty;
     public string DocumentStatus => Document.Status;
+    public string StatusLabel { get; init; } = string.Empty;
     public string FilePath => Document.FilePath ?? string.Empty;
 }
 
@@ -110,8 +112,39 @@ public partial class OfficeWorkspaceModel : ModelBase, IDisposable
         Refresh();
     }
 
+    public string GetConfidentialityLabel(string? level) => level switch
+    {
+        OfficeConfidentialityLevel.Public => _loc["OW_Conf_Public"] ?? "公開",
+        OfficeConfidentialityLevel.Internal => _loc["OW_Conf_Internal"] ?? "社内限り",
+        OfficeConfidentialityLevel.Confidential => _loc["OW_Conf_Confidential"] ?? "機密",
+        OfficeConfidentialityLevel.Restricted => _loc["OW_Conf_Restricted"] ?? "極秘",
+        _ => level ?? string.Empty
+    };
+
+    public string GetStatusLabel(string? status) => status switch
+    {
+        DocumentStatus.Unread => _loc["DS_Kind_Unread"] ?? "未読",
+        DocumentStatus.InProgress => _loc["DS_Kind_InProgress"] ?? "対応中",
+        DocumentStatus.Read => _loc["DS_Kind_Read"] ?? "読了",
+        DocumentStatus.NeedsAction => _loc["DS_Kind_NeedsAction"] ?? "要対応",
+        DocumentStatus.Completed => _loc["DS_Kind_Completed"] ?? "完了",
+        DocumentStatus.Archived => _loc["DS_Kind_Archived"] ?? "保管済み",
+        _ => status ?? string.Empty
+    };
+
+    public string GetExpiryStateLabel(OfficeExpiryState state) => state switch
+    {
+        OfficeExpiryState.Overdue => _loc["OW_ExpiryState_Overdue"] ?? "期限超過",
+        OfficeExpiryState.DueSoon => _loc["OW_ExpiryState_DueSoon"] ?? "期限切迫",
+        OfficeExpiryState.Active => _loc["OW_ExpiryState_Active"] ?? "有効",
+        _ => _loc["OW_ExpiryState_None"] ?? "期限なし"
+    };
+
     private void RefreshFilterOptions()
     {
+        var currentExpiryKey = SelectedExpiryFilter?.Key ?? "all";
+        var currentConfKey = SelectedConfidentialityFilter?.Key ?? "all";
+
         ExpiryFilterOptions =
         [
             new FilterOption("all", _loc["Common_All"] ?? "すべて"),
@@ -124,20 +157,47 @@ public partial class OfficeWorkspaceModel : ModelBase, IDisposable
         ConfidentialityFilterOptions =
         [
             new FilterOption("all", _loc["Common_All"] ?? "すべて"),
-            new FilterOption(OfficeConfidentialityLevel.Public, "Public"),
-            new FilterOption(OfficeConfidentialityLevel.Internal, "Internal"),
-            new FilterOption(OfficeConfidentialityLevel.Confidential, "Confidential"),
-            new FilterOption(OfficeConfidentialityLevel.Restricted, "Restricted")
+            new FilterOption(OfficeConfidentialityLevel.Public, GetConfidentialityLabel(OfficeConfidentialityLevel.Public)),
+            new FilterOption(OfficeConfidentialityLevel.Internal, GetConfidentialityLabel(OfficeConfidentialityLevel.Internal)),
+            new FilterOption(OfficeConfidentialityLevel.Confidential, GetConfidentialityLabel(OfficeConfidentialityLevel.Confidential)),
+            new FilterOption(OfficeConfidentialityLevel.Restricted, GetConfidentialityLabel(OfficeConfidentialityLevel.Restricted))
         ];
 
-        SelectedExpiryFilter = ExpiryFilterOptions[0];
-        SelectedConfidentialityFilter = ConfidentialityFilterOptions[0];
+        SelectedExpiryFilter = ExpiryFilterOptions.FirstOrDefault(f => f.Key == currentExpiryKey) ?? ExpiryFilterOptions[0];
+        SelectedConfidentialityFilter = ConfidentialityFilterOptions.FirstOrDefault(f => f.Key == currentConfKey) ?? ConfidentialityFilterOptions[0];
     }
 
     private void OnLanguageChanged(object? sender, EventArgs e)
     {
         RefreshFilterOptions();
+        OnPropertyChanged(nameof(ExpiryFilterOptions));
+        OnPropertyChanged(nameof(ConfidentialityFilterOptions));
+        RelocalizeRows();
+    }
+
+    private void RelocalizeRows()
+    {
+        var selectedId = SelectedRow?.DocumentId;
+        var relocalized = new List<OfficeDocumentRow>(_allRows.Count);
+        foreach (var r in _allRows)
+        {
+            relocalized.Add(new OfficeDocumentRow
+            {
+                Document = r.Document,
+                Metadata = r.Metadata,
+                ExpiryState = r.ExpiryState,
+                DaysRemaining = r.DaysRemaining,
+                ExpiryStateLabel = GetExpiryStateLabel(r.ExpiryState),
+                ConfidentialityLabel = GetConfidentialityLabel(r.ConfidentialityLevel),
+                StatusLabel = GetStatusLabel(r.DocumentStatus)
+            });
+        }
+        _allRows = relocalized;
         ApplyFilter();
+        if (selectedId.HasValue)
+        {
+            SelectedRow = FilteredRows.FirstOrDefault(r => r.DocumentId == selectedId.Value);
+        }
     }
 
     partial void OnSearchTextChanged(string value) => ApplyFilter();
@@ -209,7 +269,7 @@ public partial class OfficeWorkspaceModel : ModelBase, IDisposable
                     state = OfficeExpiryState.Overdue;
                     overdue++;
                 }
-                else if (diff <= (meta.ReminderDaysBefore > 0 ? meta.ReminderDaysBefore : 7))
+                else if (meta.ReminderEnabled && diff <= (meta.ReminderDaysBefore > 0 ? meta.ReminderDaysBefore : 7))
                 {
                     state = OfficeExpiryState.DueSoon;
                     dueSoon++;
@@ -221,22 +281,15 @@ public partial class OfficeWorkspaceModel : ModelBase, IDisposable
                 }
             }
 
-            string stateLabel = state switch
-            {
-                OfficeExpiryState.Overdue => _loc["OW_ExpiryState_Overdue"] ?? "期限超過",
-                OfficeExpiryState.DueSoon => _loc["OW_ExpiryState_DueSoon"] ?? "期限切迫",
-                OfficeExpiryState.Active => _loc["OW_ExpiryState_Active"] ?? "有効",
-                _ => _loc["OW_ExpiryState_None"] ?? "期限なし"
-            };
-
             rows.Add(new OfficeDocumentRow
             {
                 Document = doc,
                 Metadata = meta,
                 ExpiryState = state,
                 DaysRemaining = daysRemaining,
-                ExpiryStateLabel = stateLabel,
-                ConfidentialityLabel = meta.ConfidentialityLevel
+                ExpiryStateLabel = GetExpiryStateLabel(state),
+                ConfidentialityLabel = GetConfidentialityLabel(meta.ConfidentialityLevel),
+                StatusLabel = GetStatusLabel(doc.Status)
             });
         }
 
@@ -319,12 +372,19 @@ public partial class OfficeWorkspaceModel : ModelBase, IDisposable
     }
 
     [RelayCommand]
-    public void OpenFile()
+    public async Task OpenFileAsync()
     {
-        if (SelectedRow != null && !string.IsNullOrWhiteSpace(SelectedRow.FilePath))
+        if (SelectedRow == null || string.IsNullOrWhiteSpace(SelectedRow.FilePath))
+            return;
+
+        if (!File.Exists(SelectedRow.FilePath))
         {
-            _processLauncher.OpenFile(SelectedRow.FilePath);
+            var msg = string.Format(_loc["OW_Error_FileNotFound"] ?? "ファイルが見つかりません: {0}", SelectedRow.FilePath);
+            await _dialogService.ShowErrorAsync(_loc["Common_Error"] ?? "エラー", msg);
+            return;
         }
+
+        _processLauncher.OpenFile(SelectedRow.FilePath);
     }
 
     [RelayCommand]

--- a/StudyDocumentManager/Resources/Strings.en.resx
+++ b/StudyDocumentManager/Resources/Strings.en.resx
@@ -905,4 +905,10 @@ Please check your network connection.</value></data>
   <data name="OW_Confidentiality" xml:space="preserve"><value>Confidentiality</value></data>
   <data name="OW_Reminder" xml:space="preserve"><value>Enable reminder notification</value></data>
   <data name="OW_DaysRemaining" xml:space="preserve"><value>Days in advance for notification</value></data>
+  <data name="OW_DocNoPrefix" xml:space="preserve"><value>No: </value></data>
+  <data name="OW_Conf_Public" xml:space="preserve"><value>Public</value></data>
+  <data name="OW_Conf_Internal" xml:space="preserve"><value>Internal</value></data>
+  <data name="OW_Conf_Confidential" xml:space="preserve"><value>Confidential</value></data>
+  <data name="OW_Conf_Restricted" xml:space="preserve"><value>Restricted</value></data>
+  <data name="OW_Error_FileNotFound" xml:space="preserve"><value>File not found: {0}</value></data>
 </root>

--- a/StudyDocumentManager/Resources/Strings.en.resx
+++ b/StudyDocumentManager/Resources/Strings.en.resx
@@ -892,4 +892,17 @@ Please check your network connection.</value></data>
   <data name="Onboarding_Skip" xml:space="preserve"><value>Skip</value></data>
   <data name="Onboarding_Finish" xml:space="preserve"><value>Get started</value></data>
   <data name="Onboarding_MenuItem" xml:space="preserve"><value>Getting Started</value></data>
+  <data name="OW_Title" xml:space="preserve"><value>Business &amp; Contracts</value></data>
+  <data name="OW_ExpiryState_Overdue" xml:space="preserve"><value>Overdue</value></data>
+  <data name="OW_ExpiryState_DueSoon" xml:space="preserve"><value>Due Soon</value></data>
+  <data name="OW_ExpiryState_Active" xml:space="preserve"><value>Active</value></data>
+  <data name="OW_ExpiryState_None" xml:space="preserve"><value>No Expiry</value></data>
+  <data name="OW_DocumentNumber" xml:space="preserve"><value>Document No.</value></data>
+  <data name="OW_ContactName" xml:space="preserve"><value>Contact</value></data>
+  <data name="OW_OrganizationOrProject" xml:space="preserve"><value>Company / Project</value></data>
+  <data name="OW_EffectiveDate" xml:space="preserve"><value>Effective Date</value></data>
+  <data name="OW_ExpiryDate" xml:space="preserve"><value>Expiry Date</value></data>
+  <data name="OW_Confidentiality" xml:space="preserve"><value>Confidentiality</value></data>
+  <data name="OW_Reminder" xml:space="preserve"><value>Enable reminder notification</value></data>
+  <data name="OW_DaysRemaining" xml:space="preserve"><value>Days in advance for notification</value></data>
 </root>

--- a/StudyDocumentManager/Resources/Strings.resx
+++ b/StudyDocumentManager/Resources/Strings.resx
@@ -1000,6 +1000,19 @@
   <data name="Onboarding_Skip" xml:space="preserve"><value>スキップ</value></data>
   <data name="Onboarding_Finish" xml:space="preserve"><value>始める</value></data>
   <data name="Onboarding_MenuItem" xml:space="preserve"><value>使い方ガイド</value></data>
+  <data name="OW_Title" xml:space="preserve"><value>個人業務・契約管理</value></data>
+  <data name="OW_ExpiryState_Overdue" xml:space="preserve"><value>期限超過</value></data>
+  <data name="OW_ExpiryState_DueSoon" xml:space="preserve"><value>期限切迫</value></data>
+  <data name="OW_ExpiryState_Active" xml:space="preserve"><value>有効</value></data>
+  <data name="OW_ExpiryState_None" xml:space="preserve"><value>期限なし</value></data>
+  <data name="OW_DocumentNumber" xml:space="preserve"><value>文書番号</value></data>
+  <data name="OW_ContactName" xml:space="preserve"><value>担当・連絡先</value></data>
+  <data name="OW_OrganizationOrProject" xml:space="preserve"><value>会社 / プロジェクト</value></data>
+  <data name="OW_EffectiveDate" xml:space="preserve"><value>発効日</value></data>
+  <data name="OW_ExpiryDate" xml:space="preserve"><value>満了・期限日</value></data>
+  <data name="OW_Confidentiality" xml:space="preserve"><value>機密区分</value></data>
+  <data name="OW_Reminder" xml:space="preserve"><value>リマインダー通知を有効化</value></data>
+  <data name="OW_DaysRemaining" xml:space="preserve"><value>何日前に通知するか (日数)</value></data>
 </root>
 
 

--- a/StudyDocumentManager/Resources/Strings.resx
+++ b/StudyDocumentManager/Resources/Strings.resx
@@ -1013,6 +1013,12 @@
   <data name="OW_Confidentiality" xml:space="preserve"><value>機密区分</value></data>
   <data name="OW_Reminder" xml:space="preserve"><value>リマインダー通知を有効化</value></data>
   <data name="OW_DaysRemaining" xml:space="preserve"><value>何日前に通知するか (日数)</value></data>
+  <data name="OW_DocNoPrefix" xml:space="preserve"><value>番号: </value></data>
+  <data name="OW_Conf_Public" xml:space="preserve"><value>公開</value></data>
+  <data name="OW_Conf_Internal" xml:space="preserve"><value>社内限り</value></data>
+  <data name="OW_Conf_Confidential" xml:space="preserve"><value>機密</value></data>
+  <data name="OW_Conf_Restricted" xml:space="preserve"><value>極秘</value></data>
+  <data name="OW_Error_FileNotFound" xml:space="preserve"><value>ファイルが見つかりません: {0}</value></data>
 </root>
 
 

--- a/StudyDocumentManager/Resources/Strings.vi.resx
+++ b/StudyDocumentManager/Resources/Strings.vi.resx
@@ -1114,4 +1114,10 @@
   <data name="OW_Confidentiality" xml:space="preserve"><value>Mức độ bảo mật</value></data>
   <data name="OW_Reminder" xml:space="preserve"><value>Bật thông báo nhắc nhở</value></data>
   <data name="OW_DaysRemaining" xml:space="preserve"><value>Số ngày nhắc trước hạn (ngày)</value></data>
+  <data name="OW_DocNoPrefix" xml:space="preserve"><value>Số: </value></data>
+  <data name="OW_Conf_Public" xml:space="preserve"><value>Công khai</value></data>
+  <data name="OW_Conf_Internal" xml:space="preserve"><value>Nội bộ</value></data>
+  <data name="OW_Conf_Confidential" xml:space="preserve"><value>Bảo mật</value></data>
+  <data name="OW_Conf_Restricted" xml:space="preserve"><value>Tối mật</value></data>
+  <data name="OW_Error_FileNotFound" xml:space="preserve"><value>Không tìm thấy tệp: {0}</value></data>
 </root>

--- a/StudyDocumentManager/Resources/Strings.vi.resx
+++ b/StudyDocumentManager/Resources/Strings.vi.resx
@@ -1101,4 +1101,17 @@
   <data name="Onboarding_Skip" xml:space="preserve"><value>Bỏ qua</value></data>
   <data name="Onboarding_Finish" xml:space="preserve"><value>Bắt đầu</value></data>
   <data name="Onboarding_MenuItem" xml:space="preserve"><value>Hướng dẫn bắt đầu</value></data>
+  <data name="OW_Title" xml:space="preserve"><value>Nghiệp vụ cá nhân &amp; Hợp đồng</value></data>
+  <data name="OW_ExpiryState_Overdue" xml:space="preserve"><value>Quá hạn</value></data>
+  <data name="OW_ExpiryState_DueSoon" xml:space="preserve"><value>Sắp đến hạn</value></data>
+  <data name="OW_ExpiryState_Active" xml:space="preserve"><value>Còn hạn</value></data>
+  <data name="OW_ExpiryState_None" xml:space="preserve"><value>Không có hạn</value></data>
+  <data name="OW_DocumentNumber" xml:space="preserve"><value>Số tài liệu</value></data>
+  <data name="OW_ContactName" xml:space="preserve"><value>Người liên hệ</value></data>
+  <data name="OW_OrganizationOrProject" xml:space="preserve"><value>Công ty / Dự án</value></data>
+  <data name="OW_EffectiveDate" xml:space="preserve"><value>Ngày hiệu lực</value></data>
+  <data name="OW_ExpiryDate" xml:space="preserve"><value>Ngày hết hạn</value></data>
+  <data name="OW_Confidentiality" xml:space="preserve"><value>Mức độ bảo mật</value></data>
+  <data name="OW_Reminder" xml:space="preserve"><value>Bật thông báo nhắc nhở</value></data>
+  <data name="OW_DaysRemaining" xml:space="preserve"><value>Số ngày nhắc trước hạn (ngày)</value></data>
 </root>

--- a/StudyDocumentManager/Resources/Strings.zh.resx
+++ b/StudyDocumentManager/Resources/Strings.zh.resx
@@ -1101,4 +1101,17 @@
   <data name="Onboarding_Skip" xml:space="preserve"><value>跳过</value></data>
   <data name="Onboarding_Finish" xml:space="preserve"><value>开始使用</value></data>
   <data name="Onboarding_MenuItem" xml:space="preserve"><value>入门指南</value></data>
+  <data name="OW_Title" xml:space="preserve"><value>个人业务与合同管理</value></data>
+  <data name="OW_ExpiryState_Overdue" xml:space="preserve"><value>已逾期</value></data>
+  <data name="OW_ExpiryState_DueSoon" xml:space="preserve"><value>即将到期</value></data>
+  <data name="OW_ExpiryState_Active" xml:space="preserve"><value>有效</value></data>
+  <data name="OW_ExpiryState_None" xml:space="preserve"><value>无到期日</value></data>
+  <data name="OW_DocumentNumber" xml:space="preserve"><value>文档编号</value></data>
+  <data name="OW_ContactName" xml:space="preserve"><value>联系人</value></data>
+  <data name="OW_OrganizationOrProject" xml:space="preserve"><value>公司 / 项目</value></data>
+  <data name="OW_EffectiveDate" xml:space="preserve"><value>生效日期</value></data>
+  <data name="OW_ExpiryDate" xml:space="preserve"><value>截止/到期日期</value></data>
+  <data name="OW_Confidentiality" xml:space="preserve"><value>保密级别</value></data>
+  <data name="OW_Reminder" xml:space="preserve"><value>启用提醒通知</value></data>
+  <data name="OW_DaysRemaining" xml:space="preserve"><value>提前提醒天数 (天)</value></data>
 </root>

--- a/StudyDocumentManager/Resources/Strings.zh.resx
+++ b/StudyDocumentManager/Resources/Strings.zh.resx
@@ -1114,4 +1114,10 @@
   <data name="OW_Confidentiality" xml:space="preserve"><value>保密级别</value></data>
   <data name="OW_Reminder" xml:space="preserve"><value>启用提醒通知</value></data>
   <data name="OW_DaysRemaining" xml:space="preserve"><value>提前提醒天数 (天)</value></data>
+  <data name="OW_DocNoPrefix" xml:space="preserve"><value>编号: </value></data>
+  <data name="OW_Conf_Public" xml:space="preserve"><value>公开</value></data>
+  <data name="OW_Conf_Internal" xml:space="preserve"><value>内部</value></data>
+  <data name="OW_Conf_Confidential" xml:space="preserve"><value>机密</value></data>
+  <data name="OW_Conf_Restricted" xml:space="preserve"><value>绝密</value></data>
+  <data name="OW_Error_FileNotFound" xml:space="preserve"><value>找不到文件: {0}</value></data>
 </root>

--- a/StudyDocumentManager/Services/NavigationService.cs
+++ b/StudyDocumentManager/Services/NavigationService.cs
@@ -1,4 +1,4 @@
-﻿using StudyDocumentManager.Core.Entities;
+using StudyDocumentManager.Core.Entities;
 using StudyDocumentManager.Core.Interfaces;
 using StudyDocumentManager.Models;
 using Microsoft.Extensions.DependencyInjection;
@@ -50,6 +50,7 @@ public class NavigationService(IServiceProvider serviceProvider) : INavigationSe
             "related-docs" => CreateRelatedDocsModel(parameter),
             "smartviews" or "smart-views" or "savedsearches" => serviceProvider.GetRequiredService<SmartViewsModel>(),
             "student" or "assignments" or "student-workspace" => serviceProvider.GetRequiredService<StudentWorkspaceModel>(),
+            "office" or "officeworkspace" or "office-workspace" or "reminders" => serviceProvider.GetRequiredService<OfficeWorkspaceModel>(),
             "run-smartview" => CreateDashboardWithSavedSearch(parameter),
             _ => serviceProvider.GetRequiredService<DashboardModel>(),
         };

--- a/StudyDocumentManager/Views/MainWindow.axaml
+++ b/StudyDocumentManager/Views/MainWindow.axaml
@@ -89,6 +89,7 @@
                         <MenuItem Header="{loc:Localize Menu_Collections}" Command="{Binding NavigateCommand}" CommandParameter="collections"/>
                         <MenuItem Header="{loc:Localize Menu_SmartViews}" Command="{Binding NavigateCommand}" CommandParameter="smartviews"/>
                         <MenuItem Header="{loc:Localize SW_Title}" Command="{Binding NavigateCommand}" CommandParameter="student-workspace"/>
+                        <MenuItem Header="{loc:Localize OW_Title}" Command="{Binding NavigateCommand}" CommandParameter="office-workspace" AutomationProperties.AutomationId="Menu_OfficeWorkspace"/>
                     </MenuItem>
                     <MenuItem Header="{loc:Localize Menu_Import}"
                               AutomationProperties.AutomationId="Menu_Import">
@@ -309,6 +310,9 @@
                 </DataTemplate>
                 <DataTemplate DataType="{x:Type vm:StudentWorkspaceModel}">
                     <v:StudentWorkspace />
+                </DataTemplate>
+                <DataTemplate DataType="{x:Type vm:OfficeWorkspaceModel}">
+                    <v:OfficeWorkspace />
                 </DataTemplate>
                 <DataTemplate DataType="{x:Type vm:RecoveryCenterModel}">
                     <v:RecoveryCenterView />

--- a/StudyDocumentManager/Views/OfficeWorkspace.axaml
+++ b/StudyDocumentManager/Views/OfficeWorkspace.axaml
@@ -1,0 +1,211 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:StudyDocumentManager.Models"
+             xmlns:loc="using:StudyDocumentManager.Markup"
+             xmlns:automation="using:Avalonia.Automation"
+             x:Class="StudyDocumentManager.Views.OfficeWorkspace"
+             x:DataType="vm:OfficeWorkspaceModel"
+             automation:AutomationProperties.AutomationId="Screen_OfficeWorkspace">
+    <Border Background="{StaticResource ContentBackground}" Padding="{StaticResource PaddingPage}">
+        <DockPanel>
+            <!-- ═══ HEADER & OVERVIEW CARDS ═══ -->
+            <StackPanel DockPanel.Dock="Top" Spacing="10" Margin="0,0,0,12">
+                <DockPanel>
+                    <Button DockPanel.Dock="Left" Classes="secondary" Command="{Binding GoBackCommand}"
+                            Margin="0,0,12,0" Padding="8,4"
+                            automation:AutomationProperties.AutomationId="OfficeWorkspace_Back"
+                            automation:AutomationProperties.Name="{loc:Localize Action_Back}">
+                        <StackPanel Orientation="Horizontal" Spacing="4">
+                            <TextBlock Text="←" VerticalAlignment="Center"/>
+                            <TextBlock Text="{loc:Localize Action_Back}" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </Button>
+                    <TextBlock Text="{loc:Localize OW_Title}" FontSize="{StaticResource FontSizeXl}" FontWeight="Bold" VerticalAlignment="Center"/>
+                </DockPanel>
+
+                <!-- Status Cards -->
+                <Grid ColumnDefinitions="*,*,*,*,*" Margin="0,4,0,0">
+                    <Border Grid.Column="0" Background="{StaticResource CardBackground}" BorderBrush="{StaticResource CardBorder}" BorderThickness="1" CornerRadius="{StaticResource RadiusSm}" Padding="10,8" Margin="0,0,4,0">
+                        <StackPanel>
+                            <TextBlock Text="{loc:Localize Common_All}" FontSize="{StaticResource FontSizeXs}" Foreground="{StaticResource TextSecondary}"/>
+                            <TextBlock Text="{Binding TotalCount}" FontSize="{StaticResource FontSizeLg}" FontWeight="Bold" Foreground="{StaticResource TextPrimary}"/>
+                        </StackPanel>
+                    </Border>
+                    <Border Grid.Column="1" Background="{StaticResource CardBackground}" BorderBrush="{StaticResource DangerBorder}" BorderThickness="1" CornerRadius="{StaticResource RadiusSm}" Padding="10,8" Margin="4,0,4,0">
+                        <StackPanel>
+                            <TextBlock Text="{loc:Localize OW_ExpiryState_Overdue}" FontSize="{StaticResource FontSizeXs}" Foreground="{StaticResource DangerText}"/>
+                            <TextBlock Text="{Binding OverdueCount}" FontSize="{StaticResource FontSizeLg}" FontWeight="Bold" Foreground="{StaticResource DangerText}"/>
+                        </StackPanel>
+                    </Border>
+                    <Border Grid.Column="2" Background="{StaticResource CardBackground}" BorderBrush="{StaticResource WarningBorder}" BorderThickness="1" CornerRadius="{StaticResource RadiusSm}" Padding="10,8" Margin="4,0,4,0">
+                        <StackPanel>
+                            <TextBlock Text="{loc:Localize OW_ExpiryState_DueSoon}" FontSize="{StaticResource FontSizeXs}" Foreground="{StaticResource WarningText}"/>
+                            <TextBlock Text="{Binding DueSoonCount}" FontSize="{StaticResource FontSizeLg}" FontWeight="Bold" Foreground="{StaticResource WarningText}"/>
+                        </StackPanel>
+                    </Border>
+                    <Border Grid.Column="3" Background="{StaticResource CardBackground}" BorderBrush="{StaticResource SuccessBorder}" BorderThickness="1" CornerRadius="{StaticResource RadiusSm}" Padding="10,8" Margin="4,0,4,0">
+                        <StackPanel>
+                            <TextBlock Text="{loc:Localize OW_ExpiryState_Active}" FontSize="{StaticResource FontSizeXs}" Foreground="{StaticResource SuccessText}"/>
+                            <TextBlock Text="{Binding ActiveCount}" FontSize="{StaticResource FontSizeLg}" FontWeight="Bold" Foreground="{StaticResource SuccessText}"/>
+                        </StackPanel>
+                    </Border>
+                    <Border Grid.Column="4" Background="{StaticResource CardBackground}" BorderBrush="{StaticResource CardBorder}" BorderThickness="1" CornerRadius="{StaticResource RadiusSm}" Padding="10,8" Margin="4,0,0,0">
+                        <StackPanel>
+                            <TextBlock Text="{loc:Localize OW_ExpiryState_None}" FontSize="{StaticResource FontSizeXs}" Foreground="{StaticResource TextMuted}"/>
+                            <TextBlock Text="{Binding NoExpiryCount}" FontSize="{StaticResource FontSizeLg}" FontWeight="Bold" Foreground="{StaticResource TextSecondary}"/>
+                        </StackPanel>
+                    </Border>
+                </Grid>
+
+                <!-- Filter & Search Bar -->
+                <Grid ColumnDefinitions="2*,*,*,Auto" Margin="0,4,0,0">
+                    <TextBox Grid.Column="0" Text="{Binding SearchText, Mode=TwoWay}"
+                             Watermark="{loc:Localize Search_Watermark}"
+                             automation:AutomationProperties.AutomationId="OfficeWorkspace_Search"
+                             Margin="0,0,8,0"/>
+                    <ComboBox Grid.Column="1" ItemsSource="{Binding ExpiryFilterOptions}"
+                              SelectedItem="{Binding SelectedExpiryFilter, Mode=TwoWay}"
+                              HorizontalAlignment="Stretch" Margin="0,0,8,0"
+                              automation:AutomationProperties.AutomationId="OfficeWorkspace_ExpiryFilter">
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding Label}"/>
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
+                    </ComboBox>
+                    <ComboBox Grid.Column="2" ItemsSource="{Binding ConfidentialityFilterOptions}"
+                              SelectedItem="{Binding SelectedConfidentialityFilter, Mode=TwoWay}"
+                              HorizontalAlignment="Stretch" Margin="0,0,8,0"
+                              automation:AutomationProperties.AutomationId="OfficeWorkspace_ConfidentialityFilter">
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding Label}"/>
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
+                    </ComboBox>
+                    <Button Grid.Column="3" Content="{loc:Localize Action_Refresh}" Command="{Binding RefreshCommand}"
+                            automation:AutomationProperties.AutomationId="OfficeWorkspace_Refresh"/>
+                </Grid>
+            </StackPanel>
+
+            <!-- ═══ MAIN WORKSPACE SPLIT ═══ -->
+            <Grid ColumnDefinitions="3*,2*">
+                <!-- Document List (Left) -->
+                <Border Grid.Column="0" Background="{StaticResource CardBackground}" BorderBrush="{StaticResource CardBorder}" BorderThickness="1" CornerRadius="{StaticResource RadiusMd}" Padding="8" Margin="0,0,8,0">
+                    <ListBox ItemsSource="{Binding FilteredRows}" SelectedItem="{Binding SelectedRow, Mode=TwoWay}"
+                             automation:AutomationProperties.AutomationId="OfficeWorkspace_DocumentList"
+                             Background="Transparent">
+                        <ListBox.ItemTemplate>
+                            <DataTemplate x:DataType="vm:OfficeDocumentRow">
+                                <Border Padding="8,6" BorderBrush="{StaticResource CardBorder}" BorderThickness="0,0,0,1">
+                                    <Grid ColumnDefinitions="*,Auto" RowDefinitions="Auto,Auto">
+                                        <TextBlock Grid.Row="0" Grid.Column="0" Text="{Binding Name}" FontWeight="SemiBold" TextTrimming="CharacterEllipsis"/>
+                                        <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding ExpiryStateLabel}" FontWeight="Bold" FontSize="{StaticResource FontSizeXs}"/>
+                                        
+                                        <StackPanel Grid.Row="1" Grid.Column="0" Orientation="Horizontal" Spacing="8" Margin="0,4,0,0">
+                                            <TextBlock Text="{Binding DocumentNumber, StringFormat='No: {0}'}" FontSize="{StaticResource FontSizeXs}" Foreground="{StaticResource TextSecondary}"
+                                                       IsVisible="{Binding DocumentNumber, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
+                                            <TextBlock Text="{Binding OrganizationOrProject}" FontSize="{StaticResource FontSizeXs}" Foreground="{StaticResource TextSecondary}"
+                                                       IsVisible="{Binding OrganizationOrProject, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
+                                            <TextBlock Text="{Binding ConfidentialityLabel, StringFormat='[{0}]'}" FontSize="{StaticResource FontSizeXs}" Foreground="{StaticResource Accent}"/>
+                                        </StackPanel>
+
+                                        <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding ExpiryDate, StringFormat='{}{0:yyyy-MM-dd}'}"
+                                                   FontSize="{StaticResource FontSizeXs}" Foreground="{StaticResource TextMuted}" VerticalAlignment="Center"/>
+                                    </Grid>
+                                </Border>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
+                </Border>
+
+                <!-- Metadata Editor Panel (Right) -->
+                <Border Grid.Column="1" Background="{StaticResource CardBackground}" BorderBrush="{StaticResource CardBorder}" BorderThickness="1" CornerRadius="{StaticResource RadiusMd}" Padding="16">
+                    <ScrollViewer VerticalScrollBarVisibility="Auto">
+                        <StackPanel Spacing="12">
+                            <TextBlock Text="{loc:Localize Details_Title}" FontSize="{StaticResource FontSizeLg}" FontWeight="Bold"/>
+
+                            <!-- Document Number -->
+                            <StackPanel Spacing="4">
+                                <TextBlock Text="{loc:Localize OW_DocumentNumber}" FontSize="{StaticResource FontSizeSm}" Foreground="{StaticResource TextSecondary}"/>
+                                <TextBox Text="{Binding EditingDocumentNumber, Mode=TwoWay}"
+                                         IsEnabled="{Binding HasSelection}"
+                                         automation:AutomationProperties.AutomationId="OfficeWorkspace_DocNumber"/>
+                            </StackPanel>
+
+                            <!-- Organization / Project -->
+                            <StackPanel Spacing="4">
+                                <TextBlock Text="{loc:Localize OW_OrganizationOrProject}" FontSize="{StaticResource FontSizeSm}" Foreground="{StaticResource TextSecondary}"/>
+                                <TextBox Text="{Binding EditingOrganizationOrProject, Mode=TwoWay}"
+                                         IsEnabled="{Binding HasSelection}"
+                                         automation:AutomationProperties.AutomationId="OfficeWorkspace_Org"/>
+                            </StackPanel>
+
+                            <!-- Contact Name -->
+                            <StackPanel Spacing="4">
+                                <TextBlock Text="{loc:Localize OW_ContactName}" FontSize="{StaticResource FontSizeSm}" Foreground="{StaticResource TextSecondary}"/>
+                                <TextBox Text="{Binding EditingContactName, Mode=TwoWay}"
+                                         IsEnabled="{Binding HasSelection}"
+                                         automation:AutomationProperties.AutomationId="OfficeWorkspace_Contact"/>
+                            </StackPanel>
+
+                            <!-- Dates -->
+                            <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto">
+                                <TextBlock Grid.Row="0" Grid.Column="0" Text="{loc:Localize OW_EffectiveDate}" FontSize="{StaticResource FontSizeSm}" Foreground="{StaticResource TextSecondary}" Margin="0,0,4,4"/>
+                                <DatePicker Grid.Row="1" Grid.Column="0" SelectedDate="{Binding EditingEffectiveDate, Mode=TwoWay}"
+                                            IsEnabled="{Binding HasSelection}" Margin="0,0,4,0"
+                                            automation:AutomationProperties.AutomationId="OfficeWorkspace_EffectiveDate"/>
+
+                                <TextBlock Grid.Row="0" Grid.Column="1" Text="{loc:Localize OW_ExpiryDate}" FontSize="{StaticResource FontSizeSm}" Foreground="{StaticResource TextSecondary}" Margin="4,0,0,4"/>
+                                <DatePicker Grid.Row="1" Grid.Column="1" SelectedDate="{Binding EditingExpiryDate, Mode=TwoWay}"
+                                            IsEnabled="{Binding HasSelection}" Margin="4,0,0,0"
+                                            automation:AutomationProperties.AutomationId="OfficeWorkspace_ExpiryDate"/>
+                            </Grid>
+
+                            <!-- Confidentiality Level -->
+                            <StackPanel Spacing="4">
+                                <TextBlock Text="{loc:Localize OW_Confidentiality}" FontSize="{StaticResource FontSizeSm}" Foreground="{StaticResource TextSecondary}"/>
+                                <ComboBox ItemsSource="{Binding ConfidentialityLevels}"
+                                          SelectedItem="{Binding EditingConfidentialityLevel, Mode=TwoWay}"
+                                          IsEnabled="{Binding HasSelection}"
+                                          HorizontalAlignment="Stretch"
+                                          automation:AutomationProperties.AutomationId="OfficeWorkspace_Confidentiality"/>
+                            </StackPanel>
+
+                            <!-- Reminder Configuration -->
+                            <Border Background="{StaticResource SidebarBackground}" CornerRadius="{StaticResource RadiusSm}" Padding="10,8" Margin="0,4,0,0">
+                                <StackPanel Spacing="8">
+                                    <CheckBox Content="{loc:Localize OW_Reminder}" IsChecked="{Binding EditingReminderEnabled, Mode=TwoWay}"
+                                              IsEnabled="{Binding HasSelection}"
+                                              automation:AutomationProperties.AutomationId="OfficeWorkspace_ReminderEnabled"/>
+                                    <DockPanel IsEnabled="{Binding EditingReminderEnabled}">
+                                        <TextBlock Text="{loc:Localize OW_DaysRemaining}" VerticalAlignment="Center" FontSize="{StaticResource FontSizeXs}" Foreground="{StaticResource TextSecondary}"/>
+                                        <NumericUpDown Value="{Binding EditingReminderDaysBefore, Mode=TwoWay}" Minimum="1" Maximum="365"
+                                                       HorizontalAlignment="Right" Width="100"
+                                                       IsEnabled="{Binding HasSelection}"
+                                                       automation:AutomationProperties.AutomationId="OfficeWorkspace_ReminderDays"/>
+                                    </DockPanel>
+                                </StackPanel>
+                            </Border>
+
+                            <!-- Action Buttons -->
+                            <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,8,0,0">
+                                <Button Content="{loc:Localize Action_Save}" Command="{Binding SaveMetadataCommand}"
+                                        Classes="accent" IsEnabled="{Binding HasSelection}"
+                                        automation:AutomationProperties.AutomationId="OfficeWorkspace_Save"/>
+                                <Button Content="{loc:Localize Toolbar_OpenFile}" Command="{Binding OpenFileCommand}"
+                                        Classes="secondary" IsEnabled="{Binding HasSelection}"
+                                        automation:AutomationProperties.AutomationId="OfficeWorkspace_OpenFile"/>
+                            </StackPanel>
+
+                            <!-- Status text -->
+                            <TextBlock Text="{Binding StatusText}" Foreground="{StaticResource SuccessText}"
+                                       FontSize="{StaticResource FontSizeSm}" Margin="0,4,0,0"
+                                       automation:AutomationProperties.LiveSetting="Polite"/>
+                        </StackPanel>
+                    </ScrollViewer>
+                </Border>
+            </Grid>
+        </DockPanel>
+    </Border>
+</UserControl>

--- a/StudyDocumentManager/Views/OfficeWorkspace.axaml
+++ b/StudyDocumentManager/Views/OfficeWorkspace.axaml
@@ -103,8 +103,13 @@
                                         <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding ExpiryStateLabel}" FontWeight="Bold" FontSize="{StaticResource FontSizeXs}"/>
                                         
                                         <StackPanel Grid.Row="1" Grid.Column="0" Orientation="Horizontal" Spacing="8" Margin="0,4,0,0">
-                                            <TextBlock Text="{Binding DocumentNumber, StringFormat='No: {0}'}" FontSize="{StaticResource FontSizeXs}" Foreground="{StaticResource TextSecondary}"
-                                                       IsVisible="{Binding DocumentNumber, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
+                                            <TextBlock Text="{Binding StatusLabel}" FontSize="{StaticResource FontSizeXs}" Foreground="{StaticResource TextSecondary}"
+                                                       IsVisible="{Binding StatusLabel, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
+                                            <StackPanel Orientation="Horizontal" Spacing="2"
+                                                        IsVisible="{Binding DocumentNumber, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+                                                <TextBlock Text="{loc:Localize OW_DocNoPrefix}" FontSize="{StaticResource FontSizeXs}" Foreground="{StaticResource TextSecondary}"/>
+                                                <TextBlock Text="{Binding DocumentNumber}" FontSize="{StaticResource FontSizeXs}" Foreground="{StaticResource TextSecondary}"/>
+                                            </StackPanel>
                                             <TextBlock Text="{Binding OrganizationOrProject}" FontSize="{StaticResource FontSizeXs}" Foreground="{StaticResource TextSecondary}"
                                                        IsVisible="{Binding OrganizationOrProject, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
                                             <TextBlock Text="{Binding ConfidentialityLabel, StringFormat='[{0}]'}" FontSize="{StaticResource FontSizeXs}" Foreground="{StaticResource Accent}"/>

--- a/StudyDocumentManager/Views/OfficeWorkspace.axaml.cs
+++ b/StudyDocumentManager/Views/OfficeWorkspace.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace StudyDocumentManager.Views;
+
+public partial class OfficeWorkspace : UserControl
+{
+    public OfficeWorkspace()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
## 概要 (Summary)
個人業務向け文書（invoice、contract、report、receipt、form など）を対象に、業務状態や期限、連絡先、会社/プロジェクト、発効日・満了日、文書番号、機密区分ラベルなどの拡張メタデータと、期限切迫（due soon）・期限超過（overdue）リマインダー通知機能を実装しました。

## 受け入れ条件 (Acceptance Criteria)
- [x] document status、contact、company/project、effective date、expiry date、document number、personal confidentiality label を扱える。
- [x] due soon、overdue、期限なしを確認できる。
- [x] reminder の有効化、時期、対象を設定できる。
- [x] 学生向け assignment と競合せず、共通の期限・status 表示と連携する。
- [x] 全対応言語で安全な user-facing message を表示する。

## 実装計画 (Implementation)
- [x] office-personal metadata の optional field 契約を定義する (commit 9a3ed14)
- [x] expiry、reminder、due-soon view を実装する (commit f917329)
- [x] metadata、status、期限の UI と filter を実装する (commit 6fc6aec)
- [x] reminder、timezone、empty/error state のテストを追加する (commit 3729622)

## 検証証跡 (Verification Evidence)
- 単体テスト: OfficeMetadataTests (7/7 PASS)
- 互換性テスト: BackupValidator_AcceptsSchemaVersion4Candidate (PASS)
- ビルド: dotnet build (0 Warning, 0 Error)

## テスト計画 (Test Plan)
- メタデータ契約・DB永続化の単体テスト
- due soon / overdue 判定およびリマインダー計算のテスト
- UI フィルターおよび国際化表示の検証

## References
Closes #48

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds persistent office-document metadata, expiry/reminder classification, localized filtering and editing UI, navigation wiring, database validation, and tests. Three integration and lifecycle gaps remain:
- Personal archive export/import does not preserve the new metadata.
- Reminder calculations are not connected to a production notification path.
- An open workspace continues classifying deadlines against its construction date after midnight.
</details>


<details open><summary><h3>Confidence Score: 2/5</h3></summary>

The PR should not merge until office metadata survives archive transfer, configured reminders reach users, and refreshed expiry status uses the current date.

Personal archive imports silently drop the new metadata, the reminder query is unreachable from production notification code, and a workspace left open overnight presents stale deadline classifications.

**Files Needing Attention:** StudyDocumentManager.Data/Helpers/DatabaseMigrator.cs, StudyDocumentManager.Data/Repositories/OfficeMetadataRepository.cs, StudyDocumentManager/Models/OfficeWorkspaceModel.cs
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| StudyDocumentManager.Data/Repositories/OfficeMetadataRepository.cs | Adds metadata CRUD and expiry classification, but its reminder query has no production consumer. |
| StudyDocumentManager.Data/Helpers/DatabaseMigrator.cs | Creates and validates the office metadata schema, but the new persisted records are not integrated with personal archive transfer. |
| StudyDocumentManager/Models/OfficeWorkspaceModel.cs | Implements editing, filtering, and expiry metrics, but expiry state becomes stale when the view remains open across midnight. |
| StudyDocumentManager/Views/OfficeWorkspace.axaml | Adds the localized office workspace list, filters, status cards, and metadata editor without an independently identified view-layer defect. |
| StudyDocumentManager.Tests/OfficeMetadataTests.cs | Covers CRUD, classification, localization, and full-database backup validation, but not personal archive round-tripping or production notification delivery. |
| StudyDocumentManager.Data/Helpers/DatabaseHelper.cs | Extends full-database backup validation for office metadata; full backup/restore preserves the table correctly. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    D[Document] --> M[office_document_metadata]
    M --> W[Office workspace]
    M --> Q[GetUpcomingReminders]
    Q -. no production consumer .-> N[Notification UI]
    D --> A[Personal archive export]
    A --> I[Personal archive import]
    M -. omitted .-> A
    I -. no metadata insert .-> M
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `StudyDocumentManager.Data/Helpers/DatabaseMigrator.cs`, line 180-195 ([link](https://github.com/hayato-shino05/document-manager/blob/9c1746de6e80e6968de596bb5b78fb8b0349a550/StudyDocumentManager.Data/Helpers/DatabaseMigrator.cs#L180-L195)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Archive Drops Office Metadata**

   When a document with office metadata is exported and imported through the personal archive workflow, the manifest and import graph omit `office_document_metadata`, causing the imported document to lose its document number, contact, organization, dates, confidentiality label, and reminder settings.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: StudyDocumentManager.Data/Helpers/DatabaseMigrator.cs
   Line: 180-195

   Comment:
   **Archive Drops Office Metadata**

   When a document with office metadata is exported and imported through the personal archive workflow, the manifest and import graph omit `office_document_metadata`, causing the imported document to lose its document number, contact, organization, dates, confidentiality label, and reminder settings.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
StudyDocumentManager.Data/Helpers/DatabaseMigrator.cs:180-195
**Archive Drops Office Metadata**

When a document with office metadata is exported and imported through the personal archive workflow, the manifest and import graph omit `office_document_metadata`, causing the imported document to lose its document number, contact, organization, dates, confidentiality label, and reminder settings.

### Issue 2
StudyDocumentManager.Data/Repositories/OfficeMetadataRepository.cs:86
**Reminder Query Has No Consumer**

When a configured document becomes due soon or overdue, no production path calls `GetUpcomingReminders` or forwards its results to the notification service, causing users to receive no reminder unless they manually open the workspace.

### Issue 3
StudyDocumentManager/Models/OfficeWorkspaceModel.cs:108
**Expiry Date Becomes Stale**

When the office workspace remains open across local midnight, `Refresh` and metadata saves continue calculating against the date captured by the constructor, causing counts, labels, and due-soon or overdue filters to remain one day stale until the workspace is reopened.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(metadata): コードレビュー指摘に基づきリマインダー判定・スキー..."](https://github.com/hayato-shino05/document-manager/commit/9c1746de6e80e6968de596bb5b78fb8b0349a550) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59497103)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->