### PR TITLE
デスクトップ画面の初期・完了状態を分離し空状態の操作導線を改善する

### DIFF
--- a/StudyDocumentManager.Tests/DesktopQualityBatch1Tests.cs
+++ b/StudyDocumentManager.Tests/DesktopQualityBatch1Tests.cs
@@ -14,20 +14,16 @@ public class DesktopQualityBatch1Tests
         var officeWorkspace = File.ReadAllText(
             GetSourceFilePath("StudyDocumentManager", "Views", "OfficeWorkspace.axaml"));
 
-        var expectedTokens = new[]
-        {
-            "DangerText",
-            "DangerBorder",
-            "WarningText",
-            "WarningBorder",
-            "SuccessText",
-            "SuccessBorder",
-            "Accent"
-        };
+        var matches = System.Text.RegularExpressions.Regex.Matches(officeWorkspace, @"\{StaticResource\s+([A-Za-z0-9_]+)\}");
+        var colorOrBrushTokens = matches
+            .Select(m => m.Groups[1].Value)
+            .Where(t => t.EndsWith("Text") || t.EndsWith("Border") || t.EndsWith("Brush") || t.EndsWith("Bg") || t.EndsWith("Background") || t == "Accent")
+            .Distinct()
+            .ToList();
 
-        foreach (var token in expectedTokens)
+        Assert.NotEmpty(colorOrBrushTokens);
+        foreach (var token in colorOrBrushTokens)
         {
-            Assert.Contains($"{{StaticResource {token}}}", officeWorkspace);
             Assert.Contains($"x:Key=\"{token}\"", colorTokens);
         }
     }

--- a/StudyDocumentManager.Tests/DesktopQualityBatch1Tests.cs
+++ b/StudyDocumentManager.Tests/DesktopQualityBatch1Tests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using Xunit;
 
@@ -11,14 +11,25 @@ public class DesktopQualityBatch1Tests
     {
         var colorTokens = File.ReadAllText(
             GetSourceFilePath("StudyDocumentManager", "Themes", "ColorTokens.axaml"));
+        var officeWorkspace = File.ReadAllText(
+            GetSourceFilePath("StudyDocumentManager", "Views", "OfficeWorkspace.axaml"));
 
-        Assert.Contains("x:Key=\"DangerText\"", colorTokens);
-        Assert.Contains("x:Key=\"DangerBorder\"", colorTokens);
-        Assert.Contains("x:Key=\"WarningText\"", colorTokens);
-        Assert.Contains("x:Key=\"WarningBorder\"", colorTokens);
-        Assert.Contains("x:Key=\"SuccessText\"", colorTokens);
-        Assert.Contains("x:Key=\"SuccessBorder\"", colorTokens);
-        Assert.Contains("x:Key=\"Accent\"", colorTokens);
+        var expectedTokens = new[]
+        {
+            "DangerText",
+            "DangerBorder",
+            "WarningText",
+            "WarningBorder",
+            "SuccessText",
+            "SuccessBorder",
+            "Accent"
+        };
+
+        foreach (var token in expectedTokens)
+        {
+            Assert.Contains($"{{StaticResource {token}}}", officeWorkspace);
+            Assert.Contains($"x:Key=\"{token}\"", colorTokens);
+        }
     }
 
     [Fact]
@@ -43,8 +54,13 @@ public class DesktopQualityBatch1Tests
         var onboarding = File.ReadAllText(
             GetSourceFilePath("StudyDocumentManager", "Views", "OnboardingDialog.axaml"));
 
-        Assert.Contains("Name=\"SkipButton\"", onboarding);
-        Assert.Contains("IsCancel=\"True\"", onboarding);
+        // Assert that the SkipButton element specifically contains IsCancel="True"
+        var skipButtonStart = onboarding.IndexOf("Name=\"SkipButton\"", StringComparison.Ordinal);
+        Assert.True(skipButtonStart >= 0);
+        var skipButtonEnd = onboarding.IndexOf("/>", skipButtonStart, StringComparison.Ordinal);
+        Assert.True(skipButtonEnd > skipButtonStart);
+        var skipButtonXml = onboarding.Substring(skipButtonStart, skipButtonEnd - skipButtonStart);
+        Assert.Contains("IsCancel=\"True\"", skipButtonXml);
     }
 
     private static string GetSourceFilePath(params string[] pathSegments)

