### PR TITLE
IValueConverter の ConvertBack における NotSupportedException を修正する

### DIFF
--- a/StudyDocumentManager.Tests/ConverterSafetyTests.cs
+++ b/StudyDocumentManager.Tests/ConverterSafetyTests.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Globalization;
+using Avalonia.Data;
+using StudyDocumentManager.Converters;
+using Xunit;
+
+namespace StudyDocumentManager.Tests;
+
+public sealed class ConverterSafetyTests
+{
+    [Fact]
+    public void FileSizeConverter_Convert_FormatsSizesCorrectly()
+    {
+        var converter = FileSizeConverter.Instance;
+        Assert.Equal("500 B", converter.Convert(500L, typeof(string), null, CultureInfo.InvariantCulture));
+        Assert.Equal("1.5 KB", converter.Convert(1536L, typeof(string), null, CultureInfo.InvariantCulture));
+        Assert.Equal("2.0 MB", converter.Convert(2 * 1024 * 1024L, typeof(string), null, CultureInfo.InvariantCulture));
+        Assert.Equal("1.50 GB", converter.Convert((long)(1.5 * 1024 * 1024 * 1024), typeof(string), null, CultureInfo.InvariantCulture));
+        Assert.Equal(string.Empty, converter.Convert(-1L, typeof(string), null, CultureInfo.InvariantCulture));
+        Assert.Equal(string.Empty, converter.Convert(null, typeof(string), null, CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public void AllConverters_ConvertBack_ReturnsDoNothing_NeverThrows()
+    {
+        // 1. Recovery Converters
+        Assert.Same(BindingOperations.DoNothing, FileSizeConverter.Instance.ConvertBack("1.5 KB", typeof(long), null, CultureInfo.InvariantCulture));
+        Assert.Same(BindingOperations.DoNothing, BackupStatusConverter.Instance.ConvertBack("Valid", typeof(bool), null, CultureInfo.InvariantCulture));
+
+        // 2. Watcher Status Converter
+        Assert.Same(BindingOperations.DoNothing, WatcherStatusLabelConverter.Instance.ConvertBack("Running", typeof(string), null, CultureInfo.InvariantCulture));
+
+        // 3. Lang Display Converter
+        Assert.Same(BindingOperations.DoNothing, LangDisplayConverter.Instance.ConvertBack("Japanese", typeof(string), null, CultureInfo.InvariantCulture));
+
+        // 4. Document Type Icon Converter
+        Assert.Same(BindingOperations.DoNothing, new DocumentTypeIconConverter().ConvertBack(null, typeof(string), null, CultureInfo.InvariantCulture));
+
+        // 5. Deadline Converters
+        Assert.Same(BindingOperations.DoNothing, DeadlineBrushConverter.Instance.ConvertBack(null, typeof(DateTime), null, CultureInfo.InvariantCulture));
+        Assert.Same(BindingOperations.DoNothing, DeadlineTextConverter.Instance.ConvertBack(null, typeof(DateTime), null, CultureInfo.InvariantCulture));
+        Assert.Same(BindingOperations.DoNothing, DeadlineStatusConverter.Instance.ConvertBack("Overdue", typeof(DateTime), null, CultureInfo.InvariantCulture));
+
+        // 6. Dashboard Filter Label Converter
+        Assert.Same(BindingOperations.DoNothing, DashboardFilterLabelConverter.Instance.ConvertBack("Filter", typeof(string), null, CultureInfo.InvariantCulture));
+    }
+}

--- a/StudyDocumentManager/Converters/DashboardFilterLabelConverter.cs
+++ b/StudyDocumentManager/Converters/DashboardFilterLabelConverter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Globalization;
 using Avalonia;
+using Avalonia.Data;
 using Avalonia.Data.Converters;
 using StudyDocumentManager.Core.Interfaces;
 
@@ -22,5 +23,5 @@ public sealed class DashboardFilterLabelConverter : IValueConverter
     }
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
-        => throw new NotSupportedException();
+        => BindingOperations.DoNothing;
 }

--- a/StudyDocumentManager/Converters/DeadlineBrushConverter.cs
+++ b/StudyDocumentManager/Converters/DeadlineBrushConverter.cs
@@ -53,9 +53,7 @@ public class DeadlineBrushConverter : IValueConverter
     }
 
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
-    {
-        throw new NotSupportedException();
-    }
+        => Avalonia.Data.BindingOperations.DoNothing;
 }
 
 /// <summary>
@@ -89,9 +87,7 @@ public class DeadlineTextConverter : IValueConverter
     }
 
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
-    {
-        throw new NotSupportedException();
-    }
+        => Avalonia.Data.BindingOperations.DoNothing;
 }
 
 public sealed class DeadlineStatusConverter : IValueConverter
