### PR TITLE
Linux 環境におけるフォント解決・ファイル選択パス・クリップボードおよびパス比較を最適化する

### DIFF
--- a/StudyDocumentManager.Data/Helpers/DatabaseHelper.cs
+++ b/StudyDocumentManager.Data/Helpers/DatabaseHelper.cs
@@ -1382,8 +1382,13 @@ public class DatabaseHelper
         }
     }
 
-    private static bool PathsReferToSameFile(string firstPath, string secondPath)
-        => string.Equals(Path.GetFullPath(firstPath), Path.GetFullPath(secondPath), StringComparison.OrdinalIgnoreCase);
+    internal static bool PathsReferToSameFile(string firstPath, string secondPath)
+    {
+        var comparison = OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        return string.Equals(Path.GetFullPath(firstPath), Path.GetFullPath(secondPath), comparison);
+    }
 
     private static string CreateStagingPath(string targetPath)
     {

--- a/StudyDocumentManager.Data/StudyDocumentManager.Data.csproj
+++ b/StudyDocumentManager.Data/StudyDocumentManager.Data.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\StudyDocumentManager.Core\StudyDocumentManager.Core.csproj" />
+    <InternalsVisibleTo Include="StudyDocumentManager.Tests" />
   </ItemGroup>
 
 </Project>

--- a/StudyDocumentManager.Tests/LinuxPlatformPolishTests.cs
+++ b/StudyDocumentManager.Tests/LinuxPlatformPolishTests.cs
@@ -1,0 +1,71 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using StudyDocumentManager.Data.Helpers;
+using StudyDocumentManager.Services;
+using Xunit;
+
+namespace StudyDocumentManager.Tests;
+
+public sealed class LinuxPlatformPolishTests
+{
+    [Fact]
+    public void HaranoAjiFontCollection_ConstructsWithCorrectKey()
+    {
+        var collection = new HaranoAjiFontCollection();
+        Assert.NotNull(collection.Key);
+        Assert.Equal("fonts:HaranoAji", collection.Key.ToString());
+    }
+
+    [Fact]
+    public void DialogService_GetLocalPath_NullItem_ReturnsNull()
+    {
+        var result = DialogService.GetLocalPath(null);
+        Assert.Null(result);
+    }
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData("", null)]
+    [InlineData("   ", null)]
+    [InlineData("/home/user/document.pdf", "/home/user/document.pdf")]
+    [InlineData("file:///home/user/my%20documents/test%20file.pdf", "/home/user/my documents/test file.pdf")]
+    public void DialogService_DecodeStoragePath_DecodesProperly(string? input, string? expected)
+    {
+        var result = DialogService.DecodeStoragePath(input);
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void DialogService_DecodeStoragePath_WindowsUri_NormalizesToLocalPath()
+    {
+        var result = DialogService.DecodeStoragePath("file:///C:/Users/User%20Name/Documents/Doc.pdf");
+        Assert.NotNull(result);
+        Assert.Contains("User Name", result);
+        Assert.DoesNotContain("%20", result);
+    }
+
+    [Fact]
+    public void DatabaseHelper_PathsReferToSameFile_SamePaths_ReturnsTrue()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            var fullPath = Path.GetFullPath(tempFile);
+            var isSame = DatabaseHelper.PathsReferToSameFile(tempFile, fullPath);
+            Assert.True(isSame);
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task ClipboardService_SetTextAsync_DoesNotThrow()
+    {
+        var service = new ClipboardService();
+        await service.SetTextAsync("test clipboard payload");
+    }
+}

--- a/StudyDocumentManager/Services/ClipboardService.cs
+++ b/StudyDocumentManager/Services/ClipboardService.cs
@@ -1,6 +1,7 @@
+using System;
+using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
-using Avalonia.Input.Platform;
 
 namespace StudyDocumentManager.Services;
 
@@ -8,13 +9,20 @@ public class ClipboardService : IClipboardService
 {
     public async Task SetTextAsync(string text)
     {
-        if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+        try
         {
-            var clipboard = desktop.MainWindow?.Clipboard;
-            if (clipboard != null)
+            if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
             {
-                await clipboard.SetTextAsync(text);
+                var clipboard = desktop.MainWindow?.Clipboard;
+                if (clipboard != null)
+                {
+                    await clipboard.SetTextAsync(text ?? string.Empty);
+                }
             }
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[ClipboardService] Failed to set clipboard text: {ex.Message}");
         }
     }
 }

--- a/StudyDocumentManager/Services/DialogService.cs
+++ b/StudyDocumentManager/Services/DialogService.cs
@@ -180,7 +180,7 @@ public class DialogService : IDialogService, IFileDialogService, ICustomDialogSe
         };
 
         var result = await window.StorageProvider.OpenFilePickerAsync(options);
