### PR TITLE
Linux 環境におけるプロセス起動・ファイル連携および更新サービスを最適化する

### DIFF
--- a/StudyDocumentManager.Tests/LauncherBehaviorTests.cs
+++ b/StudyDocumentManager.Tests/LauncherBehaviorTests.cs
@@ -150,4 +150,82 @@ public sealed class LauncherBehaviorTests : IDisposable
 
         Assert.Empty(started);
     }
+
+    [Fact]
+    public void Linux_OpenFile_ExistingFile_StartsXdgOpenOnFile()
+    {
+        var started = new List<ProcessStartInfo>();
+        var launcher = new ProcessLauncherService(new StubPlatformInfo(isLinux: true), psi => started.Add(psi));
+        var file = MakeFile("doc.pdf");
+
+        launcher.OpenFile(file);
+
+        var psi = Assert.Single(started);
+        Assert.Equal("xdg-open", psi.FileName);
+        Assert.Equal(file, Assert.Single(psi.ArgumentList));
+    }
+
+    [Fact]
+    public void Linux_OpenFile_MissingFile_StartsNothing()
+    {
+        var started = new List<ProcessStartInfo>();
+        var launcher = new ProcessLauncherService(new StubPlatformInfo(isLinux: true), psi => started.Add(psi));
+
+        launcher.OpenFile(Path.Combine(_root, "missing.pdf"));
+
+        Assert.Empty(started);
+    }
+
+    [Fact]
+    public void Windows_OpenFile_ExistingFile_UsesShellExecute()
+    {
+        var started = new List<ProcessStartInfo>();
+        var launcher = new ProcessLauncherService(new StubPlatformInfo(isLinux: false), psi => started.Add(psi));
+        var file = MakeFile("doc.pdf");
+
+        launcher.OpenFile(file);
+
+        var psi = Assert.Single(started);
+        Assert.Equal(file, psi.FileName);
+        Assert.True(psi.UseShellExecute);
+    }
+
+    [Fact]
+    public void Windows_OpenFile_MissingFile_StartsNothing()
+    {
+        var started = new List<ProcessStartInfo>();
+        var launcher = new ProcessLauncherService(new StubPlatformInfo(isLinux: false), psi => started.Add(psi));
+
+        launcher.OpenFile(Path.Combine(_root, "missing.pdf"));
+
+        Assert.Empty(started);
+    }
+
+    [Fact]
+    public void Linux_OpenUrl_StartsXdgOpenOnUrl()
+    {
+        var started = new List<ProcessStartInfo>();
+        var launcher = new ProcessLauncherService(new StubPlatformInfo(isLinux: true), psi => started.Add(psi));
+        const string url = "https://example.com/docs";
+
+        launcher.OpenUrl(url);
+
+        var psi = Assert.Single(started);
+        Assert.Equal("xdg-open", psi.FileName);
+        Assert.Equal(url, Assert.Single(psi.ArgumentList));
+    }
+
+    [Fact]
+    public void Windows_OpenUrl_UsesShellExecute()
+    {
+        var started = new List<ProcessStartInfo>();
+        var launcher = new ProcessLauncherService(new StubPlatformInfo(isLinux: false), psi => started.Add(psi));
+        const string url = "https://example.com/docs";
+
+        launcher.OpenUrl(url);
+
+        var psi = Assert.Single(started);
+        Assert.Equal(url, psi.FileName);
+        Assert.True(psi.UseShellExecute);
+    }
 }

--- a/StudyDocumentManager.Tests/PlatformSupportTests.cs
+++ b/StudyDocumentManager.Tests/PlatformSupportTests.cs
@@ -40,6 +40,42 @@ public sealed class PlatformSupportTests : IDisposable
         Assert.Equal(_temporaryDirectory, Assert.Single(startedProcess.ArgumentList));
     }
 