@@ -124,5 +120,5 @@ public sealed class DeadlineStatusConverter : IValueConverter
     }
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
-        => throw new NotSupportedException();
+        => Avalonia.Data.BindingOperations.DoNothing;
 }

--- a/StudyDocumentManager/Converters/DocumentTypeIconConverter.cs
+++ b/StudyDocumentManager/Converters/DocumentTypeIconConverter.cs
@@ -138,7 +138,7 @@ public class DocumentTypeIconConverter : IValueConverter
     }
 
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
-        => throw new NotImplementedException();
+        => Avalonia.Data.BindingOperations.DoNothing;
 
     // ── Loaders ──────────────────────────────────────────────────────────────
 

--- a/StudyDocumentManager/Converters/LangDisplayConverter.cs
+++ b/StudyDocumentManager/Converters/LangDisplayConverter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Globalization;
+using Avalonia.Data;
 using Avalonia.Data.Converters;
 using StudyDocumentManager.Core;
 
@@ -27,7 +28,5 @@ public class LangDisplayConverter : IValueConverter
     }
 
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
-    {
-        throw new NotSupportedException();
-    }
+        => BindingOperations.DoNothing;
 }

--- a/StudyDocumentManager/Converters/RecoveryConverters.cs
+++ b/StudyDocumentManager/Converters/RecoveryConverters.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Globalization;
+using Avalonia.Data;
 using Avalonia.Data.Converters;
 using StudyDocumentManager.Core.Interfaces;
 
@@ -26,7 +28,7 @@ public sealed class FileSizeConverter : IValueConverter
     }
 
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
-        => throw new NotSupportedException();
+        => BindingOperations.DoNothing;
 }
 
 /// <summary>
@@ -45,5 +47,5 @@ public sealed class BackupStatusConverter : IValueConverter
     }
 
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
-        => throw new NotSupportedException();
+        => BindingOperations.DoNothing;
 }

--- a/StudyDocumentManager/Converters/WatcherStatusLabelConverter.cs
+++ b/StudyDocumentManager/Converters/WatcherStatusLabelConverter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Globalization;
 using Avalonia;
+using Avalonia.Data;
 using Avalonia.Data.Converters;
 using StudyDocumentManager.Core.Entities;
 using StudyDocumentManager.Core.Interfaces;
@@ -37,5 +38,5 @@ public sealed class WatcherStatusLabelConverter : IValueConverter
     }
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
-        => throw new NotSupportedException();
+        => BindingOperations.DoNothing;
 }

--- a/StudyDocumentManager/Views/RecoveryCenterView.axaml
+++ b/StudyDocumentManager/Views/RecoveryCenterView.axaml
@@ -111,8 +111,8 @@
                                             </DataTemplate>
                                         </DataGridTemplateColumn.CellTemplate>
                                     </DataGridTemplateColumn>
-                                    <DataGridTextColumn Header="{loc:Localize RC_ColCreated}" Binding="{Binding CreatedAtLocal, StringFormat=\{0:yyyy-MM-dd HH:mm:ss\}}" Width="170"/>
-                                    <DataGridTextColumn Header="{loc:Localize RC_ColSize}" Binding="{Binding SizeBytes, Converter={x:Static conv:FileSizeConverter.Instance}}" Width="90"/>
+                                    <DataGridTextColumn Header="{loc:Localize RC_ColCreated}" Binding="{Binding CreatedAtLocal, Mode=OneWay, StringFormat=\{0:yyyy-MM-dd HH:mm:ss\}}" IsReadOnly="True" Width="170"/>
+                                    <DataGridTextColumn Header="{loc:Localize RC_ColSize}" Binding="{Binding SizeBytes, Mode=OneWay, Converter={x:Static conv:FileSizeConverter.Instance}}" IsReadOnly="True" Width="90"/>
                                     <DataGridTemplateColumn Header="{loc:Localize RC_ColStatus}" Width="110">
                                         <DataGridTemplateColumn.CellTemplate>
                                             <DataTemplate x:DataType="core:BackupVersionInfo">


### PR DESCRIPTION
## 概要
Avalonia の双方向バインディングや DataGrid カラムバインディングの評価時に IValueConverter.ConvertBack が呼び出され、NotSupportedException（HResult: x80131515）によりアプリがクラッシュする問題を修正します。

