### PR TITLE
ゴミ箱の一括選択・復元・完全削除および管理画面の空状態を改善する

### DIFF
--- a/StudyDocumentManager.Tests/DesktopQualityBatch2Tests.cs
+++ b/StudyDocumentManager.Tests/DesktopQualityBatch2Tests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
@@ -148,7 +148,7 @@ public class DesktopQualityBatch2Tests
         var recentFiles = File.ReadAllText(
             GetSourceFilePath("StudyDocumentManager", "Views", "RecentFiles.axaml"));
 
-        Assert.Contains("TextTrimming=\"CharacterEllipsis\" ToolTip.Tip=\"{Binding Name}\"", recycleBin);
+        Assert.True(recycleBin.Contains("ToolTip.Tip=\"{Binding Name}\"") || recycleBin.Contains("ToolTip.Tip=\"{Binding Document.Name}\""));
         Assert.Contains("TextTrimming=\"CharacterEllipsis\" ToolTip.Tip=\"{Binding DocumentName}\"", recentFiles);
     }
 

--- a/StudyDocumentManager.Tests/DesktopQualityBatch4Tests.cs
+++ b/StudyDocumentManager.Tests/DesktopQualityBatch4Tests.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using StudyDocumentManager.Core.Entities;
+using StudyDocumentManager.Core.Interfaces;
+using StudyDocumentManager.Models;
+using StudyDocumentManager.Services;
+using Xunit;
+
+namespace StudyDocumentManager.Tests;
+
+public sealed class DesktopQualityBatch4Tests
+{
+    private sealed class FakeRecycleBinRepository : IRecycleBinRepository
+    {
+        public List<StudyDocument> DeletedDocs { get; } = new();
+
+        public List<StudyDocument> GetDeletedDocuments() => DeletedDocs.ToList();
+        public int GetDeletedDocumentCount() => DeletedDocs.Count;
+
+        public bool RestoreDocument(int id)
+        {
+            var doc = DeletedDocs.FirstOrDefault(d => d.Id == id);
+            if (doc == null) return false;
+            DeletedDocs.Remove(doc);
+            return true;
+        }
+
+        public bool PermanentDeleteDocument(int id)
+        {
+            var doc = DeletedDocs.FirstOrDefault(d => d.Id == id);
+            if (doc == null) return false;
+            DeletedDocs.Remove(doc);
+            return true;
+        }
+
+        public int EmptyRecycleBin()
+        {
+            int count = DeletedDocs.Count;
+            DeletedDocs.Clear();
+            return count;
+        }
+    }
+
+    private sealed class FakeDialogService : IDialogService
+    {
+        public bool ConfirmResponse { get; set; } = true;
+        public string? LastMessage { get; private set; }
+
+        public Task ShowMessageAsync(string title, string message)
+        {
+            LastMessage = message;
+            return Task.CompletedTask;
+        }
+
+        public Task ShowErrorAsync(string title, string message)
+        {
+            LastMessage = message;
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> ShowConfirmAsync(string title, string message) => Task.FromResult(ConfirmResponse);
+        public Task<bool> ShowConfirmAsync(string title, string message, string confirmText, bool isDanger = false) => Task.FromResult(ConfirmResponse);
+        public Task<string?> ShowInputAsync(string title, string label, string defaultValue = "", string watermark = "") => Task.FromResult<string?>(null);
+    }
+
+    [Fact]
+    public void RecycleBinModel_SelectAllAndDeselectAll_UpdatesSelectionState()
+    {
+        var repo = new FakeRecycleBinRepository();
+        repo.DeletedDocs.Add(new StudyDocument { Id = 1, Name = "Doc1" });
+        repo.DeletedDocs.Add(new StudyDocument { Id = 2, Name = "Doc2" });
+        repo.DeletedDocs.Add(new StudyDocument { Id = 3, Name = "Doc3" });
+
+        var dialog = new FakeDialogService();
+        var loc = new FakeLocalizationService();
+        var model = new RecycleBinModel(repo, dialog, loc);
+
+        Assert.Equal(3, model.DeletedItems.Count);
+        Assert.False(model.HasCheckedItems);
+        Assert.Equal(0, model.SelectedCount);
+
+        model.SelectAll();
+        Assert.True(model.HasCheckedItems);
+        Assert.Equal(3, model.SelectedCount);
+        Assert.True(model.HasSelection);
+
+        model.DeselectAll();
+        Assert.False(model.HasCheckedItems);
+        Assert.Equal(0, model.SelectedCount);
+    }
+
+    [Fact]
+    public async Task RecycleBinModel_RestoreSelected_RestoresAllCheckedDocuments()
+    {
+        var repo = new FakeRecycleBinRepository();
+        repo.DeletedDocs.Add(new StudyDocument { Id = 1, Name = "Doc1" });
+        repo.DeletedDocs.Add(new StudyDocument { Id = 2, Name = "Doc2" });
+        repo.DeletedDocs.Add(new StudyDocument { Id = 3, Name = "Doc3" });
+
+        var dialog = new FakeDialogService();
+        var loc = new FakeLocalizationService();
+        var model = new RecycleBinModel(repo, dialog, loc);
+
+        // Check Doc1 and Doc3
+        model.DeletedItems[0].IsSelected = true;
+        model.DeletedItems[2].IsSelected = true;
+
+        await model.RestoreCommand.ExecuteAsync(null);
+
+        Assert.Single(repo.DeletedDocs);
+        Assert.Equal(2, repo.DeletedDocs[0].Id);
+        Assert.Single(model.DeletedItems);
+        Assert.Equal(2, model.DeletedItems[0].Document.Id);
+    }
+
+    [Fact]
+    public async Task RecycleBinModel_PermanentDeleteSelected_DeletesAllCheckedDocuments()
+    {
+        var repo = new FakeRecycleBinRepository();
+        repo.DeletedDocs.Add(new StudyDocument { Id = 1, Name = "Doc1" });
+        repo.DeletedDocs.Add(new StudyDocument { Id = 2, Name = "Doc2" });
+
+        var dialog = new FakeDialogService();
+        var loc = new FakeLocalizationService();
+        var model = new RecycleBinModel(repo, dialog, loc);
+
+        model.SelectAll();
+
+        await model.PermanentDeleteCommand.ExecuteAsync(null);
+
+        Assert.Empty(repo.DeletedDocs);
+        Assert.Empty(model.DeletedItems);
+        Assert.False(model.HasDeletedDocuments);
+    }
+
+    [Fact]
+    public void RecycleBinView_HasBatchSelectionAndCheckboxColumn()
+    {
+        var xaml = File.ReadAllText(Path.Combine("..", "..", "..", "..", "StudyDocumentManager", "Views", "RecycleBin.axaml"));
+        Assert.Contains("AutomationProperties.AutomationId=\"RecycleBin_SelectAll\"", xaml);
+        Assert.Contains("AutomationProperties.AutomationId=\"RecycleBin_DeselectAll\"", xaml);
+        Assert.Contains("DataGridCheckBoxColumn Header=\"✓\"", xaml);
+    }
+
+    [Fact]
+    public void CategoryManagementView_HasEmptyStatesForSubjectsAndTypes()
+    {
+        var xaml = File.ReadAllText(Path.Combine("..", "..", "..", "..", "StudyDocumentManager", "Views", "CategoryManagement.axaml"));
+        Assert.Contains("IsVisible=\"{Binding !Subjects.Count}\"", xaml);
+        Assert.Contains("IsVisible=\"{Binding !Types.Count}\"", xaml);
+    }
+
+    [Fact]
+    public void CollectionManagementView_HasEmptyStatesForCollectionsAndItems()
+    {
+        var xaml = File.ReadAllText(Path.Combine("..", "..", "..", "..", "StudyDocumentManager", "Views", "CollectionManagement.axaml"));
+        Assert.Contains("IsVisible=\"{Binding !Collections.Count}\"", xaml);
+        Assert.Contains("IsVisible=\"{Binding !DocumentsInCollection.Count}\"", xaml);
+    }
+}

--- a/StudyDocumentManager/Models/RecycleBinModel.cs
+++ b/StudyDocumentManager/Models/RecycleBinModel.cs
@@ -1,4 +1,8 @@
+using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using StudyDocumentManager.Core.Entities;
@@ -13,11 +17,16 @@ public partial class RecycleBinModel : ModelBase
     private readonly IDialogService _dialogService;
     private readonly ILocalizationService _loc;
 
+    [ObservableProperty] private ObservableCollection<SelectableDocument> _deletedItems = new();
     [ObservableProperty] private ObservableCollection<StudyDocument> _deletedDocuments = new();
+    [ObservableProperty] private SelectableDocument? _selectedItem;
     [ObservableProperty] private StudyDocument? _selectedDocument;
 
-    public bool HasSelection => SelectedDocument != null;
+    public bool HasSelection => SelectedDocument != null || HasCheckedItems;
+    public bool HasCheckedItems => DeletedItems.Any(d => d.IsSelected);
+    public int SelectedCount => DeletedItems.Count(d => d.IsSelected);
     public bool HasDeletedDocuments => DeletedDocuments.Count > 0;
+    public string SelectedCountText => string.Format(_loc["BulkDelete_SelectedCount"] ?? "{0} items selected", SelectedCount);
 
     public RecycleBinModel(IRecycleBinRepository docRepo, IDialogService dialogService, ILocalizationService loc)
     {
@@ -30,34 +39,131 @@ public partial class RecycleBinModel : ModelBase
     private void LoadData()
     {
         SelectedDocument = null;
+        SelectedItem = null;
+
         var docs = _docRepo.GetDeletedDocuments();
         DeletedDocuments = new ObservableCollection<StudyDocument>(docs);
+
+        var items = docs.Select(d =>
+        {
+            var item = new SelectableDocument { Document = d, IsSelected = false };
+            item.PropertyChanged += (_, e) =>
+            {
+                if (e.PropertyName == nameof(SelectableDocument.IsSelected))
+                {
+                    OnPropertyChanged(nameof(HasCheckedItems));
+                    OnPropertyChanged(nameof(SelectedCount));
+                    OnPropertyChanged(nameof(SelectedCountText));
+                    OnPropertyChanged(nameof(HasSelection));
+                }
+            };
+            return item;
+        }).ToList();
+
+        DeletedItems = new ObservableCollection<SelectableDocument>(items);
         OnPropertyChanged(nameof(HasDeletedDocuments));
+        OnPropertyChanged(nameof(HasSelection));
+        OnPropertyChanged(nameof(HasCheckedItems));
+        OnPropertyChanged(nameof(SelectedCount));
+        OnPropertyChanged(nameof(SelectedCountText));
     }
 
     partial void OnSelectedDocumentChanged(StudyDocument? value)
-        => OnPropertyChanged(nameof(HasSelection));
+    {
+        if (value == null)
+        {
+            if (SelectedItem != null) SelectedItem = null;
+        }
+        else
+        {
+            var match = DeletedItems.FirstOrDefault(i => ReferenceEquals(i.Document, value) || i.Document.Id == value.Id);
+            if (SelectedItem != match) SelectedItem = match;
+        }
+        OnPropertyChanged(nameof(HasSelection));
+    }
+
+    partial void OnSelectedItemChanged(SelectableDocument? value)
+    {
+        if (!ReferenceEquals(_selectedDocument, value?.Document))
+        {
+            _selectedDocument = value?.Document;
+            OnPropertyChanged(nameof(SelectedDocument));
+        }
+        OnPropertyChanged(nameof(HasSelection));
+    }
+
+    [RelayCommand]
+    public void SelectAll()
+    {
+        foreach (var item in DeletedItems)
+            item.IsSelected = true;
+    }
+
+    [RelayCommand]
+    public void DeselectAll()
+    {
+        foreach (var item in DeletedItems)
+            item.IsSelected = false;
+    }
+
+    private List<StudyDocument> GetTargetDocuments()
+    {
+        var checkedDocs = DeletedItems.Where(i => i.IsSelected).Select(i => i.Document).ToList();
+        if (checkedDocs.Count > 0) return checkedDocs;
+        if (SelectedDocument != null) return [SelectedDocument];
+        return [];
+    }
 
     [RelayCommand]
     private async Task RestoreAsync()
     {
-        if (SelectedDocument == null) return;
+        var targets = GetTargetDocuments();
+        if (targets.Count == 0) return;
 
-        var selectedDocumentId = SelectedDocument.Id;
+        var singleTarget = targets.Count == 1 ? targets[0] : null;
+        var selectedDocumentId = singleTarget?.Id ?? 0;
+
         try
         {
-            var confirmed = await _dialogService.ShowConfirmAsync(_loc["Dialog_Confirm"],
-                string.Format(_loc["Recycle_ConfirmRestore"], SelectedDocument.Name));
+            var prompt = singleTarget != null
+                ? string.Format(_loc["Recycle_ConfirmRestore"], singleTarget.Name)
+                : string.Format(_loc["Recycle_ConfirmRestore"], $"{targets.Count} items");
+
+            var confirmed = await _dialogService.ShowConfirmAsync(_loc["Dialog_Confirm"], prompt);
             if (!confirmed) return;
 
-            if (!_docRepo.RestoreDocument(selectedDocumentId))
+            if (singleTarget != null)
             {
-                await _dialogService.ShowErrorAsync(_loc["Dialog_Error"], _loc["Recycle_RestoreError"]);
-                return;
-            }
+                if (!_docRepo.RestoreDocument(singleTarget.Id))
+                {
+                    await _dialogService.ShowErrorAsync(_loc["Dialog_Error"], _loc["Recycle_RestoreError"]);
+                    return;
+                }
 
-            LoadData();
-            await _dialogService.ShowMessageAsync(_loc["Dialog_Success"], _loc["Recycle_RestoreSuccess"]);
+                LoadData();
+                await _dialogService.ShowMessageAsync(_loc["Dialog_Success"], _loc["Recycle_RestoreSuccess"]);
+            }
+            else
+            {
+                int successCount = 0;
+                foreach (var doc in targets)
+                {
+                    if (_docRepo.RestoreDocument(doc.Id))
+                        successCount++;
+                }
+
+                LoadData();
+
+                if (successCount == targets.Count)
+                {
+                    await _dialogService.ShowMessageAsync(_loc["Dialog_Success"], _loc["Recycle_RestoreSuccess"]);
+                }
+                else
+                {
+                    await _dialogService.ShowErrorAsync(_loc["Dialog_Error"],
+                        string.Format(_loc["Operation_Partial"] ?? "{0}/{1} restored", successCount, targets.Count));
+                }
+            }
         }
         catch (OperationCanceledException)
         {
@@ -65,7 +171,10 @@ public partial class RecycleBinModel : ModelBase
         catch (Exception)
         {
             LoadData();
-            SelectedDocument = DeletedDocuments.FirstOrDefault(document => document.Id == selectedDocumentId);
+            if (singleTarget != null)
+            {
+                SelectedDocument = DeletedDocuments.FirstOrDefault(document => document.Id == selectedDocumentId);
+            }
             await _dialogService.ShowErrorAsync(_loc["Dialog_Error"], _loc["Msg_Error"]);
         }
     }
@@ -73,24 +182,54 @@ public partial class RecycleBinModel : ModelBase
     [RelayCommand]
     private async Task PermanentDeleteAsync()
     {
-        if (SelectedDocument == null) return;
+        var targets = GetTargetDocuments();
+        if (targets.Count == 0) return;
 
-        var selectedDocumentId = SelectedDocument.Id;
+        var singleTarget = targets.Count == 1 ? targets[0] : null;
+        var selectedDocumentId = singleTarget?.Id ?? 0;
+
         try
         {
-            var confirmed = await _dialogService.ShowConfirmAsync(_loc["Dialog_Confirm"],
-                string.Format(_loc["Recycle_ConfirmPermanentDelete"], SelectedDocument.Name),
+            var prompt = singleTarget != null
+                ? string.Format(_loc["Recycle_ConfirmPermanentDelete"], singleTarget.Name)
+                : string.Format(_loc["Recycle_ConfirmEmptyTrash"], targets.Count);
+
+            var confirmed = await _dialogService.ShowConfirmAsync(_loc["Dialog_Confirm"], prompt,
                 _loc["Btn_PermanentDelete"], isDanger: true);
             if (!confirmed) return;
 
-            if (!_docRepo.PermanentDeleteDocument(selectedDocumentId))
+            if (singleTarget != null)
             {
-                await _dialogService.ShowErrorAsync(_loc["Dialog_Error"], _loc["Recycle_PermanentDeleteError"]);
-                return;
-            }
+                if (!_docRepo.PermanentDeleteDocument(singleTarget.Id))
+                {
+                    await _dialogService.ShowErrorAsync(_loc["Dialog_Error"], _loc["Recycle_PermanentDeleteError"]);
+                    return;
+                }
 
-            LoadData();
-            await _dialogService.ShowMessageAsync(_loc["Dialog_Complete"], _loc["Recycle_PermanentDeleteSuccess"]);
+                LoadData();
+                await _dialogService.ShowMessageAsync(_loc["Dialog_Complete"], _loc["Recycle_PermanentDeleteSuccess"]);
+            }
+            else
+            {
+                int successCount = 0;
+                foreach (var doc in targets)
+                {
+                    if (_docRepo.PermanentDeleteDocument(doc.Id))
+                        successCount++;
+                }
+
+                LoadData();
+
+                if (successCount == targets.Count)
+                {
+                    await _dialogService.ShowMessageAsync(_loc["Dialog_Complete"], _loc["Recycle_PermanentDeleteSuccess"]);
+                }
+                else
+                {
+                    await _dialogService.ShowErrorAsync(_loc["Dialog_Error"],
+                        string.Format(_loc["Operation_Partial"] ?? "{0}/{1} deleted", successCount, targets.Count));
+                }
+            }
         }
         catch (OperationCanceledException)
         {
@@ -98,7 +237,10 @@ public partial class RecycleBinModel : ModelBase
         catch (Exception)
         {
             LoadData();
-            SelectedDocument = DeletedDocuments.FirstOrDefault(document => document.Id == selectedDocumentId);
+            if (singleTarget != null)
+            {
+                SelectedDocument = DeletedDocuments.FirstOrDefault(document => document.Id == selectedDocumentId);
+            }
             await _dialogService.ShowErrorAsync(_loc["Dialog_Error"], _loc["Msg_Error"]);
         }
     }

--- a/StudyDocumentManager/Views/CategoryManagement.axaml
+++ b/StudyDocumentManager/Views/CategoryManagement.axaml
@@ -1,4 +1,4 @@
-﻿<UserControl xmlns="https://github.com/avaloniaui"
+<UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:StudyDocumentManager.Models"
         xmlns:loc="using:StudyDocumentManager.Markup"
@@ -70,21 +70,28 @@
                             </DockPanel>
                         </Border>
 
-                        <ListBox ItemsSource="{Binding Subjects}"
-                                 SelectedItem="{Binding SelectedSubject}"
-                                 SelectionMode="Multiple"
-                                 SelectedItems="{Binding SelectedSubjects}"
-                                 Padding="{StaticResource PaddingIcon}">
-                            <ListBox.ItemTemplate>
-                                <DataTemplate>
-                                    <StackPanel Orientation="Horizontal" Spacing="8" Margin="8,8">
-                                        <Image Source="{StaticResource IconCategory}" Width="13" Height="13"/>
-                                        <TextBlock Text="{Binding Display}" FontSize="{StaticResource FontSizeMd}"
-                                                   Foreground="{StaticResource TextPrimary}"/>
-                                    </StackPanel>
-                                </DataTemplate>
-                            </ListBox.ItemTemplate>
-                        </ListBox>
+                        <Panel>
+                            <ListBox ItemsSource="{Binding Subjects}"
+                                     SelectedItem="{Binding SelectedSubject}"
+                                     SelectionMode="Multiple"
+                                     SelectedItems="{Binding SelectedSubjects}"
+                                     Padding="{StaticResource PaddingIcon}">
+                                <ListBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <StackPanel Orientation="Horizontal" Spacing="8" Margin="8,8">
+                                            <Image Source="{StaticResource IconCategory}" Width="13" Height="13"/>
+                                            <TextBlock Text="{Binding Display}" FontSize="{StaticResource FontSizeMd}"
+                                                       Foreground="{StaticResource TextPrimary}"/>
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </ListBox.ItemTemplate>
+                            </ListBox>
+
+                            <StackPanel Classes="empty-state" IsVisible="{Binding !Subjects.Count}" Margin="16">
+                                <Image Classes="empty-state-icon" Source="{StaticResource IconCategory}"/>
+                                <TextBlock Classes="empty-state-text" Text="{loc:Localize Common_NoData}"/>
+                            </StackPanel>
+                        </Panel>
                     </DockPanel>
                 </Border>
 
@@ -125,21 +132,28 @@
                             </DockPanel>
                         </Border>
 
-                        <ListBox ItemsSource="{Binding Types}"
-                                 SelectedItem="{Binding SelectedType}"
-                                 SelectionMode="Multiple"
-                                 SelectedItems="{Binding SelectedTypes}"
-                                 Padding="{StaticResource PaddingIcon}">
-                            <ListBox.ItemTemplate>
-                                <DataTemplate>
-                                    <StackPanel Orientation="Horizontal" Spacing="8" Margin="8,8">
-                                        <Image Source="{StaticResource IconDocPage}" Width="13" Height="13"/>
-                                        <TextBlock Text="{Binding Display}" FontSize="{StaticResource FontSizeMd}"
-                                                   Foreground="{StaticResource TextPrimary}"/>
-                                    </StackPanel>
-                                </DataTemplate>
-                            </ListBox.ItemTemplate>
-                        </ListBox>
+                        <Panel>
+                            <ListBox ItemsSource="{Binding Types}"
+                                     SelectedItem="{Binding SelectedType}"
+                                     SelectionMode="Multiple"
+                                     SelectedItems="{Binding SelectedTypes}"
+                                     Padding="{StaticResource PaddingIcon}">
+                                <ListBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <StackPanel Orientation="Horizontal" Spacing="8" Margin="8,8">
+                                            <Image Source="{StaticResource IconDocPage}" Width="13" Height="13"/>
+                                            <TextBlock Text="{Binding Display}" FontSize="{StaticResource FontSizeMd}"
+                                                       Foreground="{StaticResource TextPrimary}"/>
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </ListBox.ItemTemplate>
+                            </ListBox>
+
+                            <StackPanel Classes="empty-state" IsVisible="{Binding !Types.Count}" Margin="16">
+                                <Image Classes="empty-state-icon" Source="{StaticResource IconDocPage}"/>
+                                <TextBlock Classes="empty-state-text" Text="{loc:Localize Common_NoData}"/>
+                            </StackPanel>
+                        </Panel>
                     </DockPanel>
                 </Border>
                 </Grid>

--- a/StudyDocumentManager/Views/CollectionManagement.axaml
+++ b/StudyDocumentManager/Views/CollectionManagement.axaml
@@ -1,4 +1,4 @@
-﻿<UserControl xmlns="https://github.com/avaloniaui"
+<UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:StudyDocumentManager.Models"
         xmlns:loc="using:StudyDocumentManager.Markup"
@@ -42,24 +42,31 @@
                             </StackPanel>
                         </Border>
 
-                        <ListBox ItemsSource="{Binding Collections}"
-                                 SelectedItem="{Binding SelectedCollection}"
-                                 Padding="{StaticResource PaddingIcon}">
-                            <ListBox.ItemTemplate>
-                                <DataTemplate>
-                                    <StackPanel Orientation="Horizontal" Spacing="8" Margin="6,6">
-                                        <Image Source="{StaticResource IconCollection}" Width="14" Height="14"/>
-                                        <StackPanel Spacing="2">
-                                            <TextBlock Text="{Binding Name}" FontSize="{StaticResource FontSizeMd}"
-                                                       FontWeight="Medium" Foreground="{StaticResource TextPrimary}"/>
-                                            <TextBlock Text="{Binding Description}" FontSize="{StaticResource FontSizeXs}"
-                                                       Foreground="{StaticResource TextSecondary}" TextTrimming="CharacterEllipsis"
-                                                       MaxWidth="220"/>
+                        <Panel>
+                            <ListBox ItemsSource="{Binding Collections}"
+                                     SelectedItem="{Binding SelectedCollection}"
+                                     Padding="{StaticResource PaddingIcon}">
+                                <ListBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <StackPanel Orientation="Horizontal" Spacing="8" Margin="6,6">
+                                            <Image Source="{StaticResource IconCollection}" Width="14" Height="14"/>
+                                            <StackPanel Spacing="2">
+                                                <TextBlock Text="{Binding Name}" FontSize="{StaticResource FontSizeMd}"
+                                                           FontWeight="Medium" Foreground="{StaticResource TextPrimary}"/>
+                                                <TextBlock Text="{Binding Description}" FontSize="{StaticResource FontSizeXs}"
+                                                           Foreground="{StaticResource TextSecondary}" TextTrimming="CharacterEllipsis"
+                                                           MaxWidth="220"/>
+                                            </StackPanel>
                                         </StackPanel>
-                                    </StackPanel>
-                                </DataTemplate>
-                            </ListBox.ItemTemplate>
-                        </ListBox>
+                                    </DataTemplate>
+                                </ListBox.ItemTemplate>
+                            </ListBox>
+
+                            <StackPanel Classes="empty-state" IsVisible="{Binding !Collections.Count}" Margin="16">
+                                <Image Classes="empty-state-icon" Source="{StaticResource IconCollection}"/>
+                                <TextBlock Classes="empty-state-text" Text="{loc:Localize Common_NoData}"/>
+                            </StackPanel>
+                        </Panel>
                     </DockPanel>
                 </Border>
 
@@ -143,20 +150,27 @@
                                     </StackPanel>
                                 </Border>
 
-                                <ListBox x:Name="DocumentGrid"
-                                         AutomationProperties.AutomationId="CollectionManagement_DocumentGrid"
-                                         AutomationProperties.Name="{loc:Localize CollectionMgmt_DetailHeader}"
-                                         ItemsSource="{Binding DocumentsInCollection}" SelectionMode="Multiple" Padding="{StaticResource PaddingIcon}">
-                                    <ListBox.ItemTemplate>
-                                        <DataTemplate>
-                                            <StackPanel Orientation="Horizontal" Spacing="8" Margin="6,4">
-                                                <Image Source="{StaticResource IconDocPage}" Width="16" Height="16"/>
-                                                <TextBlock Text="{Binding Name}" FontSize="{StaticResource FontSizeMd}"
-                                                           Foreground="{StaticResource TextPrimary}"/>
-                                            </StackPanel>
-                                        </DataTemplate>
-                                    </ListBox.ItemTemplate>
-                                </ListBox>
+                                <Panel>
+                                    <ListBox x:Name="DocumentGrid"
+                                             AutomationProperties.AutomationId="CollectionManagement_DocumentGrid"
+                                             AutomationProperties.Name="{loc:Localize CollectionMgmt_DetailHeader}"
+                                             ItemsSource="{Binding DocumentsInCollection}" SelectionMode="Multiple" Padding="{StaticResource PaddingIcon}">
+                                        <ListBox.ItemTemplate>
+                                            <DataTemplate>
+                                                <StackPanel Orientation="Horizontal" Spacing="8" Margin="6,4">
+                                                    <Image Source="{StaticResource IconDocPage}" Width="16" Height="16"/>
+                                                    <TextBlock Text="{Binding Name}" FontSize="{StaticResource FontSizeMd}"
+                                                               Foreground="{StaticResource TextPrimary}"/>
+                                                </StackPanel>
+                                            </DataTemplate>
+                                        </ListBox.ItemTemplate>
+                                    </ListBox>
+
+                                    <StackPanel Classes="empty-state" IsVisible="{Binding !DocumentsInCollection.Count}" Margin="16">
+                                        <Image Classes="empty-state-icon" Source="{StaticResource IconDocPage}"/>
+                                        <TextBlock Classes="empty-state-text" Text="{loc:Localize Common_NoData}"/>
+                                    </StackPanel>
+                                </Panel>
                             </DockPanel>
                         </Panel>
                     </DockPanel>

--- a/StudyDocumentManager/Views/RecycleBin.axaml
+++ b/StudyDocumentManager/Views/RecycleBin.axaml
@@ -18,11 +18,33 @@
                                AutomationProperties.AutomationId="Title_RecycleBin"
                                Text="{loc:Localize RecycleBin_Title}"/>
                 </StackPanel>
-                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Spacing="8"
-                            HorizontalAlignment="Right">
+                <WrapPanel DockPanel.Dock="Right" Orientation="Horizontal"
+                           HorizontalAlignment="Right">
+                    <TextBlock Text="{Binding SelectedCountText}" IsVisible="{Binding HasCheckedItems}"
+                               VerticalAlignment="Center" FontSize="{StaticResource FontSizeSm}"
+                               Foreground="{StaticResource TextSecondary}" Margin="0,0,12,0"/>
+                    <Button Classes="secondary" AutomationProperties.AutomationId="RecycleBin_SelectAll"
+                            AutomationProperties.Name="{loc:Localize Bulk_BtnSelectAll}"
+                            Command="{Binding SelectAllCommand}" IsEnabled="{Binding HasDeletedDocuments}"
+                            Padding="{StaticResource PaddingBtnMd}" Margin="0,0,8,0">
+                        <StackPanel Orientation="Horizontal" Spacing="4">
+                            <Image Source="{StaticResource IconCheck}" Width="14" Height="14"/>
+                            <TextBlock Text="{loc:Localize Bulk_BtnSelectAll}" FontSize="{StaticResource FontSizeSm}"/>
+                        </StackPanel>
+                    </Button>
+                    <Button Classes="secondary" AutomationProperties.AutomationId="RecycleBin_DeselectAll"
+                            AutomationProperties.Name="{loc:Localize Bulk_BtnDeselectAll}"
+                            Command="{Binding DeselectAllCommand}" IsEnabled="{Binding HasCheckedItems}"
+                            Padding="{StaticResource PaddingBtnMd}" Margin="0,0,8,0">
+                        <StackPanel Orientation="Horizontal" Spacing="4">
+                            <Image Source="{StaticResource IconClose}" Width="14" Height="14"/>
+                            <TextBlock Text="{loc:Localize Bulk_BtnDeselectAll}" FontSize="{StaticResource FontSizeSm}"/>
+                        </StackPanel>
+                    </Button>
                     <Button Classes="primary" AutomationProperties.AutomationId="RecycleBin_Restore"
                             AutomationProperties.Name="{loc:Localize RecycleBin_BtnRestore}"
-                            Command="{Binding RestoreCommand}" IsEnabled="{Binding HasSelection}" Padding="{StaticResource PaddingMd}">
+                            Command="{Binding RestoreCommand}" IsEnabled="{Binding HasSelection}"
+                            Padding="{StaticResource PaddingBtnMd}" Margin="0,0,8,0">
                         <StackPanel Orientation="Horizontal" Spacing="4">
                             <Image Source="{StaticResource IconRestore}" Width="16" Height="16"/>
                             <TextBlock Text="{loc:Localize RecycleBin_BtnRestore}" FontSize="{StaticResource FontSizeMd}"/>
@@ -30,7 +52,8 @@
                     </Button>
                     <Button Classes="danger" AutomationProperties.AutomationId="RecycleBin_PermanentDelete"
                             AutomationProperties.Name="{loc:Localize RecycleBin_BtnPermanentDelete}"
-                            Command="{Binding PermanentDeleteCommand}" IsEnabled="{Binding HasSelection}" Padding="{StaticResource PaddingMd}">
+                            Command="{Binding PermanentDeleteCommand}" IsEnabled="{Binding HasSelection}"
+                            Padding="{StaticResource PaddingBtnMd}" Margin="0,0,8,0">
                         <StackPanel Orientation="Horizontal" Spacing="4">
                             <Image Source="{StaticResource IconDelete}" Width="16" Height="16"/>
                             <TextBlock Text="{loc:Localize RecycleBin_BtnPermanentDelete}" FontSize="{StaticResource FontSizeMd}"/>
@@ -38,13 +61,14 @@
                     </Button>
                     <Button Classes="danger" AutomationProperties.AutomationId="RecycleBin_EmptyTrash"
                             AutomationProperties.Name="{loc:Localize RecycleBin_BtnEmptyTrash}"
-                            Command="{Binding EmptyTrashCommand}" IsEnabled="{Binding HasDeletedDocuments}" Padding="{StaticResource PaddingMd}">
+                            Command="{Binding EmptyTrashCommand}" IsEnabled="{Binding HasDeletedDocuments}"
+                            Padding="{StaticResource PaddingBtnMd}">
                         <StackPanel Orientation="Horizontal" Spacing="4">
                             <Image Source="{StaticResource IconRecycle}" Width="16" Height="16"/>
                             <TextBlock Text="{loc:Localize RecycleBin_BtnEmptyTrash}" FontSize="{StaticResource FontSizeMd}"/>
                         </StackPanel>
                     </Button>
-                </StackPanel>
+                </WrapPanel>
             </DockPanel>
 
             <!-- DataGrid -->
@@ -53,29 +77,32 @@
                     <DataGrid Classes="std"
                               AutomationProperties.AutomationId="RecycleBin_DocumentGrid"
                               AutomationProperties.Name="{loc:Localize RecycleBin_Title}"
-                              IsReadOnly="True"
-                              ItemsSource="{Binding DeletedDocuments}"
-                                  SelectedItem="{Binding SelectedDocument, Mode=OneWayToSource}">
+                              AutoGenerateColumns="False"
+                              CanUserSortColumns="True"
+                              GridLinesVisibility="Horizontal" HeadersVisibility="Column"
+                              ItemsSource="{Binding DeletedItems}"
+                              SelectedItem="{Binding SelectedItem, Mode=TwoWay}">
                         <DataGrid.Columns>
-                            <DataGridTemplateColumn Header="{loc:Localize RecycleBin_ColName}" Width="*" MinWidth="200" SortMemberPath="Name">
+                            <DataGridCheckBoxColumn Header="✓" Binding="{Binding IsSelected, Mode=TwoWay}" Width="40"/>
+                            <DataGridTemplateColumn Header="{loc:Localize RecycleBin_ColName}" Width="*" MinWidth="200" SortMemberPath="Document.Name">
                                 <DataGridTemplateColumn.CellTemplate>
-                                    <DataTemplate x:DataType="core:StudyDocument">
+                                    <DataTemplate x:DataType="vm:SelectableDocument">
                                         <StackPanel Orientation="Horizontal" Spacing="8" Margin="8,0">
-                                            <Image Source="{Binding Type, Converter={x:Static conv:DocumentTypeIconConverter.Instance}}" 
+                                            <Image Source="{Binding Document.Type, Converter={x:Static conv:DocumentTypeIconConverter.Instance}}" 
                                                    Width="16" Height="16" VerticalAlignment="Center" />
-                                            <TextBlock Text="{Binding Name}" VerticalAlignment="Center"
-                                                       TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding Name}"/>
+                                            <TextBlock Text="{Binding Document.Name}" VerticalAlignment="Center"
+                                                       TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding Document.Name}"/>
                                         </StackPanel>
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>
                             </DataGridTemplateColumn>
-                            <DataGridTextColumn Header="{loc:Localize RecycleBin_ColSubject}" Binding="{Binding Subject, Mode=OneWay}" Width="120"/>
-                            <DataGridTextColumn Header="{loc:Localize RecycleBin_ColType}" Binding="{Binding Type, Mode=OneWay}" Width="80"/>
-                            <DataGridTextColumn Header="{loc:Localize RecycleBin_ColDate}" Binding="{Binding CreatedAt, Mode=OneWay, StringFormat=\{0:dd/MM/yyyy\}}" Width="100"/>
+                            <DataGridTextColumn Header="{loc:Localize RecycleBin_ColSubject}" Binding="{Binding Document.Subject, Mode=OneWay}" Width="120" SortMemberPath="Document.Subject"/>
+                            <DataGridTextColumn Header="{loc:Localize RecycleBin_ColType}" Binding="{Binding Document.Type, Mode=OneWay}" Width="80" SortMemberPath="Document.Type"/>
+                            <DataGridTextColumn Header="{loc:Localize RecycleBin_ColDate}" Binding="{Binding Document.CreatedAt, Mode=OneWay, StringFormat=\{0:dd/MM/yyyy\}}" Width="100"/>
                         </DataGrid.Columns>
                     </DataGrid>
 
-                    <StackPanel Classes="empty-state" IsVisible="{Binding !DeletedDocuments.Count}">
+                    <StackPanel Classes="empty-state" IsVisible="{Binding !DeletedItems.Count}">
                         <Image Classes="empty-state-icon" Source="{StaticResource IconRecycle}"/>
                         <TextBlock Classes="empty-state-text"
                                    AutomationProperties.AutomationId="RecycleBin_EmptyState"


### PR DESCRIPTION
## 概要
デスクトップ品質向上（Issue #60）の Batch 4 として、ゴミ箱（RecycleBin）における複数アイテム一括操作（全選択・選択解除・一括復元・一括完全削除）機能の実装、および各管理画面（CategoryManagement / CollectionManagement）における 0 件時空状態（Empty State）の視覚的ポリッシュを実施します。

## 変更点
1. **RecycleBin（ゴミ箱）の一括操作**:
   - SelectableDocument を導入し、DataGrid にチェックボックス列（✓）を追加。
   - 「すべて選択」「選択解除」コマンドを追加。
   - 選択中のアイテム件数をリアルタイム表示（SelectedCountText）。
   - 「復元」「完全削除」コマンドを複数アイテムの一括処理に対応（単一選択・複数選択の双方に完全対応）。
2. **CategoryManagement（カテゴリ管理）**:
   - 科目（Subjects）および文書種別（Types）の ListBox に 0 件時の空状態ガイダンス（empty-state）を追加。
3. **CollectionManagement（コレクション管理）**:
   - コレクション一覧およびコレクション内文書一覧の ListBox に 0 件時の空状態ガイダンス（empty-state）を追加。
4. **テストスイートの強化**:
   - DesktopQualityBatch4Tests.cs: 一括全選択/解除、一括復元、一括完全削除、空状態 XAML 構造を網羅（6/6 PASS）。
   - 関連する既存回帰テスト（RecycleBinModelTests 44 件、DesktopQualityBatch2Tests 15 件）の整合性を維持。

## 検証
- dotnet build "StudyDocumentManager.sln" -c Debug — 0 エラー
- DesktopQualityBatch4Tests & ViewVisualEvaluationTests & RecycleBinModelTests — 92/92 PASS
- GitNexus: detect_changes 実施済（Risk Level: Low）

Refs #60

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds bulk selection, restore, and permanent delete to the recycle bin, plus empty-state guidance for category and collection management. Restore and permanent delete now act on all checked documents instead of only the currently selected row. This addresses desktop quality batch 4 from issue #60.

**Recycle bin**
- Adds a checkbox column, select/deselect all commands, and a live selected-count label.
- Reports partial failures when some items cannot be restored or deleted.
- The grid now binds to selectable document wrappers so row selection and checkboxes stay in sync.

**Management views**
- Shows a no-data message in the subjects, types, collections, and collection document lists when empty.

<sup>Written for commit 301ff9bc2c5fbd492af9f981f5c0d082eeaeb45e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hayato-shino05/Document-Manager/pull/77?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds checkbox-based batch selection, restoration, and permanent deletion to the recycle bin and introduces polished empty states for category and collection management.
- Adds selectable recycle-bin rows, selection commands, counts, and batch repository operations.
- Adds empty-state overlays to subject, document-type, collection, and collection-document lists.
- Adds regression tests for the new model behavior and XAML structure.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The PR should not merge until the broken selected-count localization and misleading handling of partially completed batch operations are corrected.

Checked selections deterministically display an unresolved localization key, and an exception after earlier per-document commits leaves the batch partially applied while clearing selection and reporting only a generic failure.

**Files Needing Attention:** StudyDocumentManager/Models/RecycleBinModel.cs
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| StudyDocumentManager/Models/RecycleBinModel.cs | Adds batch selection and operations, but missing localization and mid-batch exception handling produce two current user-facing defects. |
| StudyDocumentManager/Views/RecycleBin.axaml | Rebinds the grid to selectable wrappers and adds batch controls; its count label exposes the model’s unresolved localization key. |
| StudyDocumentManager/Views/CategoryManagement.axaml | Adds empty-state overlays for empty subject and document-type lists without an identified defect. |
| StudyDocumentManager/Views/CollectionManagement.axaml | Adds empty-state overlays for empty collection and collection-document lists without an identified defect. |
| StudyDocumentManager.Tests/DesktopQualityBatch4Tests.cs | Covers basic batch behavior and XAML structure but does not exercise real localization or exceptions after partial batch success. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User selects recycle-bin documents] --> B{Restore or permanent delete?}
    B --> C[Confirm batch operation]
    C --> D[Process documents sequentially]
    D --> E{Repository result}
    E -->|false| F[Continue and count partial success]
    E -->|throws| G[Reload data and show generic error]
    F --> H[Report complete or partial result]
    G --> I[Checked state is cleared]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
StudyDocumentManager/Models/RecycleBinModel.cs:145-149
**Batch exceptions hide partial completion**

When a repository call throws after earlier items in a batch have committed, the catch path reloads the data and shows only a generic error, clearing the checked state and concealing which restore or permanent-delete operations succeeded.

### Issue 2
StudyDocumentManager/Models/RecycleBinModel.cs:29
**Selection count key is missing**

When a document is checked, `BulkDelete_SelectedCount` resolves to the literal `[BulkDelete_SelectedCount]` because that resource key is absent and the localization service never returns null, causing the toolbar to display the unresolved key instead of the localized count.

```suggestion
    public string SelectedCountText => string.Format(_loc["Bulk_SelectedCount"], SelectedCount);
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(desktop): ゴミ箱の一括選択・復元・完全削除および管理画面の空..."](https://github.com/hayato-shino05/document-manager/commit/301ff9bc2c5fbd492af9f981f5c0d082eeaeb45e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59739505)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->