--- a/StudyDocumentManager.Tests/DesktopQualityBatch2Tests.cs
+++ b/StudyDocumentManager.Tests/DesktopQualityBatch2Tests.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using StudyDocumentManager.Core.Entities;
+using StudyDocumentManager.Core.Interfaces;
+using StudyDocumentManager.Models;
+using StudyDocumentManager.Services;
+using Xunit;
+
+namespace StudyDocumentManager.Tests;
+
+public class DesktopQualityBatch2Tests
+{
+    [Fact]
+    public void Dashboard_EmptyState_HasAddButton()
+    {
+        var dashboard = File.ReadAllText(
+            GetSourceFilePath("StudyDocumentManager", "Views", "Dashboard.axaml"));
+
+        Assert.Contains("AutomationProperties.AutomationId=\"Dashboard_EmptyState_AddButton\"", dashboard);
+        Assert.Contains("Command=\"{Binding AddDocumentCommand}\"", dashboard);
+    }
+
+    [Fact]
+    public void DuplicateDetection_View_HasInitialAndCleanStates()
+    {
+        var view = File.ReadAllText(
+            GetSourceFilePath("StudyDocumentManager", "Views", "DuplicateDetection.axaml"));
+
+        Assert.Contains("IsVisible=\"{Binding IsInitialState}\"", view);
+        Assert.Contains("IsVisible=\"{Binding IsCleanState}\"", view);
+        Assert.Contains("AutomationProperties.AutomationId=\"DuplicateDetection_EmptyState_ScanButton\"", view);
+        Assert.Contains("AutomationProperties.AutomationId=\"DuplicateDetection_CleanState\"", view);
+    }
+
+    [Fact]
+    public async Task DuplicateDetectionModel_TracksInitialAndCleanState()
+    {
+        var repo = new EmptyTestDocumentRepository();
+        var loc = new CountingLocalizationService();
+        var dialog = new TestDialogService();
+        var model = new DuplicateDetectionModel(repo, dialog, loc);
+
+        Assert.True(model.IsInitialState);
+        Assert.False(model.IsCleanState);
+        Assert.False(model.HasResults);
+
+        await model.ScanDuplicatesCommand.ExecuteAsync(null);
+
+        Assert.False(model.IsInitialState);
+        Assert.True(model.IsCleanState);
+        Assert.False(model.HasResults);
+        Assert.False(string.IsNullOrWhiteSpace(model.CleanSummaryText));
+    }
+
+    [Fact]
+    public void FileIntegrityCheck_View_HasInitialAndHealthyStates()
+    {
+        var view = File.ReadAllText(
+            GetSourceFilePath("StudyDocumentManager", "Views", "FileIntegrityCheck.axaml"));
+
+        Assert.Contains("IsVisible=\"{Binding IsInitialState}\"", view);
+        Assert.Contains("IsVisible=\"{Binding IsHealthyState}\"", view);
+        Assert.Contains("AutomationProperties.AutomationId=\"FileIntegrity_EmptyState_ScanButton\"", view);
+        Assert.Contains("AutomationProperties.AutomationId=\"FileIntegrity_HealthyState\"", view);
+    }
+
+    [Fact]
+    public async Task FileIntegrityCheckModel_TracksInitialAndHealthyState()
+    {
+        var repo = new EmptyTestDocumentRepository();
+        var loc = new CountingLocalizationService();
+        var dialog = new TestDialogService();
+        var fileDialog = new TestFileDialogService();
+        var model = new FileIntegrityCheckModel(repo, null, dialog, fileDialog, loc);
+
+        Assert.True(model.IsInitialState);
+        Assert.False(model.IsHealthyState);
+
+        await model.CheckIntegrityCommand.ExecuteAsync(null);
+
+        Assert.False(model.IsInitialState);
+        Assert.True(model.IsHealthyState);
+        Assert.False(string.IsNullOrWhiteSpace(model.HealthySummaryText));
+    }
+
+    [Fact]
+    public void Views_EllipsisColumns_HaveToolTips()
+    {
+        var recycleBin = File.ReadAllText(
+            GetSourceFilePath("StudyDocumentManager", "Views", "RecycleBin.axaml"));
+        var recentFiles = File.ReadAllText(
+            GetSourceFilePath("StudyDocumentManager", "Views", "RecentFiles.axaml"));
+
+        Assert.Contains("TextTrimming=\"CharacterEllipsis\" ToolTip.Tip=\"{Binding Name}\"", recycleBin);
+        Assert.Contains("TextTrimming=\"CharacterEllipsis\" ToolTip.Tip=\"{Binding DocumentName}\"", recentFiles);
+    }
+
+    private static string GetSourceFilePath(params string[] pathSegments)
+    {
+        for (var directory = new DirectoryInfo(AppContext.BaseDirectory);
+             directory is not null;
+             directory = directory.Parent)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "StudyDocumentManager.sln")))
+                return Path.Combine(directory.FullName, Path.Combine(pathSegments));
+        }
+
+        throw new DirectoryNotFoundException("Could not locate the solution root.");
+    }
+
+    private sealed class EmptyTestDocumentRepository : IDocumentRepository
+    {
+        public List<StudyDocument> GetAll() => new();
+        public StudyDocument? GetById(int id) => null;
+        public List<StudyDocument> Search(string keyword) => new();
+        public List<StudyDocument> Filter(string subject, string type) => new();
+        public List<StudyDocument> SearchAdvanced(string keyword, string subject, string type, DateTime? fromDate, DateTime? toDate, double? minSize, double? maxSize, bool? isImportant) => new();
+        public bool Add(StudyDocument document) => true;
+        public bool AddWithCatalogs(StudyDocument document) => true;
+        public bool Update(StudyDocument document) => true;
+        public bool Delete(int id) => true;
+        public List<string> GetDistinctSubjects() => new();
+        public List<string> GetDistinctTypes() => new();
+        public List<string> GetDistinctTags() => new();
+        public List<StudyDocument> GetUpcomingDeadlines(int days) => new();
+        public List<StudyDocument> GetOverdueDocuments() => new();
+        public void EnsureSubjectExists(string subject) { }
+        public void EnsureTypeExists(string type) { }
+    }
+
+    private sealed class TestDialogService : IDialogService
+    {
+        public Task ShowMessageAsync(string title, string message) => Task.CompletedTask;
+        public Task ShowErrorAsync(string title, string message) => Task.CompletedTask;
+        public Task<bool> ShowConfirmAsync(string title, string message) => Task.FromResult(true);
+        public Task<bool> ShowConfirmAsync(string title, string message, string confirmText, bool isDanger = false) => Task.FromResult(true);
+        public Task<string?> ShowInputAsync(string title, string label, string defaultValue = "", string watermark = "") => Task.FromResult<string?>(null);
+    }
+
+    private sealed class TestFileDialogService : IFileDialogService
+    {
+        public Task<string?> ShowOpenFileAsync(string title, string? filter = null) => Task.FromResult<string?>(null);
+        public Task<string?> ShowOpenFolderAsync(string title) => Task.FromResult<string?>(null);
+        public Task<string?> ShowSaveFileAsync(string title, string defaultFileName, string? filter = null) => Task.FromResult<string?>(null);
+    }
+}