+    [Fact]
+    public void LinuxLauncher_OpenFile_UsesXdgOpenForFile()
+    {
+        ProcessStartInfo? startedProcess = null;
+        Directory.CreateDirectory(_temporaryDirectory);
+        var documentPath = Path.Combine(_temporaryDirectory, "document.pdf");
+        File.WriteAllText(documentPath, "content");
+        var service = new ProcessLauncherService(
+            new PlatformInfoStub(isLinux: true),
+            processStartInfo => startedProcess = processStartInfo);
+
+        service.OpenFile(documentPath);
+
+        Assert.NotNull(startedProcess);
+        Assert.Equal("xdg-open", startedProcess!.FileName);
+        Assert.False(startedProcess.UseShellExecute);
+        Assert.Equal(documentPath, Assert.Single(startedProcess.ArgumentList));
+    }
+
+    [Fact]
+    public void LinuxLauncher_OpenUrl_UsesXdgOpenForUrl()
+    {
+        ProcessStartInfo? startedProcess = null;
+        const string url = "https://example.com";
+        var service = new ProcessLauncherService(
+            new PlatformInfoStub(isLinux: true),
+            processStartInfo => startedProcess = processStartInfo);
+
+        service.OpenUrl(url);
+
+        Assert.NotNull(startedProcess);
+        Assert.Equal("xdg-open", startedProcess!.FileName);
+        Assert.False(startedProcess.UseShellExecute);
+        Assert.Equal(url, Assert.Single(startedProcess.ArgumentList));
+    }
+
     public void Dispose()
     {
         if (Directory.Exists(_temporaryDirectory))

--- a/StudyDocumentManager/Services/ProcessLauncherService.cs
+++ b/StudyDocumentManager/Services/ProcessLauncherService.cs
@@ -21,11 +21,21 @@ public class ProcessLauncherService : IProcessLauncherService
 
     public void OpenFile(string filePath)
     {
-        Process.Start(new ProcessStartInfo
+        if (_platformInfo.IsLinux)
         {
-            FileName = filePath,
-            UseShellExecute = true
-        });
+            if (File.Exists(filePath))
+                StartLinuxTarget(filePath);
+            return;
+        }
+
+        if (File.Exists(filePath))
+        {
+            _startProcess(new ProcessStartInfo
+            {
+                FileName = filePath,
+                UseShellExecute = true
+            });
+        }
     }
 
     public void RevealInExplorer(string filePath)
@@ -85,7 +95,7 @@ public class ProcessLauncherService : IProcessLauncherService
             return;
         }
 
