### PR TITLE
デスクトップの未定義カラートークンを補完しグローバルショートカットを有効化する

### DIFF
--- a/StudyDocumentManager.Tests/DesktopQualityBatch1Tests.cs
+++ b/StudyDocumentManager.Tests/DesktopQualityBatch1Tests.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.IO;
+using Xunit;
+
+namespace StudyDocumentManager.Tests;
+
+public class DesktopQualityBatch1Tests
+{
+    [Fact]
+    public void ColorTokens_DefinesAllSemanticBrushesReferencedByOfficeWorkspace()
+    {
+        var colorTokens = File.ReadAllText(
+            GetSourceFilePath("StudyDocumentManager", "Themes", "ColorTokens.axaml"));
+
+        Assert.Contains("x:Key=\"DangerText\"", colorTokens);
+        Assert.Contains("x:Key=\"DangerBorder\"", colorTokens);
+        Assert.Contains("x:Key=\"WarningText\"", colorTokens);
+        Assert.Contains("x:Key=\"WarningBorder\"", colorTokens);
+        Assert.Contains("x:Key=\"SuccessText\"", colorTokens);
+        Assert.Contains("x:Key=\"SuccessBorder\"", colorTokens);
+        Assert.Contains("x:Key=\"Accent\"", colorTokens);
+    }
+
+    [Fact]
+    public void MainWindow_MenuFile_HasHotKeysMatchingInputGestures()
+    {
+        var mainWindow = File.ReadAllText(
+            GetSourceFilePath("StudyDocumentManager", "Views", "MainWindow.axaml"));
+
+        Assert.Contains("InputGesture=\"Ctrl+N\" HotKey=\"Ctrl+N\"", mainWindow);
+        Assert.Contains("InputGesture=\"Ctrl+O\" HotKey=\"Ctrl+O\"", mainWindow);
+        Assert.Contains("InputGesture=\"Ctrl+U\" HotKey=\"Ctrl+U\"", mainWindow);
+        Assert.Contains("InputGesture=\"Delete\" HotKey=\"Delete\"", mainWindow);
+        Assert.Contains("InputGesture=\"Ctrl+E\" HotKey=\"Ctrl+E\"", mainWindow);
+        Assert.Contains("InputGesture=\"Ctrl+Shift+I\" HotKey=\"Ctrl+Shift+I\"", mainWindow);
+        Assert.Contains("InputGesture=\"F5\" HotKey=\"F5\"", mainWindow);
+        Assert.Contains("InputGesture=\"Ctrl+M\" HotKey=\"Ctrl+M\"", mainWindow);
+    }
+
+    [Fact]
+    public void OnboardingDialog_SkipButton_HasIsCancel()
+    {
+        var onboarding = File.ReadAllText(
+            GetSourceFilePath("StudyDocumentManager", "Views", "OnboardingDialog.axaml"));
+
+        Assert.Contains("Name=\"SkipButton\"", onboarding);
+        Assert.Contains("IsCancel=\"True\"", onboarding);
+    }
+
+    private static string GetSourceFilePath(params string[] pathSegments)
+    {
+        for (var directory = new DirectoryInfo(AppContext.BaseDirectory);
+             directory is not null;
+             directory = directory.Parent)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "StudyDocumentManager.sln")))
+                return Path.Combine(directory.FullName, Path.Combine(pathSegments));
+        }
+
+        throw new DirectoryNotFoundException("Could not locate the solution root.");
+    }
+}

--- a/StudyDocumentManager/Themes/ColorTokens.axaml
+++ b/StudyDocumentManager/Themes/ColorTokens.axaml
@@ -82,11 +82,8 @@
         <SolidColorBrush x:Key="WarningBrush"        Color="{StaticResource StatusAmber}"/>
         <SolidColorBrush x:Key="DangerBrush"         Color="{StaticResource StatusRed}"/>
         <SolidColorBrush x:Key="DangerText"          Color="{StaticResource StatusRed}"/>