## 根本原因
- RecoveryConverters.cs（FileSizeConverter, BackupStatusConverter）やその他の表示専用コンバータにおいて、ConvertBack が 	hrow new NotSupportedException() を返していたため、Avalonia の UntypedBindingExpressionBase.ConvertBack 呼び出し時にクラッシュが発生していました。
- RecoveryCenterView.axaml の DataGridTextColumn において、Mode=OneWay および IsReadOnly="True" の明示が不足していました。

## 変更点
1. **IValueConverter 実装の ConvertBack 安全化**:
   - FileSizeConverter, BackupStatusConverter（RecoveryConverters.cs）
   - WatcherStatusLabelConverter.cs
   - LangDisplayConverter.cs
   - DocumentTypeIconConverter.cs
   - DeadlineBrushConverter.cs（DeadlineBrushConverter, DeadlineTextConverter, DeadlineStatusConverter）
   - DashboardFilterLabelConverter.cs
   - すべての ConvertBack を例外スローから Avalonia.Data.BindingOperations.DoNothing を返す安全な実装へ変更。
2. **RecoveryCenterView.axaml**:
   - DataGridTextColumn に IsReadOnly="True" および Mode=OneWay を明示。
3. **テスト追加（ConverterSafetyTests.cs）**:
   - 全コンバータの ConvertBack が例外をスローせず BindingOperations.DoNothing を返すこと、および FileSizeConverter の正常フォーマットを検証（2/2 PASS）。

## 検証
- dotnet test — ConverterSafetyTests, ViewVisualEvaluationTests, RecoveryCenterTests 55/55 PASS
- GitNexus: detect_changes 実施済（Risk Level: Low）

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes app crashes from `IValueConverter.ConvertBack` throwing during Avalonia binding evaluation. Converters now return `BindingOperations.DoNothing` instead of throwing, and `RecoveryCenterView` DataGrid columns are explicitly read-only and one-way.

**Bug Fixes**
- Display-only converters (`FileSizeConverter`, `BackupStatusConverter`, `WatcherStatusLabelConverter`, `LangDisplayConverter`, `DocumentTypeIconConverter`, `DeadlineBrushConverter`, `DeadlineTextConverter`, `DeadlineStatusConverter`, `DashboardFilterLabelConverter`) return `BindingOperations.DoNothing` from `ConvertBack`.
- `RecoveryCenterView` DataGridTextColumns now set `Mode=OneWay` and `IsReadOnly="True"` to prevent two-way binding evaluation.
- Added `ConverterSafetyTests` verifying every `ConvertBack` returns `BindingOperations.DoNothing` without throwing.

<sup>Written for commit d93935557d85a195fc09b1d10cef6f3c8dc72d8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hayato-shino05/Document-Manager/pull/82?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR prevents display-only converters from throwing when Avalonia invokes `ConvertBack` and explicitly marks two recovery-grid bindings as one-way and read-only.
- Replaces exception-throwing `ConvertBack` implementations with `BindingOperations.DoNothing` across nine converters.
- Makes the recovery timestamp and file-size columns explicitly one-way and read-only.
- Adds focused tests for converter reverse-path safety and file-size formatting.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or non-blocking defect identified in the changed behavior.

The converters use the valid Avalonia no-update sentinel for display-only reverse paths, and the recovery-grid binding changes preserve the existing read-only behavior.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| StudyDocumentManager/Converters/RecoveryConverters.cs | File-size and backup-status converters now safely decline reverse updates using Avalonia’s no-update sentinel. |
| StudyDocumentManager/Converters/DashboardFilterLabelConverter.cs | The display-label converter now returns `BindingOperations.DoNothing` instead of throwing during reverse evaluation. |
| StudyDocumentManager/Converters/DeadlineBrushConverter.cs | All three deadline display converters now safely ignore reverse conversion attempts. |
| StudyDocumentManager/Converters/DocumentTypeIconConverter.cs | Icon reverse conversion now returns Avalonia’s no-update sentinel rather than throwing. |
| StudyDocumentManager/Converters/LangDisplayConverter.cs | Language display conversion now safely declines source updates. |
| StudyDocumentManager/Converters/WatcherStatusLabelConverter.cs | Watcher status reverse evaluation no longer raises an exception. |
| StudyDocumentManager/Views/RecoveryCenterView.axaml | Timestamp and size columns are explicitly one-way and read-only, consistent with the already read-only grid and immutable row model. |
| StudyDocumentManager.Tests/ConverterSafetyTests.cs | New tests assert no-update behavior for every changed converter and verify representative file-size formatting. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(desktop): IValueConverter の ConvertB..."](https://github.com/hayato-shino05/document-manager/commit/d93935557d85a195fc09b1d10cef6f3c8dc72d8f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59821318)</sub>

<!-- /greptile_comment -->