-        Process.Start(new ProcessStartInfo
+        _startProcess(new ProcessStartInfo
         {
             FileName = url,
             UseShellExecute = true

--- a/StudyDocumentManager/Services/UpdateService.cs
+++ b/StudyDocumentManager/Services/UpdateService.cs
@@ -19,12 +19,14 @@ public class UpdateService : IUpdateService
     private readonly IDialogService _dialogService;
     private readonly ILocalizationService _loc;
     private readonly IToastService _toast;
+    private readonly IProcessLauncherService? _launcher;
 
-    public UpdateService(IDialogService dialogService, ILocalizationService loc, IToastService toast)
+    public UpdateService(IDialogService dialogService, ILocalizationService loc, IToastService toast, IProcessLauncherService? launcher = null)
     {
         _dialogService = dialogService;
         _loc = loc;
         _toast = toast;
+        _launcher = launcher;
     }
 
     private static HttpClient CreateHttpClient()
@@ -88,11 +90,18 @@ public class UpdateService : IUpdateService
 
         try
         {
-            Process.Start(new ProcessStartInfo
+            if (_launcher != null)
             {
-                FileName = url,
-                UseShellExecute = true
-            });
+                _launcher.OpenUrl(url);
+            }
+            else
+            {
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = url,
+                    UseShellExecute = true
+                });
+            }
         }
         catch
         {


### PR DESCRIPTION
## 概要
Linux 環境（Debian / Ubuntu / X11 / Wayland 等）において、デスクトップアプリケーションのすべての機能が Windows 同等に安全かつスムーズに動作するよう、プロセス起動（ProcessLauncherService）、ファイルおよび URL オープン（xdg-open 連携）、更新確認サービス（UpdateService）のクロスプラットフォーム最適化と回帰テストの拡充を実施します。

## 変更点
1. **ProcessLauncherService のクロスプラットフォーム強化**:
   - OpenFile: Linux 環境下において xdg-open を正しく呼び出すよう分岐を追加し、存在チェックおよびテスト用 _startProcess シームへ統一。
   - OpenUrl: Linux 環境下で xdg-open、Windows 環境下で UseShellExecute を使用する処理を _startProcess シームへ統合。
2. **UpdateService のリファクタリング**:
   - IProcessLauncherService を注入し、ブラウザ起動によるリリースダウンロードページ遷移をクロスプラットフォームで安全に実行。
3. **テストスイートの拡充**:
   - LauncherBehaviorTests.cs: Linux/Windows 双方における OpenFile, OpenUrl, OpenFolder, RevealInExplorer の全分岐テストを網羅。
   - PlatformSupportTests.cs: Linux 環境におけるファイルおよび URL 起動（xdg-open）のテストケースを追加。
   - 全体テストスイート 1,563 件オールグリーン。

## 検証
- dotnet build "StudyDocumentManager.sln" -c Debug — 0 エラー
- dotnet test（PlatformSupportTests & LauncherBehaviorTests 19 件） — 19/19 PASS
- 全体テストスイート — 1563/1563 PASS
- GitNexus: detect_changes 実施済

Refs #65

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR routes Linux file and URL launches through `xdg-open`, makes process creation testable through the existing launcher seam, and delegates update-page opening to `IProcessLauncherService`.

- Adds Linux and Windows launcher branch coverage for files and URLs.
- Adds file-existence checks before opening documents.
- Injects the launcher into `UpdateService`, while retaining a compatibility fallback when it is absent.
- The production update delegation path is not yet exercised by an `UpdateService`-level test.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with the non-blocking caveat that the production UpdateService launcher delegation lacks direct regression coverage.

The changed runtime paths are correctly wired and use argument-safe platform launch behavior, but current UpdateService tests select the nullable legacy fallback instead of exercising the injected launcher used by production.

**Files Needing Attention:** StudyDocumentManager/Services/UpdateService.cs and its UpdateService tests
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| StudyDocumentManager/Services/ProcessLauncherService.cs | Adds existence-guarded, seam-based file launching and routes Linux files and URLs through argument-safe xdg-open invocation. |
| StudyDocumentManager/Services/UpdateService.cs | Delegates release-page opening to the injected launcher in production, but keeps a nullable fallback that prevents existing tests from covering the new branch. |
| StudyDocumentManager.Tests/LauncherBehaviorTests.cs | Adds focused Linux and Windows branch tests for OpenFile and OpenUrl behavior. |
| StudyDocumentManager.Tests/PlatformSupportTests.cs | Adds Linux process-start assertions for file and URL targets using xdg-open. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Update as UpdateService
    participant Launcher as IProcessLauncherService
    participant OS as Platform launcher
    User->>Update: Confirm update
    alt launcher injected
        Update->>Launcher: OpenUrl(releaseUrl)
        alt Linux
            Launcher->>OS: xdg-open releaseUrl
        else Windows
            Launcher->>OS: ShellExecute releaseUrl
        end
    else launcher absent
        Update->>OS: Process.Start with ShellExecute
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
StudyDocumentManager/Services/UpdateService.cs:24
**Production Delegation Remains Untested**

Production dependency injection supplies `IProcessLauncherService`, but existing `UpdateService` tests omit the optional argument and exercise only the legacy fallback. A regression in launcher delegation, dependency wiring, or URL forwarding can therefore pass the test suite while preventing the release page from opening.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(platform): Linux 環境におけるプロセス起動・ファイル連..."](https://github.com/hayato-shino05/document-manager/commit/3bef03aea7c09e92cb7d46effb76e2361e62815a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59762413)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Issue #65 のLinux対応要件に合わせ、ファイル・URLの起動と更新ページへの遷移をクロスプラットフォーム化します。Linuxでは従来の直接起動から`xdg-open`を使う方式に変わり、Windowsの既存動作は維持されます。

- 存在しないファイルは起動せず、Linuxでは`xdg-open`が必要です。
- `UpdateService`はプロセスランチャー経由で更新ページを開き、未注入時は従来の起動方式にフォールバックします。
- LinuxとWindowsの起動分岐および回帰ケースを追加テストします。

<sup>Written for commit 3bef03aea7c09e92cb7d46effb76e2361e62815a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hayato-shino05/Document-Manager/pull/79?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