-        <SolidColorBrush x:Key="DangerBorder"        Color="{StaticResource ColorDanger}"/>
         <SolidColorBrush x:Key="WarningText"         Color="{StaticResource StatusAmber}"/>
-        <SolidColorBrush x:Key="WarningBorder"       Color="{StaticResource ColorWarningBtn}"/>
         <SolidColorBrush x:Key="SuccessText"         Color="{StaticResource StatusGreen}"/>
-        <SolidColorBrush x:Key="SuccessBorder"       Color="{StaticResource ColorSuccess}"/>
         <SolidColorBrush x:Key="Accent"              Color="{StaticResource AccentBlue}"/>
         <SolidColorBrush x:Key="OnColorPrimaryBrush"  Color="{StaticResource OnColorPrimary}"/>
         <SolidColorBrush x:Key="OnColorSecondaryBrush" Color="{StaticResource OnColorSecondary}"/>
@@ -132,6 +129,9 @@
         <SolidColorBrush x:Key="WarningColorHover"   Color="{StaticResource ColorWarningHover}"/>
         <SolidColorBrush x:Key="SuccessColor"        Color="{StaticResource ColorSuccess}"/>
         <SolidColorBrush x:Key="SuccessColorHover"   Color="{StaticResource ColorSuccessHover}"/>
+        <SolidColorBrush x:Key="DangerBorder"        Color="{StaticResource ColorDanger}"/>
+        <SolidColorBrush x:Key="WarningBorder"       Color="{StaticResource ColorWarningBtn}"/>
+        <SolidColorBrush x:Key="SuccessBorder"       Color="{StaticResource ColorSuccess}"/>
 
         <SolidColorBrush x:Key="ChipBgBrush"           Color="{StaticResource ChipBg}"/>
         <SolidColorBrush x:Key="ChipFgBrush"           Color="{StaticResource ChipFg}"/>

--- a/StudyDocumentManager/Themes/ColorTokens.axaml
+++ b/StudyDocumentManager/Themes/ColorTokens.axaml
@@ -81,6 +81,13 @@
         <SolidColorBrush x:Key="SuccessBrush"        Color="{StaticResource StatusGreen}"/>
         <SolidColorBrush x:Key="WarningBrush"        Color="{StaticResource StatusAmber}"/>
         <SolidColorBrush x:Key="DangerBrush"         Color="{StaticResource StatusRed}"/>
+        <SolidColorBrush x:Key="DangerText"          Color="{StaticResource StatusRed}"/>
+        <SolidColorBrush x:Key="DangerBorder"        Color="{StaticResource ColorDanger}"/>
+        <SolidColorBrush x:Key="WarningText"         Color="{StaticResource StatusAmber}"/>
+        <SolidColorBrush x:Key="WarningBorder"       Color="{StaticResource ColorWarningBtn}"/>
+        <SolidColorBrush x:Key="SuccessText"         Color="{StaticResource StatusGreen}"/>
+        <SolidColorBrush x:Key="SuccessBorder"       Color="{StaticResource ColorSuccess}"/>
+        <SolidColorBrush x:Key="Accent"              Color="{StaticResource AccentBlue}"/>
         <SolidColorBrush x:Key="OnColorPrimaryBrush"  Color="{StaticResource OnColorPrimary}"/>
         <SolidColorBrush x:Key="OnColorSecondaryBrush" Color="{StaticResource OnColorSecondary}"/>
 

--- a/StudyDocumentManager/Views/MainWindow.axaml
+++ b/StudyDocumentManager/Views/MainWindow.axaml
@@ -68,15 +68,15 @@
                 <Menu Background="Transparent" Padding="4,0">
                     <MenuItem Header="{loc:Localize Menu_File}"
                               AutomationProperties.AutomationId="Menu_File">