-        return result.Count > 0 ? result[0].Path.LocalPath : null;
+        return result.Count > 0 ? GetLocalPath(result[0]) : null;
     }
 
     public async Task<string?> ShowOpenFolderAsync(string title)
@@ -195,7 +195,7 @@ public class DialogService : IDialogService, IFileDialogService, ICustomDialogSe
         };
 
         var result = await window.StorageProvider.OpenFolderPickerAsync(options);
-        return result.Count > 0 ? result[0].Path.LocalPath : null;
+        return result.Count > 0 ? GetLocalPath(result[0]) : null;
     }
 
     public async Task<string?> ShowSaveFileAsync(string title, string defaultFileName, string? filter = null)
@@ -211,7 +211,33 @@ public class DialogService : IDialogService, IFileDialogService, ICustomDialogSe
         };
 
         var result = await window.StorageProvider.SaveFilePickerAsync(options);
-        return result?.Path.LocalPath;
+        return GetLocalPath(result);
+    }
+
+    internal static string? DecodeStoragePath(string? rawPath)
+    {
+        if (string.IsNullOrWhiteSpace(rawPath))
+            return null;
+
+        var path = rawPath.Trim();
+        if (path.StartsWith("file://", StringComparison.OrdinalIgnoreCase) &&
+            Uri.TryCreate(path, UriKind.Absolute, out var uri))
+        {
+            path = uri.LocalPath;
+        }
+
+        return string.IsNullOrWhiteSpace(path) ? null : Uri.UnescapeDataString(path);
+    }
+
+    internal static string? GetLocalPath(IStorageItem? item)
+    {
+        if (item == null) return null;
+        var localPath = item.TryGetLocalPath();
+        if (string.IsNullOrEmpty(localPath) && item.Path != null)
+        {
+            localPath = item.Path.IsAbsoluteUri ? item.Path.LocalPath : item.Path.ToString();
+        }
+        return DecodeStoragePath(localPath);
     }
 
     public async Task<string?> ShowChangeCategoryAsync(string documentName, IList<string> existingCategories, string currentCategory)

--- a/StudyDocumentManager/Services/HaranoAjiFontCollection.cs
+++ b/StudyDocumentManager/Services/HaranoAjiFontCollection.cs
@@ -5,10 +5,12 @@ namespace StudyDocumentManager.Services;
 
 public sealed class HaranoAjiFontCollection : EmbeddedFontCollection
 {
+    private static readonly string AssemblyName = typeof(HaranoAjiFontCollection).Assembly.GetName().Name ?? "DocumentManager";
+
     public HaranoAjiFontCollection()
         : base(
             new Uri("fonts:HaranoAji", UriKind.Absolute),
-            new Uri("avares://StudyDocumentManager/Assets/Fonts", UriKind.Absolute))
+            new Uri($"avares://{AssemblyName}/Assets/Fonts", UriKind.Absolute))
     {
     }
 }


### PR DESCRIPTION
## 概要
Linux 環境（Debian / Ubuntu / X11 / Wayland）におけるデスクトップアプリの動作信頼性と整合性を向上させるため、フォント解決・ファイル選択パス正規化・クリップボード安全性・大文字小文字パス比較の4点を最適化します。

## 変更点
1. **埋め込み CJK フォントの動的 URI 解決（HaranoAjiFontCollection.cs）**:
   - アセンブリ名 DocumentManager との不一致を修正し、	ypeof(HaranoAjiFontCollection).Assembly.GetName().Name により vares://DocumentManager/Assets/Fonts を動的解決。日本語フォントが未インストールの Linux minimal 環境でも HaranoAji Gothic が正しくロードされ、文字化け（Tofu）を完全に防止。
2. **ファイル/フォルダ選択ダイアログのパスデコード（DialogService.cs）**:
   - DecodeStoragePath ヘルパーを新設し、ShowOpenFileAsync, ShowOpenFolderAsync, ShowSaveFileAsync において XDG Desktop Portal / URI 形式のパスや URL エンコード（%20 等）を確実にローカル絶対パスへ正規化。
3. **OS 依存のファイルパス等価性比較（DatabaseHelper.cs）**:
   - PathsReferToSameFile において Windows は StringComparison.OrdinalIgnoreCase、Linux/Unix 環境は StringComparison.Ordinal（POSIX 大文字小文字厳密比較）を適用。
4. **クリップボード操作の安全性（ClipboardService.cs）**:
   - Wayland / X11 クリップボードマネージャー不在時やアクセス不可時の例外を安全に捕捉する try-catch ガードを追加。