--- a/StudyDocumentManager.Tests/DesktopQualityBatch2Tests.cs
+++ b/StudyDocumentManager.Tests/DesktopQualityBatch2Tests.cs
@@ -55,6 +55,21 @@ public class DesktopQualityBatch2Tests
     }
 
     [Fact]
+    public async Task DuplicateDetectionModel_OnException_DoesNotShowCleanState()
+    {
+        var repo = new ThrowingTestDocumentRepository();
+        var loc = new CountingLocalizationService();
+        var dialog = new TestDialogService();
+        var model = new DuplicateDetectionModel(repo, dialog, loc);
+
+        await model.ScanDuplicatesCommand.ExecuteAsync(null);
+
+        Assert.True(model.IsInitialState);
+        Assert.False(model.IsCleanState);
+        Assert.False(model.HasResults);
+    }
+
+    [Fact]
     public void FileIntegrityCheck_View_HasInitialAndHealthyStates()
     {
         var view = File.ReadAllText(
@@ -86,6 +101,46 @@ public class DesktopQualityBatch2Tests
     }
 
     [Fact]
+    public async Task FileIntegrityCheckModel_OnException_DoesNotShowHealthyState()
+    {
+        var repo = new ThrowingTestDocumentRepository();
+        var loc = new CountingLocalizationService();
+        var dialog = new TestDialogService();
+        var fileDialog = new TestFileDialogService();
+        var model = new FileIntegrityCheckModel(repo, null, dialog, fileDialog, loc);
+
+        await model.CheckIntegrityCommand.ExecuteAsync(null);
+
+        Assert.True(model.IsInitialState);
+        Assert.False(model.IsHealthyState);
+    }
+
+    [Fact]
+    public void FileIntegrityCheckModel_TransitionToHealthyState_WhenMissingCountDecrementsToZero()
+    {
+        var repo = new EmptyTestDocumentRepository();
+        var loc = new CountingLocalizationService();
+        var dialog = new TestDialogService();
+        var fileDialog = new TestFileDialogService();
+        var model = new FileIntegrityCheckModel(repo, null, dialog, fileDialog, loc);
+
+        model.HasScanned = true;
+        model.MissingCount = 1;
+        Assert.False(model.IsHealthyState);
+
+        var notified = false;
+        model.PropertyChanged += (sender, args) =>
+        {
+            if (args.PropertyName == nameof(model.IsHealthyState))
+                notified = true;
+        };
+
+        model.MissingCount = 0;
+        Assert.True(notified);
+        Assert.True(model.IsHealthyState);
+    }
+
+    [Fact]
     public void Views_EllipsisColumns_HaveToolTips()
     {
         var recycleBin = File.ReadAllText(
@@ -113,6 +168,26 @@ public class DesktopQualityBatch2Tests
     private sealed class EmptyTestDocumentRepository : IDocumentRepository
     {
         public List<StudyDocument> GetAll() => new();
+        public StudyDocument? GetById(int id) => null;
+        public List<StudyDocument> Search(string keyword) => new();
+        public List<StudyDocument> Filter(string subject, string type) => new();
+        public List<StudyDocument> SearchAdvanced(string keyword, string subject, string type, DateTime? fromDate, DateTime? toDate, double? minSize, double? maxSize, bool? isImportant) => new();
+        public bool Add(StudyDocument document) => true;
+        public bool AddWithCatalogs(StudyDocument document) => true;
+        public bool Update(StudyDocument document) => true;
+        public bool Delete(int id) => true;
+        public List<string> GetDistinctSubjects() => new();
+        public List<string> GetDistinctTypes() => new();
+        public List<string> GetDistinctTags() => new();
+        public List<StudyDocument> GetUpcomingDeadlines(int days) => new();
+        public List<StudyDocument> GetOverdueDocuments() => new();
+        public void EnsureSubjectExists(string subject) { }
+        public void EnsureTypeExists(string type) { }
+    }
+
+    private sealed class ThrowingTestDocumentRepository : IDocumentRepository
+    {
+        public List<StudyDocument> GetAll() => throw new InvalidOperationException("Simulated database failure");
         public StudyDocument? GetById(int id) => null;
         public List<StudyDocument> Search(string keyword) => new();
         public List<StudyDocument> Filter(string subject, string type) => new();

--- a/StudyDocumentManager/Models/DashboardModel.cs
+++ b/StudyDocumentManager/Models/DashboardModel.cs
@@ -80,6 +80,7 @@ public partial class DashboardModel : ModelBase, IDisposable
     [ObservableProperty] private string _statusText = string.Empty;
     [ObservableProperty] private bool _isLoading = true;
     [ObservableProperty] private bool _isEmptyState;
+    public bool IsDatabaseEmpty => _allDocuments.Count == 0;
     [ObservableProperty] private bool _hasLoadError;
     [ObservableProperty] private string _stateMessage = string.Empty;
     [ObservableProperty] private string _lastBackupDisplay = string.Empty;
@@ -276,6 +277,7 @@ public partial class DashboardModel : ModelBase, IDisposable
 
             _allDocuments.Clear();
             _allDocuments.AddRange(docs);
+            OnPropertyChanged(nameof(IsDatabaseEmpty));
             _availableSubjects = [..subjects];
             _availableTypes = [..types];
 

--- a/StudyDocumentManager/Models/DuplicateDetectionModel.cs
+++ b/StudyDocumentManager/Models/DuplicateDetectionModel.cs
@@ -50,13 +50,12 @@ public partial class DuplicateDetectionModel : ModelBase
     private async Task ScanDuplicatesAsync()
     {
         IsScanning = true;
-        HasScanned = true;
+        HasScanned = false;
         DuplicateGroups.Clear();
         TotalGroups = 0;
         OnPropertyChanged(nameof(HasResults));
         OnPropertyChanged(nameof(IsInitialState));
         OnPropertyChanged(nameof(IsCleanState));
-        OnPropertyChanged(nameof(CleanSummaryText));
 
         try
         {
@@ -99,7 +98,9 @@ public partial class DuplicateDetectionModel : ModelBase
             }
 
             TotalGroups = DuplicateGroups.Count;
+            HasScanned = true;
             OnPropertyChanged(nameof(HasResults));
+            OnPropertyChanged(nameof(CleanSummaryText));
 
             if (TotalGroups == 0)
             {
@@ -108,6 +109,7 @@ public partial class DuplicateDetectionModel : ModelBase
         }
         catch (Exception)
         {
+            HasScanned = false;
             DuplicateGroups.Clear();
             TotalGroups = 0;
             OnPropertyChanged(nameof(HasResults));

--- a/StudyDocumentManager/Models/DuplicateDetectionModel.cs
+++ b/StudyDocumentManager/Models/DuplicateDetectionModel.cs
@@ -19,6 +19,7 @@ public partial class DuplicateDetectionModel : ModelBase
 
     [ObservableProperty] private ObservableCollection<DuplicateGroup> _duplicateGroups = new();
     [ObservableProperty] private bool _isScanning;
+    [ObservableProperty] private bool _hasScanned;
     [ObservableProperty] private int _totalGroups;
 
     public DuplicateDetectionModel(
@@ -37,17 +38,25 @@ public partial class DuplicateDetectionModel : ModelBase
         _undoRepository = undoRepository;
         _undo = undo;
         _duplicateReviewService = duplicateReviewService;
+        _loc.LanguageChanged += (_, _) => OnPropertyChanged(nameof(CleanSummaryText));
     }
 
     public bool HasResults => DuplicateGroups.Count > 0;
+    public bool IsInitialState => !HasScanned && !IsScanning;
+    public bool IsCleanState => HasScanned && !IsScanning && TotalGroups == 0;
+    public string CleanSummaryText => _loc["Duplicate_NoDuplicates"];
 
     [RelayCommand]
     private async Task ScanDuplicatesAsync()
     {
         IsScanning = true;
+        HasScanned = true;
         DuplicateGroups.Clear();
         TotalGroups = 0;
         OnPropertyChanged(nameof(HasResults));
+        OnPropertyChanged(nameof(IsInitialState));
+        OnPropertyChanged(nameof(IsCleanState));
+        OnPropertyChanged(nameof(CleanSummaryText));
 
         try
         {
@@ -107,6 +116,8 @@ public partial class DuplicateDetectionModel : ModelBase
         finally
         {
             IsScanning = false;
+            OnPropertyChanged(nameof(IsInitialState));
+            OnPropertyChanged(nameof(IsCleanState));
         }
     }
 

--- a/StudyDocumentManager/Models/FileIntegrityCheckModel.cs
+++ b/StudyDocumentManager/Models/FileIntegrityCheckModel.cs
@@ -29,7 +29,7 @@ public partial class FileIntegrityCheckModel : ModelBase
     [ObservableProperty] private bool _hasScanned;
     [ObservableProperty] private bool _isCheckCancelled;
     [ObservableProperty] private int _totalChecked;
-    [ObservableProperty] private int _missingCount;
+    [ObservableProperty, NotifyPropertyChangedFor(nameof(IsHealthyState))] private int _missingCount;
     [ObservableProperty] private string _statusText = string.Empty;
     [ObservableProperty] private string _databaseLocation = string.Empty;
 
@@ -62,13 +62,12 @@ public partial class FileIntegrityCheckModel : ModelBase
 
         IsChecking = true;
         IsCheckCancelled = false;
-        HasScanned = true;
+        HasScanned = false;
         Results.Clear();
         TotalChecked = 0;
         MissingCount = 0;
         OnPropertyChanged(nameof(IsInitialState));
         OnPropertyChanged(nameof(IsHealthyState));
-        OnPropertyChanged(nameof(HealthySummaryText));
         _checkCancellation?.Dispose();
         _checkCancellation = new CancellationTokenSource();
         var cancellation = _checkCancellation;
@@ -83,11 +82,14 @@ public partial class FileIntegrityCheckModel : ModelBase
 
             if (scan.IsCancelled)
             {
+                HasScanned = false;
                 IsCheckCancelled = true;
                 SetLocalizedStatus("FileIntegrity_Cancelled", TotalChecked, scan.Total);
             }
             else
             {
+                HasScanned = true;
+                OnPropertyChanged(nameof(HealthySummaryText));
                 SetLocalizedStatus("Status_ScanComplete", MissingCount, TotalChecked);
                 if (MissingCount == 0)
                 {
@@ -98,11 +100,13 @@ public partial class FileIntegrityCheckModel : ModelBase
         }
         catch (OperationCanceledException)
         {
+            HasScanned = false;
             IsCheckCancelled = true;
             SetLocalizedStatus("FileIntegrity_Cancelled", TotalChecked, TotalChecked);
         }
         catch (Exception)
         {
+            HasScanned = false;
             Results.Clear();
             TotalChecked = 0;
             MissingCount = 0;

--- a/StudyDocumentManager/Models/FileIntegrityCheckModel.cs
+++ b/StudyDocumentManager/Models/FileIntegrityCheckModel.cs
@@ -26,11 +26,16 @@ public partial class FileIntegrityCheckModel : ModelBase
 
     [ObservableProperty] private ObservableCollection<IntegrityResult> _results = new();
     [ObservableProperty] private bool _isChecking;
+    [ObservableProperty] private bool _hasScanned;
     [ObservableProperty] private bool _isCheckCancelled;
     [ObservableProperty] private int _totalChecked;
     [ObservableProperty] private int _missingCount;
     [ObservableProperty] private string _statusText = string.Empty;
     [ObservableProperty] private string _databaseLocation = string.Empty;
+
+    public bool IsInitialState => !HasScanned && !IsChecking;
+    public bool IsHealthyState => HasScanned && !IsChecking && MissingCount == 0;
+    public string HealthySummaryText => string.Format(_loc["Integrity_AllFilesOk"], TotalChecked);
 
     public FileIntegrityCheckModel(IDocumentRepository repository, IFileIntegrityRepository? fileIntegrityRepo, IDialogService dialogService, IFileDialogService fileDialogService, ILocalizationService loc, Action<int>? scanProgress = null, IClipboardService? clipboardService = null, IProcessLauncherService? processLauncher = null, Func<string, bool>? fileProbe = null, Func<string, bool>? rootReadyProbe = null)
     {
@@ -57,9 +62,13 @@ public partial class FileIntegrityCheckModel : ModelBase
 
         IsChecking = true;
         IsCheckCancelled = false;
+        HasScanned = true;
         Results.Clear();
         TotalChecked = 0;
         MissingCount = 0;
+        OnPropertyChanged(nameof(IsInitialState));
+        OnPropertyChanged(nameof(IsHealthyState));
+        OnPropertyChanged(nameof(HealthySummaryText));
         _checkCancellation?.Dispose();
         _checkCancellation = new CancellationTokenSource();
         var cancellation = _checkCancellation;
@@ -103,6 +112,9 @@ public partial class FileIntegrityCheckModel : ModelBase
         finally
         {
             IsChecking = false;
+            OnPropertyChanged(nameof(IsInitialState));
+            OnPropertyChanged(nameof(IsHealthyState));
+            OnPropertyChanged(nameof(HealthySummaryText));
             if (ReferenceEquals(_checkCancellation, cancellation))
             {
                 _checkCancellation.Dispose();
@@ -464,6 +476,7 @@ public partial class FileIntegrityCheckModel : ModelBase
         StatusText = FormatLocalized(_statusKey, _statusArguments);
         foreach (var result in Results)
             result.Status = FormatLocalized(result.StatusKey, result.StatusArguments);
+        OnPropertyChanged(nameof(HealthySummaryText));
     }
 
     private void SetLocalizedStatus(string key, params object[] args)

--- a/StudyDocumentManager/Models/FileIntegrityCheckModel.cs
+++ b/StudyDocumentManager/Models/FileIntegrityCheckModel.cs
@@ -33,8 +33,8 @@ public partial class FileIntegrityCheckModel : ModelBase
     [ObservableProperty] private string _statusText = string.Empty;
     [ObservableProperty] private string _databaseLocation = string.Empty;
 
-    public bool IsInitialState => !HasScanned && !IsChecking;
-    public bool IsHealthyState => HasScanned && !IsChecking && MissingCount == 0;
+    public bool IsInitialState => !HasScanned && !IsChecking && !IsCheckCancelled && Results.Count == 0;
+    public bool IsHealthyState => HasScanned && !IsChecking && !IsCheckCancelled && MissingCount == 0;
     public string HealthySummaryText => string.Format(_loc["Integrity_AllFilesOk"], TotalChecked);
 
     public FileIntegrityCheckModel(IDocumentRepository repository, IFileIntegrityRepository? fileIntegrityRepo, IDialogService dialogService, IFileDialogService fileDialogService, ILocalizationService loc, Action<int>? scanProgress = null, IClipboardService? clipboardService = null, IProcessLauncherService? processLauncher = null, Func<string, bool>? fileProbe = null, Func<string, bool>? rootReadyProbe = null)
@@ -217,6 +217,8 @@ public partial class FileIntegrityCheckModel : ModelBase
             }
             else
             {
+                HasScanned = true;
+                IsCheckCancelled = false;
                 SetLocalizedStatus("Status_MissingFiles", MissingCount);
             }
         }
@@ -234,6 +236,9 @@ public partial class FileIntegrityCheckModel : ModelBase
         finally
         {
             IsChecking = false;
+            OnPropertyChanged(nameof(IsInitialState));
+            OnPropertyChanged(nameof(IsHealthyState));
+            OnPropertyChanged(nameof(HealthySummaryText));
             if (ReferenceEquals(_checkCancellation, cancellation))
             {
                 _checkCancellation.Dispose();

--- a/StudyDocumentManager/Themes/AppTheme.axaml
+++ b/StudyDocumentManager/Themes/AppTheme.axaml
@@ -268,7 +268,9 @@
         <DrawingImage x:Key="IconCheckSuccess">
             <DrawingGroup>
                 <GeometryDrawing Brush="{StaticResource BrushIconSuccess}"
-                    Geometry="M12,2 C6.48,2 2,6.48 2,12 C2,17.52 6.48,22 12,22 C17.52,22 22,17.52 22,12 C22,6.48 17.52,2 12,2 Z M10,17 L5,12 L6.41,10.59 L10,14.17 L17.59,6.58 L19,8 L10,17 Z"/>
+                    Geometry="M12,2 A10,10 0 1,0 12,22 A10,10 0 1,0 12,2 Z"/>
+                <GeometryDrawing Brush="White"
+                    Geometry="M9.5,16.2 L5.5,12.2 L6.9,10.8 L9.5,13.4 L17.1,5.8 L18.5,7.2 Z"/>
             </DrawingGroup>
         </DrawingImage>
 

--- a/StudyDocumentManager/Themes/AppTheme.axaml
+++ b/StudyDocumentManager/Themes/AppTheme.axaml
@@ -265,6 +265,13 @@
                 Geometry="M5,12 L10,17 L19,7 L17.5,5.5 L10,14 L6.5,10.5 Z"/>
         </DrawingImage>
 
+        <DrawingImage x:Key="IconCheckSuccess">
+            <DrawingGroup>
+                <GeometryDrawing Brush="{StaticResource BrushIconSuccess}"
+                    Geometry="M12,2 C6.48,2 2,6.48 2,12 C2,17.52 6.48,22 12,22 C17.52,22 22,17.52 22,12 C22,6.48 17.52,2 12,2 Z M10,17 L5,12 L6.41,10.59 L10,14.17 L17.59,6.58 L19,8 L10,17 Z"/>
+            </DrawingGroup>
+        </DrawingImage>
+
         <!-- Close/X -->
         <DrawingImage x:Key="IconClose">
             <GeometryDrawing Brush="{StaticResource BrushIconNeutral}"

--- a/StudyDocumentManager/Views/Dashboard.axaml
+++ b/StudyDocumentManager/Views/Dashboard.axaml
@@ -1,4 +1,4 @@
-﻿<UserControl xmlns="https://github.com/avaloniaui"
+<UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:StudyDocumentManager.Models"
              xmlns:items="using:StudyDocumentManager.Models.Items"
@@ -612,6 +612,10 @@
                         <StackPanel Classes="empty-state" IsVisible="{Binding IsEmptyState}">
                             <Image Classes="empty-state-icon" Source="{StaticResource IconDocPage}"/>
                             <TextBlock Classes="empty-state-text" Text="{Binding StateMessage}"/>
+                            <Button Classes="primary" Command="{Binding AddDocumentCommand}"
+                                    Padding="{StaticResource PaddingBtnSm}" Margin="0,8,0,0"
+                                    Content="{loc:Localize Toolbar_Add}"
+                                    AutomationProperties.AutomationId="Dashboard_EmptyState_AddButton"/>
                         </StackPanel>
                         </Panel>
                     </Border>

--- a/StudyDocumentManager/Views/Dashboard.axaml
+++ b/StudyDocumentManager/Views/Dashboard.axaml
@@ -613,6 +613,7 @@
                             <Image Classes="empty-state-icon" Source="{StaticResource IconDocPage}"/>
                             <TextBlock Classes="empty-state-text" Text="{Binding StateMessage}"/>
                             <Button Classes="primary" Command="{Binding AddDocumentCommand}"
+                                    IsVisible="{Binding IsDatabaseEmpty}"
                                     Padding="{StaticResource PaddingBtnSm}" Margin="0,8,0,0"
                                     Content="{loc:Localize Toolbar_Add}"
                                     AutomationProperties.AutomationId="Dashboard_EmptyState_AddButton"/>

--- a/StudyDocumentManager/Views/DuplicateDetection.axaml
+++ b/StudyDocumentManager/Views/DuplicateDetection.axaml
@@ -1,4 +1,4 @@
-﻿<UserControl xmlns="https://github.com/avaloniaui"
+<UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:StudyDocumentManager.Models"
         xmlns:loc="using:StudyDocumentManager.Markup"
@@ -69,13 +69,30 @@
                     </Border>
 
                     <Panel>
-                        <StackPanel IsVisible="{Binding !HasResults}"
+                        <!-- Initial Prompt State (before scan) -->
+                        <StackPanel IsVisible="{Binding IsInitialState}"
                                     VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="8" Margin="0,40">
                             <Image Source="{StaticResource IconDuplicate}" Width="36" Height="36" Opacity="0.4"/>
                             <TextBlock AutomationProperties.AutomationId="DuplicateDetection_EmptyState"
                                        AutomationProperties.LiveSetting="Polite"
                                        Text="{loc:Localize DuplicateDetection_EmptyState}"
                                        FontSize="{StaticResource FontSizeMd}" Foreground="{StaticResource TextMuted}"
+                                       HorizontalAlignment="Center"/>
+                            <Button Classes="primary" Command="{Binding ScanDuplicatesCommand}"
+                                    Content="{loc:Localize DuplicateDetection_BtnScan}"
+                                    Padding="{StaticResource PaddingBtnSm}" Margin="0,6,0,0"
+                                    AutomationProperties.AutomationId="DuplicateDetection_EmptyState_ScanButton"/>
+                        </StackPanel>
+
+                        <!-- Clean State (scanned, no duplicates found) -->
+                        <StackPanel IsVisible="{Binding IsCleanState}"
+                                    VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="8" Margin="0,40">
+                            <Image Source="{StaticResource IconCheckSuccess}" Width="36" Height="36"/>
+                            <TextBlock AutomationProperties.AutomationId="DuplicateDetection_CleanState"
+                                       AutomationProperties.LiveSetting="Polite"
+                                       Text="{Binding CleanSummaryText}"
+                                       FontSize="{StaticResource FontSizeMd}" Foreground="{StaticResource SuccessText}"
+                                       FontWeight="Medium"
                                        HorizontalAlignment="Center"/>
                         </StackPanel>
 

--- a/StudyDocumentManager/Views/FileIntegrityCheck.axaml
+++ b/StudyDocumentManager/Views/FileIntegrityCheck.axaml
@@ -95,11 +95,28 @@
                         </Border>
 
                         <Panel>
-                            <StackPanel IsVisible="{Binding !Results.Count}"
+                            <!-- Initial Prompt State (before scan) -->
+                            <StackPanel IsVisible="{Binding IsInitialState}"
                                         VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="8" Margin="0,40">
                                 <Image Source="{StaticResource IconIntegrity}" Width="36" Height="36" Opacity="0.4"/>
                                 <TextBlock Text="{loc:Localize FileIntegrity_EmptyState}"
                                            FontSize="{StaticResource FontSizeMd}" Foreground="{StaticResource TextMuted}"
+                                           HorizontalAlignment="Center"/>
+                                <Button Classes="primary" Command="{Binding CheckIntegrityCommand}"
+                                        Content="{loc:Localize FileIntegrity_BtnScan}"
+                                        Padding="{StaticResource PaddingBtnSm}" Margin="0,6,0,0"
+                                        AutomationProperties.AutomationId="FileIntegrity_EmptyState_ScanButton"/>
+                            </StackPanel>
+
+                            <!-- Healthy State (scanned, all files intact) -->
+                            <StackPanel IsVisible="{Binding IsHealthyState}"
+                                        VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="8" Margin="0,40">
+                                <Image Source="{StaticResource IconCheckSuccess}" Width="36" Height="36"/>
+                                <TextBlock AutomationProperties.AutomationId="FileIntegrity_HealthyState"
+                                           AutomationProperties.LiveSetting="Polite"
+                                           Text="{Binding HealthySummaryText}"
+                                           FontSize="{StaticResource FontSizeMd}" Foreground="{StaticResource SuccessText}"
+                                           FontWeight="Medium"
                                            HorizontalAlignment="Center"/>
                             </StackPanel>
 

--- a/StudyDocumentManager/Views/RecentFiles.axaml
+++ b/StudyDocumentManager/Views/RecentFiles.axaml
@@ -1,4 +1,4 @@
-﻿<UserControl xmlns="https://github.com/avaloniaui"
+<UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:StudyDocumentManager.Models"
              xmlns:conv="using:StudyDocumentManager.Converters"
@@ -58,7 +58,8 @@
                                         <StackPanel Orientation="Horizontal" Spacing="8" Margin="8,0">
                                             <Image Source="{Binding FileType, Converter={x:Static conv:DocumentTypeIconConverter.Instance}}" 
                                                    Width="16" Height="16" VerticalAlignment="Center" />
-                                            <TextBlock Text="{Binding DocumentName}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
+                                            <TextBlock Text="{Binding DocumentName}" VerticalAlignment="Center"
+                                                       TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding DocumentName}"/>
                                         </StackPanel>
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>

--- a/StudyDocumentManager/Views/RecycleBin.axaml
+++ b/StudyDocumentManager/Views/RecycleBin.axaml
@@ -1,4 +1,4 @@
-﻿<UserControl xmlns="https://github.com/avaloniaui"
+<UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:StudyDocumentManager.Models"
              xmlns:conv="using:StudyDocumentManager.Converters"
@@ -63,7 +63,8 @@
                                         <StackPanel Orientation="Horizontal" Spacing="8" Margin="8,0">
                                             <Image Source="{Binding Type, Converter={x:Static conv:DocumentTypeIconConverter.Instance}}" 
                                                    Width="16" Height="16" VerticalAlignment="Center" />
-                                            <TextBlock Text="{Binding Name}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
+                                            <TextBlock Text="{Binding Name}" VerticalAlignment="Center"
+                                                       TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding Name}"/>
                                         </StackPanel>
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>


### PR DESCRIPTION
## 概要
デスクトップ品質向上（Issue #60）の Batch 2 として、各スキャン画面における初期プロンプト状態と健全完了状態の分離、Dashboard 空状態における新規文書作成導線（CTA）の追加、および省略テキストへの ToolTip 付与を実施します。

## 変更点
1. `StudyDocumentManager/Views/Dashboard.axaml`:
   - `IsEmptyState` 時に `AddDocumentCommand` を呼び出すプライマリボタンを追加し、文書未登録時のデッドエンドを解消
2. `StudyDocumentManager/Models/DuplicateDetectionModel.cs` & `Views/DuplicateDetection.axaml`:
   - `HasScanned` プロパティを導入し、スキャン未実行の初期状態（`IsInitialState`）と重複 0 件完了状態（`IsCleanState`）を分離
   - 重複 0 件時に `IconCheckSuccess` と緑色の完了メッセージを表示し、ユーザーの誤認を防止
3. `StudyDocumentManager/Models/FileIntegrityCheckModel.cs` & `Views/FileIntegrityCheck.axaml`:
   - `HasScanned` プロパティを導入し、初期状態（`IsInitialState`）と全件健全完了状態（`IsHealthyState`）を分離
   - 欠損 0 件時に `IconCheckSuccess` と整合性確認完了メッセージを表示
4. `StudyDocumentManager/Themes/AppTheme.axaml`:
   - 成功・健全状態表示用のベクターアイコン `IconCheckSuccess`（DrawingImage）を定義
5. `StudyDocumentManager/Views/RecycleBin.axaml`, `RecentFiles.axaml`:
   - `TextTrimming="CharacterEllipsis"` を持つカラムに `ToolTip.Tip` を設定し、省略文字列の全文確認を可能に改善
6. テスト強化:
   - `DesktopQualityBatch1Tests.cs`: `SkipButton` の `IsCancel="True"` および `ColorTokens` の参照チェックを厳格化
   - `DesktopQualityBatch2Tests.cs`: 新規 6 件の回帰テストを追加（UI 状態分離、モデル状態遷移、ToolTip 設定）

## 検証
- `dotnet build "StudyDocumentManager.sln" -c Debug` — 0 エラー
- `DesktopQuality` テスト — 9/9 PASS
- `ScanRecoveryTests` & `Issue60ViewRenderSmokeTests` — 27/27 PASS
- GitNexus: detect_changes 実施済

Refs #60

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Separates initial and completed states on the desktop scan screens so an empty result is no longer confused with a scan that hasn't run, and adds a document-creation button to the empty dashboard.

- Duplicate Detection and File Integrity Check now show a distinct pre-scan prompt and a green success message when a scan finds zero issues.
- Failed or cancelled scans no longer reach the success state; cancelling after partial results keeps the initial prompt, and retrying to a healthy result now refreshes the success panel.
- The empty-dashboard add button only shows when the database has zero documents, not when a filter just returns no matches.
- Adds `IconCheckSuccess`, tooltips for truncated file names in Recycle Bin and Recent Files, and regression tests plus stricter existing assertions.

Refs #60.

<sup>Written for commit 0fa8d33820aea766ddce9024b070c1c3c2937543. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hayato-shino05/Document-Manager/pull/75?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR separates pre-scan and successful-completion states, improves empty-state actions, and adds full-text tooltips. One retry error path can still incorrectly expose the new healthy state.
- Adds explicit scan lifecycle state to duplicate detection and file-integrity models and views.
- Adds a document-creation CTA to the genuinely empty dashboard.
- Adds a shared success icon, truncated-text tooltips, and desktop regression tests.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The retry exception path must be fixed before merging because it can report unresolved missing files as a healthy completion.

RetryMissingAsync resets MissingCount before a fallible scan and does not restore it on a general exception, allowing the new healthy predicate to become true while the old missing-file results remain visible.

**Files Needing Attention:** StudyDocumentManager/Models/FileIntegrityCheckModel.cs and StudyDocumentManager/Views/FileIntegrityCheck.axaml
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| StudyDocumentManager/Models/FileIntegrityCheckModel.cs | Adds explicit initial and healthy states and repairs notifications, but retry exceptions can leave the healthy predicate true while unresolved results remain. |
| StudyDocumentManager/Models/DuplicateDetectionModel.cs | Adds initial-versus-clean state tracking and resets the completion marker on scan failures. |
| StudyDocumentManager/Views/FileIntegrityCheck.axaml | Adds distinct initial and healthy panels; independent visibility bindings expose the model's mixed retry-error state. |
| StudyDocumentManager/Views/DuplicateDetection.axaml | Separates the initial prompt from the successful no-duplicates state. |
| StudyDocumentManager/Models/DashboardModel.cs | Exposes and notifies database-wide emptiness so filtered zero-result states do not receive the creation CTA. |
| StudyDocumentManager/Views/Dashboard.axaml | Adds a primary document-creation action to the true database-empty state. |
| StudyDocumentManager.Tests/DesktopQualityBatch2Tests.cs | Covers the principal state transitions and view markers but does not exercise an exception during RetryMissingAsync. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Completed integrity scan with missing files] --> B[Retry missing files]
  B --> C[MissingCount reset to zero]
  C --> D{Retry scan outcome}
  D -->|Success, no missing files| E[Healthy state]
  D -->|Success, missing files remain| F[Results state]
  D -->|Cancellation| G[Cancelled state]
  D -->|Exception| H[Old Results retained]
  H --> I[IsChecking becomes false]
  I --> J[Healthy panel and missing-results list overlap]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
StudyDocumentManager/Models/FileIntegrityCheckModel.cs:37
**Retry errors appear healthy**

When retrying unresolved files throws during scanning, `RetryMissingAsync` retains the old results and `HasScanned` value but leaves `MissingCount` at zero, causing the healthy-success panel to appear alongside the unresolved missing-file list after the error dialog closes.

```suggestion
    public bool IsHealthyState => HasScanned && !IsChecking && !IsCheckCancelled && MissingCount == 0 && Results.Count == 0;
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(desktop): 空状態CTAの絞り込み判定・キャンセル後健全状態遷移..."](https://github.com/hayato-shino05/document-manager/commit/0fa8d33820aea766ddce9024b070c1c3c2937543) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59705562)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->