-                        <MenuItem Header="{loc:Localize Menu_AddNewDocument}" Command="{Binding NavigateCommand}" CommandParameter="add" InputGesture="Ctrl+N"/>
-                        <MenuItem Header="{loc:Localize Menu_OpenDocument}" Command="{Binding OpenFileCommand}" InputGesture="Ctrl+O"/>
-                        <MenuItem Header="{loc:Localize Menu_EditDocument}" Command="{Binding EditDocumentCommand}" InputGesture="Ctrl+U"/>
-                        <MenuItem Header="{loc:Localize Menu_DeleteDocument}" Command="{Binding DeleteDocumentCommand}" InputGesture="Delete"/>
+                        <MenuItem Header="{loc:Localize Menu_AddNewDocument}" Command="{Binding NavigateCommand}" CommandParameter="add" InputGesture="Ctrl+N" HotKey="Ctrl+N"/>
+                        <MenuItem Header="{loc:Localize Menu_OpenDocument}" Command="{Binding OpenFileCommand}" InputGesture="Ctrl+O" HotKey="Ctrl+O"/>
+                        <MenuItem Header="{loc:Localize Menu_EditDocument}" Command="{Binding EditDocumentCommand}" InputGesture="Ctrl+U" HotKey="Ctrl+U"/>
+                        <MenuItem Header="{loc:Localize Menu_DeleteDocument}" Command="{Binding DeleteDocumentCommand}" InputGesture="Delete" HotKey="Delete"/>
                         <Separator/>
-                        <MenuItem Header="{loc:Localize Menu_ExportCsv}" Command="{Binding ExportCsvCommand}" InputGesture="Ctrl+E"/>
+                        <MenuItem Header="{loc:Localize Menu_ExportCsv}" Command="{Binding ExportCsvCommand}" InputGesture="Ctrl+E" HotKey="Ctrl+E"/>
                         <MenuItem Header="{loc:Localize Menu_ExportArchive}" Command="{Binding ExportArchiveCommand}" AutomationProperties.AutomationId="Menu_ExportArchive"/>
-                        <MenuItem Header="{loc:Localize Menu_ImportArchive}" Command="{Binding ImportArchiveCommand}" AutomationProperties.AutomationId="Menu_ImportArchive" InputGesture="Ctrl+Shift+I"/>
-                        <MenuItem Header="{loc:Localize Menu_RefreshList}" Command="{Binding RefreshCommand}" InputGesture="F5"/>
+                        <MenuItem Header="{loc:Localize Menu_ImportArchive}" Command="{Binding ImportArchiveCommand}" AutomationProperties.AutomationId="Menu_ImportArchive" InputGesture="Ctrl+Shift+I" HotKey="Ctrl+Shift+I"/>
+                        <MenuItem Header="{loc:Localize Menu_RefreshList}" Command="{Binding RefreshCommand}" InputGesture="F5" HotKey="F5"/>
                         <MenuItem Header="{loc:Localize RecentFiles_Title}" Command="{Binding NavigateCommand}" CommandParameter="recentfiles"/>
                         <MenuItem Header="{loc:Localize Menu_BackupDb}" Command="{Binding BackupDatabaseCommand}"/>
                         <MenuItem Header="{loc:Localize Menu_RestoreDb}" Command="{Binding RestoreDatabaseCommand}"/>
@@ -85,7 +85,7 @@
                     </MenuItem>
                     <MenuItem Header="{loc:Localize Menu_Organize}"
                               AutomationProperties.AutomationId="Menu_Organize">
-                        <MenuItem Header="{loc:Localize Menu_ManageCategories}" Command="{Binding NavigateCommand}" CommandParameter="categories" InputGesture="Ctrl+M"/>
+                        <MenuItem Header="{loc:Localize Menu_ManageCategories}" Command="{Binding NavigateCommand}" CommandParameter="categories" InputGesture="Ctrl+M" HotKey="Ctrl+M"/>
                         <MenuItem Header="{loc:Localize Menu_Collections}" Command="{Binding NavigateCommand}" CommandParameter="collections"/>
                         <MenuItem Header="{loc:Localize Menu_SmartViews}" Command="{Binding NavigateCommand}" CommandParameter="smartviews"/>
                         <MenuItem Header="{loc:Localize SW_Title}" Command="{Binding NavigateCommand}" CommandParameter="student-workspace"/>