5. **テストスイートの強化（LinuxPlatformPolishTests.cs）**:
   - フォントコレクション Key 検証、StorageProvider パスデコード単体テスト、パス等価性テストを新設（10/10 PASS）。
   - 全体テストスイート 1,578 件オールグリーン。

## 検証
- dotnet build "StudyDocumentManager.sln" -c Debug — 0 エラー
- LinuxPlatformPolishTests — 10/10 PASS
- 全体テストスイート — 1578/1578 PASS
- GitNexus: detect_changes 実施済（Risk Level: Low）

Refs #65

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves Linux reliability for embedded CJK font loading, file picker paths, clipboard access, and path comparisons. Previously, HaranoAji fonts failed to load on minimal Linux installs, file picker paths with URI/percent-encoding weren't normalized, clipboard errors crashed on Wayland/X11, and path equality used case-insensitive comparison on POSIX systems. Now all four areas behave correctly on Linux and Windows.

- Resolves font URI dynamically from the assembly name so `avares://` points to the correct embedded resource.
- Decodes `file://` URIs and percent-encoded characters when returning paths from open/save dialogs.
- Applies `StringComparison.OrdinalIgnoreCase` on Windows and `StringComparison.Ordinal` on Linux/Unix for file path equality.
- Wraps clipboard `SetTextAsync` in a try-catch that logs failures instead of throwing.
- Adds `LinuxPlatformPolishTests` covering font key, path decoding, path equality, and clipboard safety; all 1,578 tests pass.

Refs #65

<sup>Written for commit 17ad0c3bc16e852bafdccf6bfb1ab68386db66e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hayato-shino05/Document-Manager/pull/81?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adjusts Linux-oriented font resolution, storage-picker path handling, clipboard error handling, and filesystem path comparison, with focused platform tests.
- Derives the embedded CJK font resource URI from the runtime assembly name.
- Normalizes paths returned by open, folder, and save pickers.
- Makes same-path comparison case-sensitive on non-Windows systems.
- Suppresses clipboard-access exceptions and adds platform-polish tests.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The PR should not merge until picker paths preserve literal local filenames and database self-operation guards handle case-insensitive non-Windows filesystems.

The new path normalization can redirect selected local paths by decoding literal percent escapes, while the OS-based case comparison can let aliases of the live database bypass backup and restore safeguards.

**Files Needing Attention:** StudyDocumentManager/Services/DialogService.cs; StudyDocumentManager.Data/Helpers/DatabaseHelper.cs
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| StudyDocumentManager/Services/DialogService.cs | Centralizes picker-path conversion, but URI-decodes already-local paths and can change literal filenames. |
| StudyDocumentManager.Data/Helpers/DatabaseHelper.cs | Corrects ordinary POSIX case handling but weakens database self-operation guards on case-insensitive non-Windows filesystems. |
| StudyDocumentManager/Services/ClipboardService.cs | Makes clipboard writes best-effort by catching platform-access failures. |
| StudyDocumentManager/Services/HaranoAjiFontCollection.cs | Replaces the stale hardcoded font-resource authority with the containing assembly name. |
| StudyDocumentManager.Tests/LinuxPlatformPolishTests.cs | Adds focused regression coverage, although path tests omit literal-percent names and case-insensitive non-Windows filesystems. |
| StudyDocumentManager.Data/StudyDocumentManager.Data.csproj | Exposes data-project internals to the test assembly for direct path-comparison testing. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Storage picker] --> B[IStorageItem]
    B --> C[TryGetLocalPath]
    C --> D[DecodeStoragePath]
    D --> E[Open / import / export / backup]
    F[Backup or restore path] --> G[PathsReferToSameFile]
    G --> H{Same as live database?}
    H -->|No| I[Stage and replace database]
    H -->|Yes| J[Reject operation]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
StudyDocumentManager/Services/DialogService.cs:239
**Local paths are URI-decoded**

When a selected file or directory has a literal percent escape such as `%20` or `%2F` in its name, `GetLocalPath` passes the already-local path to `Uri.UnescapeDataString`, changing which filesystem path is returned. Downstream imports, exports, backups, restores, and existence checks then fail or operate on a different location than the one selected.

### Issue 2
StudyDocumentManager.Data/Helpers/DatabaseHelper.cs:1387-1389
**Filesystem identity follows OS family**

If the application database resides on a case-insensitive non-Windows filesystem, paths differing only by case identify the same file but compare unequal here. This bypasses the self-backup and self-restore guards, allowing the live database to enter staging and replacement processing as though it were a distinct file.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(platform): Linux 環境におけるフォント解決・ファイル選択..."](https://github.com/hayato-shino05/document-manager/commit/17ad0c3bc16e852bafdccf6bfb1ab68386db66e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59800159)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->