--- a/StudyDocumentManager/Views/OnboardingDialog.axaml
+++ b/StudyDocumentManager/Views/OnboardingDialog.axaml
@@ -40,6 +40,7 @@
                     Content="{loc:Localize Onboarding_Skip}"
                     AutomationProperties.AutomationId="Onboarding_Skip"
                     Classes="secondary"
+                    IsCancel="True"
                     Command="{Binding SkipCommand}" />
             <Button Name="FinishButton"
                     Content="{loc:Localize Onboarding_Finish}"


### PR DESCRIPTION
## 概要
デスクトップ品質・アクセシビリティ監査（Issue #60）の Batch 1 として、未定義カラートークンによるランタイム例外リスクの解消、およびメニューのグローバル HotKey 有効化を実施します。

## 変更点
1. `StudyDocumentManager/Themes/ColorTokens.axaml`:
   - `OfficeWorkspace.axaml` 等で参照されていた SolidColorBrush トークン 7 件（`DangerText`, `DangerBorder`, `WarningText`, `WarningBorder`, `SuccessText`, `SuccessBorder`, `Accent`）を定義し、XAML パース時のランタイムクラッシュを防止
   - 前方参照を避けるため、`ColorDanger`, `ColorWarningBtn`, `ColorSuccess` の定義直後に各 Border ブラシを配置し、静的リソース解決順序を適正化
2. `StudyDocumentManager/Views/MainWindow.axaml`:
   - メインメニューの各項目に `HotKey`（`Ctrl+N`, `Ctrl+O`, `Ctrl+U`, `Delete`, `Ctrl+E`, `Ctrl+Shift+I`, `F5`, `Ctrl+M`）を設定し、メニュー非展開時でもキーボードショートカットが即座に反応するように改善
3. `StudyDocumentManager/Views/OnboardingDialog.axaml`:
   - `SkipButton` に `IsCancel="True"` を設定し、Escape キーによる自然なダイアログ終了をサポート
4. `StudyDocumentManager.Tests/DesktopQualityBatch1Tests.cs`:
   - トークン定義、HotKey 設定、Dialog Cancel プロパティの回帰テスト 3 件を追加

## 検証
- `dotnet build "StudyDocumentManager.sln" -c Debug` — 0 エラー
- `DesktopQualityBatch1Tests` — 3/3 PASS
- `OfficeMetadataTests` — 13/13 PASS
- GitNexus: change detection low risk, cycleCount 0

Refs #60

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR completes missing desktop color tokens, enables global menu shortcuts, and allows Escape to cancel onboarding.
- Adds seven semantic brushes used by the desktop workspace.
- Adds `HotKey` bindings matching eight displayed menu gestures.
- Marks the onboarding skip action as the dialog cancel button.
- Adds source-level regression tests for these changes.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| StudyDocumentManager/Themes/ColorTokens.axaml | Adds the missing semantic brushes and now places border brushes after their referenced colors, resolving the previously reported forward references. |
| StudyDocumentManager/Views/MainWindow.axaml | Adds global hotkeys corresponding to the existing menu input-gesture labels. |
| StudyDocumentManager/Views/OnboardingDialog.axaml | Makes the skip button the dialog cancel action so Escape can invoke it. |
| StudyDocumentManager.Tests/DesktopQualityBatch1Tests.cs | Adds source-content checks covering semantic brush keys, menu hotkeys, and onboarding cancellation. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(desktop): カラートークンの前方参照を解消しリソース解決順序を適..."](https://github.com/hayato-shino05/document-manager/commit/5ccb89207021ba31d978190c6ba0b69ac9f67d24) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59688634)</sub>

<!-- /greptile_comment -->