### PR TITLE
5ステップのクイックツアーと機能ガイド・ショートカット一覧を追加する

### DIFF
--- a/StudyDocumentManager.Tests/OnboardingModelTests.cs
+++ b/StudyDocumentManager.Tests/OnboardingModelTests.cs
@@ -60,4 +60,80 @@ public sealed class OnboardingModelTests
         Assert.Equal(1, completed);
         Assert.False(new OnboardingModel(settings).ShouldShow);
     }
+
+    [Fact]
+    public void Step_navigation_walks_through_all_5_steps_and_completes()
+    {
+        var settings = new InMemorySettingsService();
+        var model = new OnboardingModel(settings);
+        var completed = 0;
+        model.Completed += (_, _) => completed++;
+
+        Assert.Equal(0, model.CurrentStepIndex);
+        Assert.Equal(5, model.TotalSteps);
+        Assert.False(model.CanGoPrevious);
+        Assert.True(model.CanGoNext);
+        Assert.False(model.IsLastStep);
+        Assert.Equal("1 / 5", model.StepNumberText);
+        Assert.Equal(20.0, model.StepProgress);
+        Assert.True(model.IsStep0);
+
+        // Previous on step 0 does nothing
+        model.PreviousStepCommand.Execute(null);
+        Assert.Equal(0, model.CurrentStepIndex);
+
+        // Step 1
+        model.NextStepCommand.Execute(null);
+        Assert.Equal(1, model.CurrentStepIndex);
+        Assert.True(model.CanGoPrevious);
+        Assert.True(model.CanGoNext);
+        Assert.True(model.IsStep1);
+        Assert.Equal("2 / 5", model.StepNumberText);
+        Assert.Equal(40.0, model.StepProgress);
+
+        // Step 2
+        model.NextStepCommand.Execute(null);
+        Assert.Equal(2, model.CurrentStepIndex);
+        Assert.True(model.IsStep2);
+
+        // Step 3
+        model.NextStepCommand.Execute(null);
+        Assert.Equal(3, model.CurrentStepIndex);
+        Assert.True(model.IsStep3);
+
+        // Step 4 (Last Step)
+        model.NextStepCommand.Execute(null);
+        Assert.Equal(4, model.CurrentStepIndex);
+        Assert.True(model.IsStep4);
+        Assert.False(model.CanGoNext);
+        Assert.True(model.IsLastStep);
+        Assert.Equal("5 / 5", model.StepNumberText);
+        Assert.Equal(100.0, model.StepProgress);
+
+        // Next on last step completes
+        model.NextStepCommand.Execute(null);
+        Assert.Equal(1, completed);
+        Assert.Equal("true", settings.GetSetting(OnboardingModel.CompletionKey));
+    }
+
+    [Fact]
+    public void GoToStep_jumps_to_valid_indices()
+    {
+        var settings = new InMemorySettingsService();
+        var model = new OnboardingModel(settings);
+
+        model.GoToStepCommand.Execute(3);
+        Assert.Equal(3, model.CurrentStepIndex);
+        Assert.True(model.IsStep3);
+
+        model.GoToStepCommand.Execute(10); // Out of bounds
+        Assert.Equal(3, model.CurrentStepIndex);
+
+        model.GoToStepCommand.Execute(-1); // Out of bounds
+        Assert.Equal(3, model.CurrentStepIndex);
+
+        model.GoToStepCommand.Execute(0);
+        Assert.Equal(0, model.CurrentStepIndex);
+        Assert.True(model.IsStep0);
+    }
 }

--- a/StudyDocumentManager/Models/OnboardingModel.cs
+++ b/StudyDocumentManager/Models/OnboardingModel.cs
@@ -7,8 +7,38 @@ namespace StudyDocumentManager.Models;
 public partial class OnboardingModel : ModelBase
 {
     public const string CompletionKey = "onboarding_completed";
+    public const int TotalStepsCount = 5;
 
     private readonly ISettingsService _settingsService;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CanGoPrevious))]
+    [NotifyPropertyChangedFor(nameof(CanGoNext))]
+    [NotifyPropertyChangedFor(nameof(IsLastStep))]
+    [NotifyPropertyChangedFor(nameof(StepNumberText))]
+    [NotifyPropertyChangedFor(nameof(StepProgress))]
+    [NotifyPropertyChangedFor(nameof(IsStep0))]
+    [NotifyPropertyChangedFor(nameof(IsStep1))]
+    [NotifyPropertyChangedFor(nameof(IsStep2))]
+    [NotifyPropertyChangedFor(nameof(IsStep3))]
+    [NotifyPropertyChangedFor(nameof(IsStep4))]
+    private int _currentStepIndex;
+
+    [ObservableProperty]
+    private int _selectedTabIndex;
+
+    public int TotalSteps => TotalStepsCount;
+    public bool CanGoPrevious => CurrentStepIndex > 0;
+    public bool CanGoNext => CurrentStepIndex < TotalStepsCount - 1;
+    public bool IsLastStep => CurrentStepIndex == TotalStepsCount - 1;
+    public string StepNumberText => $"{CurrentStepIndex + 1} / {TotalStepsCount}";
+    public double StepProgress => (double)(CurrentStepIndex + 1) / TotalStepsCount * 100.0;
+
+    public bool IsStep0 => CurrentStepIndex == 0;
+    public bool IsStep1 => CurrentStepIndex == 1;
+    public bool IsStep2 => CurrentStepIndex == 2;
+    public bool IsStep3 => CurrentStepIndex == 3;
+    public bool IsStep4 => CurrentStepIndex == 4;
 
     public bool ShouldShow => !string.Equals(
         _settingsService.GetSetting(CompletionKey),
@@ -20,6 +50,37 @@ public partial class OnboardingModel : ModelBase
     public OnboardingModel(ISettingsService settingsService)
     {
         _settingsService = settingsService;
+    }
+
+    [RelayCommand]
+    private void NextStep()
+    {
+        if (CurrentStepIndex < TotalStepsCount - 1)
+        {
+            CurrentStepIndex++;
+        }
+        else
+        {
+            Complete();
+        }
+    }
+
+    [RelayCommand]
+    private void PreviousStep()
+    {
+        if (CurrentStepIndex > 0)
+        {
+            CurrentStepIndex--;
+        }
+    }
+
+    [RelayCommand]
+    private void GoToStep(int stepIndex)
+    {
+        if (stepIndex >= 0 && stepIndex < TotalStepsCount)
+        {
+            CurrentStepIndex = stepIndex;
+        }
     }
 
     [RelayCommand]

--- a/StudyDocumentManager/Resources/Strings.en.resx
+++ b/StudyDocumentManager/Resources/Strings.en.resx
@@ -909,6 +909,40 @@ Please check your network connection.</value></data>
   <data name="OW_Conf_Public" xml:space="preserve"><value>Public</value></data>
   <data name="OW_Conf_Internal" xml:space="preserve"><value>Internal</value></data>
   <data name="OW_Conf_Confidential" xml:space="preserve"><value>Confidential</value></data>
-  <data name="OW_Conf_Restricted" xml:space="preserve"><value>Restricted</value></data>
   <data name="OW_Error_FileNotFound" xml:space="preserve"><value>File not found: {0}</value></data>
+  <data name="Onboarding_TabTour" xml:space="preserve"><value>Quick Tour (5 Steps)</value></data>
+  <data name="Onboarding_TabCatalog" xml:space="preserve"><value>Feature Guide</value></data>
+  <data name="Onboarding_TabShortcuts" xml:space="preserve"><value>Shortcuts</value></data>
+  <data name="Onboarding_Step1_Title" xml:space="preserve"><value>1. Search &amp; Quick Filters</value></data>
+  <data name="Onboarding_Step1_Desc" xml:space="preserve"><value>Search documents instantly by title, author, or tags. Use quick status filters (Urgent, Normal, Completed) to track deadlines effortlessly.</value></data>
+  <data name="Onboarding_Step1_Tip" xml:space="preserve"><value>Tip: Press F5 or Ctrl+R at any time to refresh the view.</value></data>
+  <data name="Onboarding_Step2_Title" xml:space="preserve"><value>2. Add Documents &amp; Drag &amp; Drop</value></data>
+  <data name="Onboarding_Step2_Desc" xml:space="preserve"><value>Click 'Add Document' (Ctrl+N) or simply drag and drop files (PDF, Word, Excel, images) directly from your file manager onto the app window (supported on both Windows and Linux).</value></data>
+  <data name="Onboarding_Step2_Tip" xml:space="preserve"><value>Tip: To import multiple files at once, use 'Batch Import' (Ctrl+Shift+I).</value></data>
+  <data name="Onboarding_Step3_Title" xml:space="preserve"><value>3. Dedicated Workspaces (Office &amp; Student)</value></data>
+  <data name="Onboarding_Step3_Desc" xml:space="preserve"><value>Switch between two specialized workspaces tailored to your needs:&#x0a;・Office Workspace: Manage confidentiality classifications (Public, Internal, Confidential, Restricted) and expiration reminders.&#x0a;・Student Workspace: Track courses, semesters, assignments, and submission deadlines.</value></data>
+  <data name="Onboarding_Step3_Tip" xml:space="preserve"><value>Tip: Switch easily from the Workspaces menu.</value></data>
+  <data name="Onboarding_Step4_Title" xml:space="preserve"><value>4. Duplicate Detection &amp; File Integrity</value></data>
+  <data name="Onboarding_Step4_Desc" xml:space="preserve"><value>Use 'Duplicate Detection' (Ctrl+D) to find and merge duplicate documents. Use 'File Integrity Check' (Ctrl+H) with SHA-256 hashing to detect missing or altered files instantly.</value></data>
+  <data name="Onboarding_Step4_Tip" xml:space="preserve"><value>Tip: Keep your workspace organized and save storage safely.</value></data>
+  <data name="Onboarding_Step5_Title" xml:space="preserve"><value>5. Recycle Bin, Recovery &amp; ZIP Archive</value></data>
+  <data name="Onboarding_Step5_Desc" xml:space="preserve"><value>Deleted documents are safely kept in the 'Recycle Bin' (Ctrl+Shift+R) with multi-select batch restore. 'Recovery Center' provides SQLite backups, and 'Personal Document Archive' allows full ZIP export/import.</value></data>
+  <data name="Onboarding_Step5_Tip" xml:space="preserve"><value>Tip: Regularly create database snapshots in Recovery Center for peace of mind.</value></data>
+  <data name="Onboarding_Next" xml:space="preserve"><value>Next ➔</value></data>
+  <data name="Onboarding_Prev" xml:space="preserve"><value>⬅ Back</value></data>
+  <data name="Onboarding_Start" xml:space="preserve"><value>🎉 Get Started</value></data>
+  <data name="Onboarding_Cat_WatchedFolder_Title" xml:space="preserve"><value>Folder Watcher (Watched Folder)</value></data>
+  <data name="Onboarding_Cat_WatchedFolder_Desc" xml:space="preserve"><value>Monitors chosen folders in background, detecting and importing new files automatically.</value></data>
+  <data name="Onboarding_Cat_Inbox_Title" xml:space="preserve"><value>Import Inbox (Staging Area)</value></data>
+  <data name="Onboarding_Cat_Inbox_Desc" xml:space="preserve"><value>A dedicated space to review and tag newly ingested documents before organizing them.</value></data>
+  <data name="Onboarding_Cat_Reports_Title" xml:space="preserve"><value>Reports &amp; TreeMap Analytics</value></data>
+  <data name="Onboarding_Cat_Reports_Desc" xml:space="preserve"><value>Visual graphs and color TreeMap displaying storage usage and document distribution.</value></data>
+  <data name="Onboarding_Cat_Notes_Title" xml:space="preserve"><value>Personal Notes &amp; Document Relations</value></data>
+  <data name="Onboarding_Cat_Notes_Desc" xml:space="preserve"><value>Attach private notes to any document and establish direct bidirectional relationships.</value></data>
+  <data name="Onboarding_Cat_Archive_Title" xml:space="preserve"><value>Personal Document ZIP Archive</value></data>
+  <data name="Onboarding_Cat_Archive_Desc" xml:space="preserve"><value>Fully packages documents and JSON manifest into a portable ZIP for backup or transfer.</value></data>
+  <data name="Onboarding_Cat_Lang_Title" xml:space="preserve"><value>Multi-Language Switching</value></data>
+  <data name="Onboarding_Cat_Lang_Desc" xml:space="preserve"><value>Instantly switch between Japanese, English, Vietnamese, and Chinese from the top menu.</value></data>
+  <data name="Onboarding_Shortcuts_Title" xml:space="preserve"><value>Global Keyboard Shortcuts</value></data>
+  <data name="Onboarding_Shortcuts_Desc" xml:space="preserve"><value>Boost your daily productivity with instant keyboard access to all major features.</value></data>
 </root>

--- a/StudyDocumentManager/Resources/Strings.en.resx
+++ b/StudyDocumentManager/Resources/Strings.en.resx
@@ -909,6 +909,7 @@ Please check your network connection.</value></data>
   <data name="OW_Conf_Public" xml:space="preserve"><value>Public</value></data>
   <data name="OW_Conf_Internal" xml:space="preserve"><value>Internal</value></data>
   <data name="OW_Conf_Confidential" xml:space="preserve"><value>Confidential</value></data>
+  <data name="OW_Conf_Restricted" xml:space="preserve"><value>Restricted</value></data>
   <data name="OW_Error_FileNotFound" xml:space="preserve"><value>File not found: {0}</value></data>
   <data name="Onboarding_TabTour" xml:space="preserve"><value>Quick Tour (5 Steps)</value></data>
   <data name="Onboarding_TabCatalog" xml:space="preserve"><value>Feature Guide</value></data>
@@ -920,7 +921,7 @@ Please check your network connection.</value></data>
   <data name="Onboarding_Step2_Desc" xml:space="preserve"><value>Click 'Add Document' (Ctrl+N) or simply drag and drop files (PDF, Word, Excel, images) directly from your file manager onto the app window (supported on both Windows and Linux).</value></data>
   <data name="Onboarding_Step2_Tip" xml:space="preserve"><value>Tip: To import multiple files at once, use 'Batch Import' (Ctrl+Shift+I).</value></data>
   <data name="Onboarding_Step3_Title" xml:space="preserve"><value>3. Dedicated Workspaces (Office &amp; Student)</value></data>
-  <data name="Onboarding_Step3_Desc" xml:space="preserve"><value>Switch between two specialized workspaces tailored to your needs:&#x0a;・Office Workspace: Manage confidentiality classifications (Public, Internal, Confidential, Restricted) and expiration reminders.&#x0a;・Student Workspace: Track courses, semesters, assignments, and submission deadlines.</value></data>
+  <data name="Onboarding_Step3_Desc" xml:space="preserve"><value>Switch between two specialized workspaces tailored to your needs:&#x0a;- Office Workspace: Manage confidentiality classifications (Public, Internal, Confidential, Restricted) and expiration reminders.&#x0a;- Student Workspace: Track courses, semesters, assignments, and submission deadlines.</value></data>
   <data name="Onboarding_Step3_Tip" xml:space="preserve"><value>Tip: Switch easily from the Workspaces menu.</value></data>
   <data name="Onboarding_Step4_Title" xml:space="preserve"><value>4. Duplicate Detection &amp; File Integrity</value></data>
   <data name="Onboarding_Step4_Desc" xml:space="preserve"><value>Use 'Duplicate Detection' (Ctrl+D) to find and merge duplicate documents. Use 'File Integrity Check' (Ctrl+H) with SHA-256 hashing to detect missing or altered files instantly.</value></data>

--- a/StudyDocumentManager/Resources/Strings.resx
+++ b/StudyDocumentManager/Resources/Strings.resx
@@ -1019,6 +1019,41 @@
   <data name="OW_Conf_Confidential" xml:space="preserve"><value>機密</value></data>
   <data name="OW_Conf_Restricted" xml:space="preserve"><value>極秘</value></data>
   <data name="OW_Error_FileNotFound" xml:space="preserve"><value>ファイルが見つかりません: {0}</value></data>
+  <data name="Onboarding_TabTour" xml:space="preserve"><value>クイックツアー (5ステップ)</value></data>
+  <data name="Onboarding_TabCatalog" xml:space="preserve"><value>機能ガイド</value></data>
+  <data name="Onboarding_TabShortcuts" xml:space="preserve"><value>ショートカット一覧</value></data>
+  <data name="Onboarding_Step1_Title" xml:space="preserve"><value>1. 検索とクイックフィルター</value></data>
+  <data name="Onboarding_Step1_Desc" xml:space="preserve"><value>ダッシュボードでは、タイトル・著者・タグで即座に文書を検索できます。緊急・通常・完了などのクイックフィルターで期限管理もスムーズに行えます。</value></data>
+  <data name="Onboarding_Step1_Tip" xml:space="preserve"><value>ヒント: F5 または Ctrl+R でいつでも表示を最新状態に更新できます。</value></data>
+  <data name="Onboarding_Step2_Title" xml:space="preserve"><value>2. 文書の追加とドラッグ＆ドロップ</value></data>
+  <data name="Onboarding_Step2_Desc" xml:space="preserve"><value>「文書追加」ボタン（Ctrl+N）のほか、エクスプローラーやLinuxファイルマネージャーからファイルを直接画面にドラッグ＆ドロップして即座に登録できます（PDF、Word、Excel、画像などに対応）。</value></data>
+  <data name="Onboarding_Step2_Tip" xml:space="preserve"><value>ヒント: 複数ファイルを一度に登録したい場合は「一括インポート」（Ctrl+Shift+I）が便利です。</value></data>
+  <data name="Onboarding_Step3_Title" xml:space="preserve"><value>3. 専用ワークスペース（業務・学習）</value></data>
+  <data name="Onboarding_Step3_Desc" xml:space="preserve"><value>用途に合わせて2つの専門ワークスペースを活用できます：&#x0a;・Office Workspace: 機密レベル区分（公開・社内・機密・極秘）や期日リマインダーを管理。&#x0a;・Student Workspace: 科目、学期、課題提出期限と進捗を管理。</value></data>
+  <data name="Onboarding_Step3_Tip" xml:space="preserve"><value>ヒント: ワークスペースメニューからワンクリックで切り替えられます。</value></data>
+  <data name="Onboarding_Step4_Title" xml:space="preserve"><value>4. 重複検出と整合性チェック</value></data>
+  <data name="Onboarding_Step4_Desc" xml:space="preserve"><value>「重複検出」（Ctrl+D）で同一内容のファイルを整理・マージできます。「整合性チェック」（Ctrl+H）ではSHA-256ハッシュを用いてファイルの欠損や破損を素早く発見します。</value></data>
+  <data name="Onboarding_Step4_Tip" xml:space="preserve"><value>ヒント: 整理後は不要なファイルを安全に整理してディスク容量を節約できます。</value></data>
+  <data name="Onboarding_Step5_Title" xml:space="preserve"><value>5. ごみ箱・復元とZIPアーカイブ</value></data>
+  <data name="Onboarding_Step5_Desc" xml:space="preserve"><value>削除した文書は「ごみ箱」（Ctrl+Shift+R）で安全に保持され、複数選択で一括復元できます。「リカバリーセンター」ではデータベースの世代バックアップと復元、さらに個人文書全体のZIPエクスポート／インポートにも対応しています。</value></data>
+  <data name="Onboarding_Step5_Tip" xml:space="preserve"><value>ヒント: 大切なデータは定期的にリカバリーセンターでバックアップを作成しましょう。</value></data>
+  <data name="Onboarding_Next" xml:space="preserve"><value>次へ ➔</value></data>
+  <data name="Onboarding_Prev" xml:space="preserve"><value>⬅ 戻る</value></data>
+  <data name="Onboarding_Start" xml:space="preserve"><value>🎉 始める</value></data>
+  <data name="Onboarding_Cat_WatchedFolder_Title" xml:space="preserve"><value>フォルダ自動監視 (Watched Folder)</value></data>
+  <data name="Onboarding_Cat_WatchedFolder_Desc" xml:space="preserve"><value>指定したフォルダを常時監視し、新しいファイルが追加されると自動的に検知して登録候補とします。</value></data>
+  <data name="Onboarding_Cat_Inbox_Title" xml:space="preserve"><value>インポート受信トレイ (Import Inbox)</value></data>
+  <data name="Onboarding_Cat_Inbox_Desc" xml:space="preserve"><value>自動取り込みされた文書のメタデータ（カテゴリやタグ）を本登録前に確認・編集する専用スペースです。</value></data>
+  <data name="Onboarding_Cat_Reports_Title" xml:space="preserve"><value>レポートとツリーマップ (Reports &amp; TreeMap)</value></data>
+  <data name="Onboarding_Cat_Reports_Desc" xml:space="preserve"><value>文書のカテゴリ別・種類別の容量や件数分布を視覚的なグラフとカラーツリーマップで直感的に把握できます。</value></data>
+  <data name="Onboarding_Cat_Notes_Title" xml:space="preserve"><value>個人メモと関連文書 (Personal Notes &amp; Relations)</value></data>
+  <data name="Onboarding_Cat_Notes_Desc" xml:space="preserve"><value>文書ごとにプライベートなメモを記録したり、関連する文書同士を直接リンクして双方向に行き来できます。</value></data>
+  <data name="Onboarding_Cat_Archive_Title" xml:space="preserve"><value>個人文書ZIPアーカイブ (Archive Service)</value></data>
+  <data name="Onboarding_Cat_Archive_Desc" xml:space="preserve"><value>文書実体とマニフェスト情報を1つのZIPファイルへ完全にエクスポートし、別のPCへ安全に移送・インポートできます。</value></data>
+  <data name="Onboarding_Cat_Lang_Title" xml:space="preserve"><value>4言語リアルタイム切り替え (Localization)</value></data>
+  <data name="Onboarding_Cat_Lang_Desc" xml:space="preserve"><value>日本語、English、Tiếng Việt、中文 の4言語に対応し、右上のメニューからいつでも即時切り替えが可能です。</value></data>
+  <data name="Onboarding_Shortcuts_Title" xml:space="preserve"><value>操作効率を高めるグローバルショートカット</value></data>
+  <data name="Onboarding_Shortcuts_Desc" xml:space="preserve"><value>キーボード操作だけで主要な全画面へ瞬時にアクセスできます。</value></data>
 </root>
 
 

--- a/StudyDocumentManager/Resources/Strings.vi.resx
+++ b/StudyDocumentManager/Resources/Strings.vi.resx
@@ -1117,7 +1117,40 @@
   <data name="OW_DocNoPrefix" xml:space="preserve"><value>Số: </value></data>
   <data name="OW_Conf_Public" xml:space="preserve"><value>Công khai</value></data>
   <data name="OW_Conf_Internal" xml:space="preserve"><value>Nội bộ</value></data>
-  <data name="OW_Conf_Confidential" xml:space="preserve"><value>Bảo mật</value></data>
-  <data name="OW_Conf_Restricted" xml:space="preserve"><value>Tối mật</value></data>
   <data name="OW_Error_FileNotFound" xml:space="preserve"><value>Không tìm thấy tệp: {0}</value></data>
+  <data name="Onboarding_TabTour" xml:space="preserve"><value>Hướng dẫn từng bước (5 Bước)</value></data>
+  <data name="Onboarding_TabCatalog" xml:space="preserve"><value>Cẩm nang tính năng</value></data>
+  <data name="Onboarding_TabShortcuts" xml:space="preserve"><value>Bảng phím tắt</value></data>
+  <data name="Onboarding_Step1_Title" xml:space="preserve"><value>1. Tìm kiếm &amp; Bộ lọc nhanh</value></data>
+  <data name="Onboarding_Step1_Desc" xml:space="preserve"><value>Tìm kiếm tài liệu siêu tốc theo tiêu đề, tác giả hoặc tag. Sử dụng các bộ lọc trạng thái nhanh (Gấp, Bình thường, Đã xong) để theo dõi hạn nộp dễ dàng.</value></data>
+  <data name="Onboarding_Step1_Tip" xml:space="preserve"><value>Mẹo: Bấm F5 hoặc Ctrl+R bất kỳ lúc nào để làm mới dữ liệu.</value></data>
+  <data name="Onboarding_Step2_Title" xml:space="preserve"><value>2. Thêm tài liệu &amp; Kéo thả tệp</value></data>
+  <data name="Onboarding_Step2_Desc" xml:space="preserve"><value>Bấm nút 'Thêm tài liệu' (Ctrl+N) hoặc chỉ cần kéo và thả trực tiếp tệp (PDF, Word, Excel, hình ảnh...) từ máy tính vào cửa sổ ứng dụng (hỗ trợ mượt mà trên cả Windows và Linux).</value></data>
+  <data name="Onboarding_Step2_Tip" xml:space="preserve"><value>Mẹo: Để nhập hàng loạt nhiều tệp cùng lúc, hãy dùng tính năng 'Nhập hàng loạt' (Ctrl+Shift+I).</value></data>
+  <data name="Onboarding_Step3_Title" xml:space="preserve"><value>3. Không gian làm việc chuyên biệt (Nghiệp vụ &amp; Học tập)</value></data>
+  <data name="Onboarding_Step3_Desc" xml:space="preserve"><value>Chuyển đổi linh hoạt giữa 2 không gian làm việc chuyên biệt theo nhu cầu:&#x0a;・Office Workspace: Quản lý cấp độ bảo mật (Công khai, Nội bộ, Mật, Tối mật) và thông báo nhắc hạn.&#x0a;・Student Workspace: Quản lý môn học, học kỳ, bài tập lớn và tiến độ nộp bài.</value></data>
+  <data name="Onboarding_Step3_Tip" xml:space="preserve"><value>Mẹo: Chuyển đổi nhanh chóng từ menu Workspaces.</value></data>
+  <data name="Onboarding_Step4_Title" xml:space="preserve"><value>4. Phát hiện trùng lặp &amp; Kiểm tra toàn vẹn</value></data>
+  <data name="Onboarding_Step4_Desc" xml:space="preserve"><value>Dùng 'Phát hiện trùng lặp' (Ctrl+D) để tìm và gộp các tệp trùng nhau. Dùng 'Kiểm tra toàn vẹn' (Ctrl+H) với mã băm SHA-256 để phát hiện ngay các tệp bị lỗi hoặc bị đổi vị trí.</value></data>
+  <data name="Onboarding_Step4_Tip" xml:space="preserve"><value>Mẹo: Giữ cho kho tài liệu luôn gọn gàng và tiết kiệm dung lượng ổ đĩa.</value></data>
+  <data name="Onboarding_Step5_Title" xml:space="preserve"><value>5. Thùng rác, Phục hồi &amp; Gói lưu trữ ZIP</value></data>
+  <data name="Onboarding_Step5_Desc" xml:space="preserve"><value>Tài liệu khi xóa được giữ an toàn trong 'Thùng rác' (Ctrl+Shift+R) với tính năng khôi phục hàng loạt. 'Trung tâm Phục hồi' giúp sao lưu CSDL, cùng tính năng xuất/nhập gói ZIP lưu trữ cá nhân tiện lợi.</value></data>
+  <data name="Onboarding_Step5_Tip" xml:space="preserve"><value>Mẹo: Thường xuyên tạo bản sao lưu trong Trung tâm Phục hồi để an tâm tuyệt đối.</value></data>
+  <data name="Onboarding_Next" xml:space="preserve"><value>Tiếp theo ➔</value></data>
+  <data name="Onboarding_Prev" xml:space="preserve"><value>⬅ Quay lại</value></data>
+  <data name="Onboarding_Start" xml:space="preserve"><value>🎉 Bắt đầu sử dụng</value></data>
+  <data name="Onboarding_Cat_WatchedFolder_Title" xml:space="preserve"><value>Thư mục tự động quét (Watched Folder)</value></data>
+  <data name="Onboarding_Cat_WatchedFolder_Desc" xml:space="preserve"><value>Tự động giám sát thư mục trên máy, phát hiện khi có tệp mới xuất hiện để đưa vào hệ thống.</value></data>
+  <data name="Onboarding_Cat_Inbox_Title" xml:space="preserve"><value>Hộp thư nhập liệu (Import Inbox)</value></data>
+  <data name="Onboarding_Cat_Inbox_Desc" xml:space="preserve"><value>Nơi tạm giữ các tệp vừa nhập tự động để bạn bổ sung Danh mục, Thẻ tag trước khi lưu kho chính.</value></data>
+  <data name="Onboarding_Cat_Reports_Title" xml:space="preserve"><value>Báo cáo &amp; Biểu đồ TreeMap</value></data>
+  <data name="Onboarding_Cat_Reports_Desc" xml:space="preserve"><value>Trực quan hóa dung lượng, tỉ lệ phân bố tài liệu theo Danh mục và Định dạng tệp bằng biểu đồ màu.</value></data>
+  <data name="Onboarding_Cat_Notes_Title" xml:space="preserve"><value>Ghi chú &amp; Liên kết tài liệu</value></data>
+  <data name="Onboarding_Cat_Notes_Desc" xml:space="preserve"><value>Ghi chú điểm quan trọng cho từng tài liệu và tạo liên kết trực tiếp giữa các tài liệu liên quan.</value></data>
+  <data name="Onboarding_Cat_Archive_Title" xml:space="preserve"><value>Gói lưu trữ ZIP cá nhân (Archive Service)</value></data>
+  <data name="Onboarding_Cat_Archive_Desc" xml:space="preserve"><value>Đóng gói toàn bộ tài liệu và manifest thành file ZIP duy nhất để backup hoặc chuyển máy an toàn.</value></data>
+  <data name="Onboarding_Cat_Lang_Title" xml:space="preserve"><value>Chuyển đổi 4 ngôn ngữ (Localization)</value></data>
+  <data name="Onboarding_Cat_Lang_Desc" xml:space="preserve"><value>Chuyển đổi mượt mà ngay trên menu giữa Tiếng Việt, Tiếng Nhật, Tiếng Anh, Tiếng Trung.</value></data>
+  <data name="Onboarding_Shortcuts_Title" xml:space="preserve"><value>Bảng phím tắt toàn năng</value></data>
+  <data name="Onboarding_Shortcuts_Desc" xml:space="preserve"><value>Tăng tốc thao tác hàng ngày với các phím tắt nhanh đến mọi màn hình chính.</value></data>
 </root>

--- a/StudyDocumentManager/Resources/Strings.vi.resx
+++ b/StudyDocumentManager/Resources/Strings.vi.resx
@@ -1117,6 +1117,8 @@
   <data name="OW_DocNoPrefix" xml:space="preserve"><value>Số: </value></data>
   <data name="OW_Conf_Public" xml:space="preserve"><value>Công khai</value></data>
   <data name="OW_Conf_Internal" xml:space="preserve"><value>Nội bộ</value></data>
+  <data name="OW_Conf_Confidential" xml:space="preserve"><value>Bảo mật</value></data>
+  <data name="OW_Conf_Restricted" xml:space="preserve"><value>Tối mật</value></data>
   <data name="OW_Error_FileNotFound" xml:space="preserve"><value>Không tìm thấy tệp: {0}</value></data>
   <data name="Onboarding_TabTour" xml:space="preserve"><value>Hướng dẫn từng bước (5 Bước)</value></data>
   <data name="Onboarding_TabCatalog" xml:space="preserve"><value>Cẩm nang tính năng</value></data>

--- a/StudyDocumentManager/Resources/Strings.zh.resx
+++ b/StudyDocumentManager/Resources/Strings.zh.resx
@@ -1117,6 +1117,8 @@
   <data name="OW_DocNoPrefix" xml:space="preserve"><value>编号: </value></data>
   <data name="OW_Conf_Public" xml:space="preserve"><value>公开</value></data>
   <data name="OW_Conf_Internal" xml:space="preserve"><value>内部</value></data>
+  <data name="OW_Conf_Confidential" xml:space="preserve"><value>机密</value></data>
+  <data name="OW_Conf_Restricted" xml:space="preserve"><value>绝密</value></data>
   <data name="OW_Error_FileNotFound" xml:space="preserve"><value>找不到文件: {0}</value></data>
   <data name="Onboarding_TabTour" xml:space="preserve"><value>快速教程 (5步)</value></data>
   <data name="Onboarding_TabCatalog" xml:space="preserve"><value>功能指南</value></data>

--- a/StudyDocumentManager/Resources/Strings.zh.resx
+++ b/StudyDocumentManager/Resources/Strings.zh.resx
@@ -1117,7 +1117,40 @@
   <data name="OW_DocNoPrefix" xml:space="preserve"><value>编号: </value></data>
   <data name="OW_Conf_Public" xml:space="preserve"><value>公开</value></data>
   <data name="OW_Conf_Internal" xml:space="preserve"><value>内部</value></data>
-  <data name="OW_Conf_Confidential" xml:space="preserve"><value>机密</value></data>
-  <data name="OW_Conf_Restricted" xml:space="preserve"><value>绝密</value></data>
   <data name="OW_Error_FileNotFound" xml:space="preserve"><value>找不到文件: {0}</value></data>
+  <data name="Onboarding_TabTour" xml:space="preserve"><value>快速教程 (5步)</value></data>
+  <data name="Onboarding_TabCatalog" xml:space="preserve"><value>功能指南</value></data>
+  <data name="Onboarding_TabShortcuts" xml:space="preserve"><value>快捷键列表</value></data>
+  <data name="Onboarding_Step1_Title" xml:space="preserve"><value>1. 搜索与快速筛选</value></data>
+  <data name="Onboarding_Step1_Desc" xml:space="preserve"><value>在主界面按标题、作者或标签即时搜索文档。使用快速状态筛选（紧急、普通、已完成）轻松跟踪截止日期。</value></data>
+  <data name="Onboarding_Step1_Tip" xml:space="preserve"><value>提示：随时按 F5 或 Ctrl+R 刷新视图。</value></data>
+  <data name="Onboarding_Step2_Title" xml:space="preserve"><value>2. 添加文档与拖放文件</value></data>
+  <data name="Onboarding_Step2_Desc" xml:space="preserve"><value>点击“添加文档”（Ctrl+N）或直接将文件（PDF、Word、Excel、图片等）从文件管理器拖放到应用窗口中（Windows 和 Linux 均完美支持）。</value></data>
+  <data name="Onboarding_Step2_Tip" xml:space="preserve"><value>提示：如需一次性导入多个文件，请使用“批量导入”（Ctrl+Shift+I）。</value></data>
+  <data name="Onboarding_Step3_Title" xml:space="preserve"><value>3. 专用工作区（办公与学习）</value></data>
+  <data name="Onboarding_Step3_Desc" xml:space="preserve"><value>根据需求在两个专用工作区之间切换：&#x0a;・办公工作区：管理保密级别（公开、内部、机密、绝密）和到期提醒。&#x0a;・学生工作区：跟踪课程、学期、作业和提交截止日期。</value></data>
+  <data name="Onboarding_Step3_Tip" xml:space="preserve"><value>提示：从工作区菜单一键轻松切换。</value></data>
+  <data name="Onboarding_Step4_Title" xml:space="preserve"><value>4. 重复检测与完整性检查</value></data>
+  <data name="Onboarding_Step4_Desc" xml:space="preserve"><value>使用“重复检测”（Ctrl+D）查找并合并重复文档。使用带有 SHA-256 哈希的“完整性检查”（Ctrl+H）即时发现缺失或损坏的文件。</value></data>
+  <data name="Onboarding_Step4_Tip" xml:space="preserve"><value>提示：保持工作区整洁并安全节省磁盘空间。</value></data>
+  <data name="Onboarding_Step5_Title" xml:space="preserve"><value>5. 回收站、恢复中心与ZIP归档</value></data>
+  <data name="Onboarding_Step5_Desc" xml:space="preserve"><value>删除的文档保存在“回收站”（Ctrl+Shift+R）中，支持多选批量恢复。“恢复中心”提供数据库备份与恢复，并支持个人文档 ZIP 导出/导入。</value></data>
+  <data name="Onboarding_Step5_Tip" xml:space="preserve"><value>提示：定期在恢复中心创建数据库快照以确保数据安全。</value></data>
+  <data name="Onboarding_Next" xml:space="preserve"><value>下一步 ➔</value></data>
+  <data name="Onboarding_Prev" xml:space="preserve"><value>⬅ 返回</value></data>
+  <data name="Onboarding_Start" xml:space="preserve"><value>🎉 开始使用</value></data>
+  <data name="Onboarding_Cat_WatchedFolder_Title" xml:space="preserve"><value>文件夹自动监控 (Watched Folder)</value></data>
+  <data name="Onboarding_Cat_WatchedFolder_Desc" xml:space="preserve"><value>在后台持续监控指定文件夹，发现新文件时自动将其列入导入候选。</value></data>
+  <data name="Onboarding_Cat_Inbox_Title" xml:space="preserve"><value>导入收件箱 (Import Inbox)</value></data>
+  <data name="Onboarding_Cat_Inbox_Desc" xml:space="preserve"><value>用于在正式归档前检查并编辑新导入文档的分类与标签。</value></data>
+  <data name="Onboarding_Cat_Reports_Title" xml:space="preserve"><value>报表与树状图统计 (Reports &amp; TreeMap)</value></data>
+  <data name="Onboarding_Cat_Reports_Desc" xml:space="preserve"><value>通过直观的图表和色彩树状图分析各分类与格式文档的存储占用及分布。</value></data>
+  <data name="Onboarding_Cat_Notes_Title" xml:space="preserve"><value>个人笔记与关联文档</value></data>
+  <data name="Onboarding_Cat_Notes_Desc" xml:space="preserve"><value>为每份文档添加私密笔记，并建立关联文档的双向跳转。</value></data>
+  <data name="Onboarding_Cat_Archive_Title" xml:space="preserve"><value>个人文档 ZIP 归档包 (Archive Service)</value></data>
+  <data name="Onboarding_Cat_Archive_Desc" xml:space="preserve"><value>将文档实体与元数据清单打包为单个 ZIP 文件，以便安全备份或迁移。</value></data>
+  <data name="Onboarding_Cat_Lang_Title" xml:space="preserve"><value>多语言实时切换 (Localization)</value></data>
+  <data name="Onboarding_Cat_Lang_Desc" xml:space="preserve"><value>支持日语、英语、越南语、中文，可在右上角菜单即时切换。</value></data>
+  <data name="Onboarding_Shortcuts_Title" xml:space="preserve"><value>全局快捷键</value></data>
+  <data name="Onboarding_Shortcuts_Desc" xml:space="preserve"><value>通过键盘快捷键快速访问核心功能，全面提升日常办公效率。</value></data>
 </root>

--- a/StudyDocumentManager/Views/OnboardingDialog.axaml
+++ b/StudyDocumentManager/Views/OnboardingDialog.axaml
@@ -6,48 +6,370 @@
         x:DataType="vm:OnboardingModel"
         AutomationProperties.AutomationId="Dialog_Onboarding"
         Title="{loc:Localize Onboarding_Title}"
-        Width="560" Height="520"
-        MinWidth="420" MinHeight="420"
+        Width="740" Height="620"
+        MinWidth="600" MinHeight="500"
         WindowStartupLocation="CenterOwner"
         CanResize="True"
         ShowInTaskbar="False"
         Background="{StaticResource ContentBackground}">
     <Grid RowDefinitions="Auto,*,Auto" Margin="24">
-        <StackPanel Grid.Row="0" Spacing="6">
-            <TextBlock Text="{loc:Localize Onboarding_Welcome}"
-                       AutomationProperties.AutomationId="Onboarding_Welcome"
-                       FontSize="{StaticResource FontSizeXl}"
-                       FontWeight="Bold"
-                       Foreground="{StaticResource TextPrimary}" />
-            <TextBlock Text="{loc:Localize Onboarding_Intro}"
-                       TextWrapping="Wrap"
-                       Foreground="{StaticResource TextSecondary}" />
-        </StackPanel>
-        <ScrollViewer Grid.Row="1" Margin="0,20,0,20"
-                      HorizontalScrollBarVisibility="Disabled"
-                      VerticalScrollBarVisibility="Auto">
-            <StackPanel Spacing="14">
-                <TextBlock Text="{loc:Localize Onboarding_StepStorage}" TextWrapping="Wrap" />
-                <TextBlock Text="{loc:Localize Onboarding_StepAdd}" TextWrapping="Wrap" />
-                <TextBlock Text="{loc:Localize Onboarding_StepOrganize}" TextWrapping="Wrap" />
-                <TextBlock Text="{loc:Localize Onboarding_StepBackup}" TextWrapping="Wrap" />
-                <TextBlock Text="{loc:Localize Onboarding_StepRecovery}" TextWrapping="Wrap" />
-                <TextBlock Text="{loc:Localize Onboarding_StepLanguage}" TextWrapping="Wrap" />
+        <!-- Header -->
+        <Grid Grid.Row="0" ColumnDefinitions="*,Auto" Margin="0,0,0,16">
+            <StackPanel Grid.Column="0" Spacing="4">
+                <TextBlock Text="{loc:Localize Onboarding_Welcome}"
+                           AutomationProperties.AutomationId="Onboarding_Welcome"
+                           FontSize="{StaticResource FontSizeXl}"
+                           FontWeight="Bold"
+                           Foreground="{StaticResource TextPrimary}" />
+                <TextBlock Text="{loc:Localize Onboarding_Intro}"
+                           TextWrapping="Wrap"
+                           FontSize="{StaticResource FontSizeSm}"
+                           Foreground="{StaticResource TextSecondary}" />
             </StackPanel>
-        </ScrollViewer>
-        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="10">
-            <Button Name="SkipButton"
+        </Grid>
+
+        <!-- Main Tabs -->
+        <TabControl Grid.Row="1" SelectedIndex="{Binding SelectedTabIndex}" Margin="0,0,0,16">
+            <!-- TAB 1: Quick Tour (5 Steps) -->
+            <TabItem Header="{loc:Localize Onboarding_TabTour}" AutomationProperties.AutomationId="Onboarding_Tab_Tour">
+                <Grid RowDefinitions="Auto,*,Auto" Margin="0,12,0,0">
+                    <!-- Step Progress Header -->
+                    <Grid Grid.Row="0" ColumnDefinitions="Auto,*,Auto" Margin="0,0,0,14" VerticalAlignment="Center">
+                        <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="8">
+                            <Border Background="{StaticResource PrimaryColor}" CornerRadius="12" Padding="10,3">
+                                <TextBlock Text="{Binding StepNumberText}"
+                                           Foreground="White"
+                                           FontWeight="SemiBold"
+                                           FontSize="{StaticResource FontSizeXs}" />
+                            </Border>
+                        </StackPanel>
+                        <ProgressBar Grid.Column="1"
+                                     Margin="16,0"
+                                     Value="{Binding StepProgress}"
+                                     Maximum="100"
+                                     Height="6"
+                                     Foreground="{StaticResource PrimaryColor}"
+                                     Background="{StaticResource SurfaceHover}"
+                                     CornerRadius="3" />
+                    </Grid>
+
+                    <!-- Step Cards Container -->
+                    <Border Grid.Row="1" Classes="card" Background="{StaticResource SurfaceBackground}" CornerRadius="12" Padding="20">
+                        <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+                            <Panel>
+                                <!-- Step 0: Search & Filters -->
+                                <StackPanel Spacing="14" IsVisible="{Binding IsStep0}">
+                                    <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Center">
+                                        <Border Width="40" Height="40" CornerRadius="20" Background="{StaticResource PrimaryLightBrush}">
+                                            <Image Source="{StaticResource IconSearch}" Width="20" Height="20" HorizontalAlignment="Center" VerticalAlignment="Center" />
+                                        </Border>
+                                        <TextBlock Text="{loc:Localize Onboarding_Step1_Title}"
+                                                   FontSize="{StaticResource FontSizeLg}"
+                                                   FontWeight="Bold"
+                                                   Foreground="{StaticResource TextPrimary}"
+                                                   VerticalAlignment="Center" />
+                                    </StackPanel>
+                                    <TextBlock Text="{loc:Localize Onboarding_Step1_Desc}"
+                                               FontSize="{StaticResource FontSizeMd}"
+                                               LineHeight="22"
+                                               TextWrapping="Wrap"
+                                               Foreground="{StaticResource TextPrimary}" />
+                                    <Border Background="{StaticResource SurfaceHover}" CornerRadius="8" Padding="12,10" Margin="0,6,0,0">
+                                        <TextBlock Text="{loc:Localize Onboarding_Step1_Tip}"
+                                                   FontSize="{StaticResource FontSizeSm}"
+                                                   Foreground="{StaticResource PrimaryColor}"
+                                                   TextWrapping="Wrap"
+                                                   FontWeight="Medium" />
+                                    </Border>
+                                </StackPanel>
+
+                                <!-- Step 1: Add Document & Drag and Drop -->
+                                <StackPanel Spacing="14" IsVisible="{Binding IsStep1}">
+                                    <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Center">
+                                        <Border Width="40" Height="40" CornerRadius="20" Background="{StaticResource PrimaryLightBrush}">
+                                            <Image Source="{StaticResource IconAdd}" Width="20" Height="20" HorizontalAlignment="Center" VerticalAlignment="Center" />
+                                        </Border>
+                                        <TextBlock Text="{loc:Localize Onboarding_Step2_Title}"
+                                                   FontSize="{StaticResource FontSizeLg}"
+                                                   FontWeight="Bold"
+                                                   Foreground="{StaticResource TextPrimary}"
+                                                   VerticalAlignment="Center" />
+                                    </StackPanel>
+                                    <TextBlock Text="{loc:Localize Onboarding_Step2_Desc}"
+                                               FontSize="{StaticResource FontSizeMd}"
+                                               LineHeight="22"
+                                               TextWrapping="Wrap"
+                                               Foreground="{StaticResource TextPrimary}" />
+                                    <Border Background="{StaticResource SurfaceHover}" CornerRadius="8" Padding="12,10" Margin="0,6,0,0">
+                                        <TextBlock Text="{loc:Localize Onboarding_Step2_Tip}"
+                                                   FontSize="{StaticResource FontSizeSm}"
+                                                   Foreground="{StaticResource PrimaryColor}"
+                                                   TextWrapping="Wrap"
+                                                   FontWeight="Medium" />
+                                    </Border>
+                                </StackPanel>
+
+                                <!-- Step 2: Dedicated Workspaces -->
+                                <StackPanel Spacing="14" IsVisible="{Binding IsStep2}">
+                                    <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Center">
+                                        <Border Width="40" Height="40" CornerRadius="20" Background="{StaticResource PrimaryLightBrush}">
+                                            <Image Source="{StaticResource IconWorkspaces}" Width="20" Height="20" HorizontalAlignment="Center" VerticalAlignment="Center" />
+                                        </Border>
+                                        <TextBlock Text="{loc:Localize Onboarding_Step3_Title}"
+                                                   FontSize="{StaticResource FontSizeLg}"
+                                                   FontWeight="Bold"
+                                                   Foreground="{StaticResource TextPrimary}"
+                                                   VerticalAlignment="Center" />
+                                    </StackPanel>
+                                    <TextBlock Text="{loc:Localize Onboarding_Step3_Desc}"
+                                               FontSize="{StaticResource FontSizeMd}"
+                                               LineHeight="22"
+                                               TextWrapping="Wrap"
+                                               Foreground="{StaticResource TextPrimary}" />
+                                    <Border Background="{StaticResource SurfaceHover}" CornerRadius="8" Padding="12,10" Margin="0,6,0,0">
+                                        <TextBlock Text="{loc:Localize Onboarding_Step3_Tip}"
+                                                   FontSize="{StaticResource FontSizeSm}"
+                                                   Foreground="{StaticResource PrimaryColor}"
+                                                   TextWrapping="Wrap"
+                                                   FontWeight="Medium" />
+                                    </Border>
+                                </StackPanel>
+
+                                <!-- Step 3: Duplicate & Integrity -->
+                                <StackPanel Spacing="14" IsVisible="{Binding IsStep3}">
+                                    <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Center">
+                                        <Border Width="40" Height="40" CornerRadius="20" Background="{StaticResource PrimaryLightBrush}">
+                                            <Image Source="{StaticResource IconTools}" Width="20" Height="20" HorizontalAlignment="Center" VerticalAlignment="Center" />
+                                        </Border>
+                                        <TextBlock Text="{loc:Localize Onboarding_Step4_Title}"
+                                                   FontSize="{StaticResource FontSizeLg}"
+                                                   FontWeight="Bold"
+                                                   Foreground="{StaticResource TextPrimary}"
+                                                   VerticalAlignment="Center" />
+                                    </StackPanel>
+                                    <TextBlock Text="{loc:Localize Onboarding_Step4_Desc}"
+                                               FontSize="{StaticResource FontSizeMd}"
+                                               LineHeight="22"
+                                               TextWrapping="Wrap"
+                                               Foreground="{StaticResource TextPrimary}" />
+                                    <Border Background="{StaticResource SurfaceHover}" CornerRadius="8" Padding="12,10" Margin="0,6,0,0">
+                                        <TextBlock Text="{loc:Localize Onboarding_Step4_Tip}"
+                                                   FontSize="{StaticResource FontSizeSm}"
+                                                   Foreground="{StaticResource PrimaryColor}"
+                                                   TextWrapping="Wrap"
+                                                   FontWeight="Medium" />
+                                    </Border>
+                                </StackPanel>
+
+                                <!-- Step 4: Recycle Bin & Recovery -->
+                                <StackPanel Spacing="14" IsVisible="{Binding IsStep4}">
+                                    <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Center">
+                                        <Border Width="40" Height="40" CornerRadius="20" Background="{StaticResource PrimaryLightBrush}">
+                                            <Image Source="{StaticResource IconRestore}" Width="20" Height="20" HorizontalAlignment="Center" VerticalAlignment="Center" />
+                                        </Border>
+                                        <TextBlock Text="{loc:Localize Onboarding_Step5_Title}"
+                                                   FontSize="{StaticResource FontSizeLg}"
+                                                   FontWeight="Bold"
+                                                   Foreground="{StaticResource TextPrimary}"
+                                                   VerticalAlignment="Center" />
+                                    </StackPanel>
+                                    <TextBlock Text="{loc:Localize Onboarding_Step5_Desc}"
+                                               FontSize="{StaticResource FontSizeMd}"
+                                               LineHeight="22"
+                                               TextWrapping="Wrap"
+                                               Foreground="{StaticResource TextPrimary}" />
+                                    <Border Background="{StaticResource SurfaceHover}" CornerRadius="8" Padding="12,10" Margin="0,6,0,0">
+                                        <TextBlock Text="{loc:Localize Onboarding_Step5_Tip}"
+                                                   FontSize="{StaticResource FontSizeSm}"
+                                                   Foreground="{StaticResource PrimaryColor}"
+                                                   TextWrapping="Wrap"
+                                                   FontWeight="Medium" />
+                                    </Border>
+                                </StackPanel>
+                            </Panel>
+                        </ScrollViewer>
+                    </Border>
+                </Grid>
+            </TabItem>
+
+            <!-- TAB 2: Feature Guide (Catalog) -->
+            <TabItem Header="{loc:Localize Onboarding_TabCatalog}" AutomationProperties.AutomationId="Onboarding_Tab_Catalog">
+                <ScrollViewer Margin="0,12,0,0" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+                    <StackPanel Spacing="12">
+                        <!-- Watched Folder -->
+                        <Border Classes="card" Background="{StaticResource SurfaceBackground}" CornerRadius="8" Padding="14">
+                            <StackPanel Spacing="6">
+                                <StackPanel Orientation="Horizontal" Spacing="8">
+                                    <Image Source="{StaticResource IconFolder}" Width="18" Height="18" />
+                                    <TextBlock Text="{loc:Localize Onboarding_Cat_WatchedFolder_Title}" FontWeight="SemiBold" Foreground="{StaticResource TextPrimary}" />
+                                </StackPanel>
+                                <TextBlock Text="{loc:Localize Onboarding_Cat_WatchedFolder_Desc}" TextWrapping="Wrap" Foreground="{StaticResource TextSecondary}" FontSize="{StaticResource FontSizeSm}" />
+                            </StackPanel>
+                        </Border>
+
+                        <!-- Import Inbox -->
+                        <Border Classes="card" Background="{StaticResource SurfaceBackground}" CornerRadius="8" Padding="14">
+                            <StackPanel Spacing="6">
+                                <StackPanel Orientation="Horizontal" Spacing="8">
+                                    <Image Source="{StaticResource IconImport}" Width="18" Height="18" />
+                                    <TextBlock Text="{loc:Localize Onboarding_Cat_Inbox_Title}" FontWeight="SemiBold" Foreground="{StaticResource TextPrimary}" />
+                                </StackPanel>
+                                <TextBlock Text="{loc:Localize Onboarding_Cat_Inbox_Desc}" TextWrapping="Wrap" Foreground="{StaticResource TextSecondary}" FontSize="{StaticResource FontSizeSm}" />
+                            </StackPanel>
+                        </Border>
+
+                        <!-- Reports & TreeMap -->
+                        <Border Classes="card" Background="{StaticResource SurfaceBackground}" CornerRadius="8" Padding="14">
+                            <StackPanel Spacing="6">
+                                <StackPanel Orientation="Horizontal" Spacing="8">
+                                    <Image Source="{StaticResource IconReport}" Width="18" Height="18" />
+                                    <TextBlock Text="{loc:Localize Onboarding_Cat_Reports_Title}" FontWeight="SemiBold" Foreground="{StaticResource TextPrimary}" />
+                                </StackPanel>
+                                <TextBlock Text="{loc:Localize Onboarding_Cat_Reports_Desc}" TextWrapping="Wrap" Foreground="{StaticResource TextSecondary}" FontSize="{StaticResource FontSizeSm}" />
+                            </StackPanel>
+                        </Border>
+
+                        <!-- Personal Notes & Relations -->
+                        <Border Classes="card" Background="{StaticResource SurfaceBackground}" CornerRadius="8" Padding="14">
+                            <StackPanel Spacing="6">
+                                <StackPanel Orientation="Horizontal" Spacing="8">
+                                    <Image Source="{StaticResource IconTag}" Width="18" Height="18" />
+                                    <TextBlock Text="{loc:Localize Onboarding_Cat_Notes_Title}" FontWeight="SemiBold" Foreground="{StaticResource TextPrimary}" />
+                                </StackPanel>
+                                <TextBlock Text="{loc:Localize Onboarding_Cat_Notes_Desc}" TextWrapping="Wrap" Foreground="{StaticResource TextSecondary}" FontSize="{StaticResource FontSizeSm}" />
+                            </StackPanel>
+                        </Border>
+
+                        <!-- Archive ZIP -->
+                        <Border Classes="card" Background="{StaticResource SurfaceBackground}" CornerRadius="8" Padding="14">
+                            <StackPanel Spacing="6">
+                                <StackPanel Orientation="Horizontal" Spacing="8">
+                                    <Image Source="{StaticResource IconExport}" Width="18" Height="18" />
+                                    <TextBlock Text="{loc:Localize Onboarding_Cat_Archive_Title}" FontWeight="SemiBold" Foreground="{StaticResource TextPrimary}" />
+                                </StackPanel>
+                                <TextBlock Text="{loc:Localize Onboarding_Cat_Archive_Desc}" TextWrapping="Wrap" Foreground="{StaticResource TextSecondary}" FontSize="{StaticResource FontSizeSm}" />
+                            </StackPanel>
+                        </Border>
+
+                        <!-- Localization -->
+                        <Border Classes="card" Background="{StaticResource SurfaceBackground}" CornerRadius="8" Padding="14">
+                            <StackPanel Spacing="6">
+                                <StackPanel Orientation="Horizontal" Spacing="8">
+                                    <Image Source="{StaticResource IconSettings}" Width="18" Height="18" />
+                                    <TextBlock Text="{loc:Localize Onboarding_Cat_Lang_Title}" FontWeight="SemiBold" Foreground="{StaticResource TextPrimary}" />
+                                </StackPanel>
+                                <TextBlock Text="{loc:Localize Onboarding_Cat_Lang_Desc}" TextWrapping="Wrap" Foreground="{StaticResource TextSecondary}" FontSize="{StaticResource FontSizeSm}" />
+                            </StackPanel>
+                        </Border>
+                    </StackPanel>
+                </ScrollViewer>
+            </TabItem>
+
+            <!-- TAB 3: Shortcuts Cheatsheet -->
+            <TabItem Header="{loc:Localize Onboarding_TabShortcuts}" AutomationProperties.AutomationId="Onboarding_Tab_Shortcuts">
+                <ScrollViewer Margin="0,12,0,0" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+                    <StackPanel Spacing="10">
+                        <TextBlock Text="{loc:Localize Onboarding_Shortcuts_Desc}" Foreground="{StaticResource TextSecondary}" FontSize="{StaticResource FontSizeSm}" Margin="0,0,0,6" />
+                        
+                        <Grid ColumnDefinitions="140,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" Margin="4">
+                            <!-- Row 0: Ctrl+N -->
+                            <Border Grid.Row="0" Grid.Column="0" Background="{StaticResource SurfaceHover}" CornerRadius="4" Padding="6,2" HorizontalAlignment="Left" Margin="0,3">
+                                <TextBlock Text="Ctrl + N" FontWeight="Bold" FontFamily="Consolas, monospace" FontSize="{StaticResource FontSizeSm}" />
+                            </Border>
+                            <TextBlock Grid.Row="0" Grid.Column="1" Text="{loc:Localize Onboarding_Step2_Title}" VerticalAlignment="Center" Margin="8,0" />
+
+                            <!-- Row 1: Ctrl+Shift+I -->
+                            <Border Grid.Row="1" Grid.Column="0" Background="{StaticResource SurfaceHover}" CornerRadius="4" Padding="6,2" HorizontalAlignment="Left" Margin="0,3">
+                                <TextBlock Text="Ctrl + Shift + I" FontWeight="Bold" FontFamily="Consolas, monospace" FontSize="{StaticResource FontSizeSm}" />
+                            </Border>
+                            <TextBlock Grid.Row="1" Grid.Column="1" Text="{loc:Localize Main_Menu_BatchImport}" VerticalAlignment="Center" Margin="8,0" />
+
+                            <!-- Row 2: Ctrl+Shift+R -->
+                            <Border Grid.Row="2" Grid.Column="0" Background="{StaticResource SurfaceHover}" CornerRadius="4" Padding="6,2" HorizontalAlignment="Left" Margin="0,3">
+                                <TextBlock Text="Ctrl + Shift + R" FontWeight="Bold" FontFamily="Consolas, monospace" FontSize="{StaticResource FontSizeSm}" />
+                            </Border>
+                            <TextBlock Grid.Row="2" Grid.Column="1" Text="{loc:Localize Main_Menu_RecycleBin}" VerticalAlignment="Center" Margin="8,0" />
+
+                            <!-- Row 3: Ctrl+D -->
+                            <Border Grid.Row="3" Grid.Column="0" Background="{StaticResource SurfaceHover}" CornerRadius="4" Padding="6,2" HorizontalAlignment="Left" Margin="0,3">
+                                <TextBlock Text="Ctrl + D" FontWeight="Bold" FontFamily="Consolas, monospace" FontSize="{StaticResource FontSizeSm}" />
+                            </Border>
+                            <TextBlock Grid.Row="3" Grid.Column="1" Text="{loc:Localize Main_Menu_DuplicateDetection}" VerticalAlignment="Center" Margin="8,0" />
+
+                            <!-- Row 4: Ctrl+H -->
+                            <Border Grid.Row="4" Grid.Column="0" Background="{StaticResource SurfaceHover}" CornerRadius="4" Padding="6,2" HorizontalAlignment="Left" Margin="0,3">
+                                <TextBlock Text="Ctrl + H" FontWeight="Bold" FontFamily="Consolas, monospace" FontSize="{StaticResource FontSizeSm}" />
+                            </Border>
+                            <TextBlock Grid.Row="4" Grid.Column="1" Text="{loc:Localize Main_Menu_FileIntegrityCheck}" VerticalAlignment="Center" Margin="8,0" />
+
+                            <!-- Row 5: Ctrl+Shift+C -->
+                            <Border Grid.Row="5" Grid.Column="0" Background="{StaticResource SurfaceHover}" CornerRadius="4" Padding="6,2" HorizontalAlignment="Left" Margin="0,3">
+                                <TextBlock Text="Ctrl + Shift + C" FontWeight="Bold" FontFamily="Consolas, monospace" FontSize="{StaticResource FontSizeSm}" />
+                            </Border>
+                            <TextBlock Grid.Row="5" Grid.Column="1" Text="{loc:Localize Main_Menu_CategoryManagement}" VerticalAlignment="Center" Margin="8,0" />
+
+                            <!-- Row 6: Ctrl+Shift+L -->
+                            <Border Grid.Row="6" Grid.Column="0" Background="{StaticResource SurfaceHover}" CornerRadius="4" Padding="6,2" HorizontalAlignment="Left" Margin="0,3">
+                                <TextBlock Text="Ctrl + Shift + L" FontWeight="Bold" FontFamily="Consolas, monospace" FontSize="{StaticResource FontSizeSm}" />
+                            </Border>
+                            <TextBlock Grid.Row="6" Grid.Column="1" Text="{loc:Localize Main_Menu_CollectionManagement}" VerticalAlignment="Center" Margin="8,0" />
+
+                            <!-- Row 7: Alt+Left -->
+                            <Border Grid.Row="7" Grid.Column="0" Background="{StaticResource SurfaceHover}" CornerRadius="4" Padding="6,2" HorizontalAlignment="Left" Margin="0,3">
+                                <TextBlock Text="Alt + Left" FontWeight="Bold" FontFamily="Consolas, monospace" FontSize="{StaticResource FontSizeSm}" />
+                            </Border>
+                            <TextBlock Grid.Row="7" Grid.Column="1" Text="{loc:Localize Main_Menu_BackToDashboard}" VerticalAlignment="Center" Margin="8,0" />
+
+                            <!-- Row 8: F5 / Ctrl+R -->
+                            <Border Grid.Row="8" Grid.Column="0" Background="{StaticResource SurfaceHover}" CornerRadius="4" Padding="6,2" HorizontalAlignment="Left" Margin="0,3">
+                                <TextBlock Text="F5 / Ctrl + R" FontWeight="Bold" FontFamily="Consolas, monospace" FontSize="{StaticResource FontSizeSm}" />
+                            </Border>
+                            <TextBlock Grid.Row="8" Grid.Column="1" Text="{loc:Localize Main_Menu_Refresh}" VerticalAlignment="Center" Margin="8,0" />
+
+                            <!-- Row 9: F1 -->
+                            <Border Grid.Row="9" Grid.Column="0" Background="{StaticResource SurfaceHover}" CornerRadius="4" Padding="6,2" HorizontalAlignment="Left" Margin="0,3">
+                                <TextBlock Text="F1" FontWeight="Bold" FontFamily="Consolas, monospace" FontSize="{StaticResource FontSizeSm}" />
+                            </Border>
+                            <TextBlock Grid.Row="9" Grid.Column="1" Text="{loc:Localize Onboarding_MenuItem}" VerticalAlignment="Center" Margin="8,0" />
+                        </Grid>
+                    </StackPanel>
+                </ScrollViewer>
+            </TabItem>
+        </TabControl>
+
+        <!-- Footer Navigation Controls -->
+        <Grid Grid.Row="2" ColumnDefinitions="Auto,*,Auto" VerticalAlignment="Center">
+            <!-- Left: Skip -->
+            <Button Grid.Column="0"
+                    Name="SkipButton"
                     Content="{loc:Localize Onboarding_Skip}"
                     AutomationProperties.AutomationId="Onboarding_Skip"
                     Classes="secondary"
                     IsCancel="True"
                     Command="{Binding SkipCommand}" />
-            <Button Name="FinishButton"
-                    Content="{loc:Localize Onboarding_Finish}"
-                    AutomationProperties.AutomationId="Onboarding_Finish"
-                    Classes="primary"
-                    IsDefault="True"
-                    Command="{Binding FinishCommand}" />
-        </StackPanel>
+
+            <!-- Right: Step Navigation & Finish -->
+            <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="10">
+                <Button Name="PrevButton"
+                        Content="{loc:Localize Onboarding_Prev}"
+                        AutomationProperties.AutomationId="Onboarding_Prev"
+                        Classes="secondary"
+                        IsVisible="{Binding CanGoPrevious}"
+                        Command="{Binding PreviousStepCommand}" />
+                <Button Name="NextButton"
+                        Content="{loc:Localize Onboarding_Next}"
+                        AutomationProperties.AutomationId="Onboarding_Next"
+                        Classes="primary"
+                        IsVisible="{Binding CanGoNext}"
+                        Command="{Binding NextStepCommand}" />
+                <Button Name="FinishButton"
+                        Content="{loc:Localize Onboarding_Start}"
+                        AutomationProperties.AutomationId="Onboarding_Finish"
+                        Classes="primary"
+                        IsDefault="True"
+                        IsVisible="{Binding IsLastStep}"
+                        Command="{Binding FinishCommand}" />
+            </StackPanel>
+        </Grid>
     </Grid>
 </Window>


### PR DESCRIPTION
## 概要
初回起動時およびヘルプ要求時（F1キー / メニュー）に表示されるオンボーディング画面を大幅に強化し、5ステップの対話型クイックツアー（ドラッグ＆ドロップ対応の明示を含む）、機能カタログ、グローバルショートカット一覧を統合した新しいオンボーディングハブを提供します。

## 主な変更点
1. **5ステップのクイックツアー（Tab 1）**:
   - ステップ進捗インジケーター（プログレスバー、Step X / 5 バッジ、ステップ直接移動）。
   - **Step 1**: 検索とクイックフィルター（タイトル・著者・タグ検索、緊急・通常・完了フィルター）。
   - **Step 2**: 文書の追加とドラッグ＆ドロップ（Ctrl+N、Windows/Linux のファイルマネージャーからの直接ファイルドラッグ＆ドロップ、一括インポート Ctrl+Shift+I を明示）。
   - **Step 3**: 専用ワークスペース（Office Workspace の機密区分・期日リマインダー、Student Workspace の科目・課題提出管理）。
   - **Step 4**: 重複検出と整合性チェック（Ctrl+D 重複検出、Ctrl+H SHA-256 ファイル整合性チェック）。
   - **Step 5**: ごみ箱・復元とZIPアーカイブ（Ctrl+Shift+R ごみ箱一括復元、リカバリーセンター CSDL バックアップ、個人文書 ZIP アーカイブ）。
   - ナビゲーションボタン（スキップ、⬅ 戻る、次へ ➔、🎉 始める）。
2. **機能カタログ（Tab 2）**:
   - フォルダ自動監視（Watched Folder）、インポート受信トレイ（Import Inbox）、レポートとツリーマップ（Reports & TreeMap）、個人メモと関連文書（Notes & Relations）、個人文書 ZIP アーカイブ、4言語リアルタイム切り替えを一覧カード形式で紹介。
3. **ショートカット一覧（Tab 3）**:
   - 日常の操作効率を高める10種類のグローバルショートカットをバッジ形式で整理。
4. **多言語リソース同期**:
   - Strings.resx（日本語）、Strings.en.resx（英語）、Strings.vi.resx（ベトナム語）、Strings.zh.resx（中国語）の4言語すべてに同一の34キーを同期追加。
5. **テスト拡充（OnboardingModelTests.cs）**:
   - 全5ステップの前進・後退・直接ジャンプ・完了状態の永続化を検証するテストを追加（7/7 PASS）。

## 検証
- dotnet test — OnboardingModelTests (7/7 PASS), ViewVisualEvaluationTests (20/20 PASS)
- GitNexus: detect_changes 実施済（Risk Level: Low）

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the static onboarding text list with a tabbed hub: a 5-step interactive quick tour, a feature catalog, and a global shortcut cheatsheet. The dialog grows from 560x520 to 740x620.

**New Features**
- Adds step navigation (next/previous/direct jump) with a progress bar, step badge, and per-step completion state.
- Adds 35 new localization keys across all four language files (`Strings.resx`, `Strings.en.resx`, `Strings.vi.resx`, `Strings.zh.resx`).
- Adds tests for step navigation, out-of-bounds jumps, and completion persistence.

<sup>Written for commit 11f48ae58a430f1abe4aa4c2471fe9f1754b0dd9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hayato-shino05/Document-Manager/pull/83?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces the static onboarding dialog with a localized, tabbed onboarding hub.
- Adds a five-step quick tour with progress and navigation state.
- Adds feature-catalog and keyboard-shortcut tabs.
- Adds synchronized onboarding text across Japanese, English, Vietnamese, and Chinese resources.
- Expands onboarding model tests for navigation and completion persistence.
</details>


<details open><summary><h3>Confidence Score: 2/5</h3></summary>

The PR is not safe to merge because the onboarding dialog still has unresolved resources, its shortcut labels remain untranslated, and six advertised shortcuts navigate to the wrong destination.

Opening onboarding still resolves three undefined icon resources; the shortcut table still resolves eight absent localization keys to bracketed identifiers; and six global bindings pass route strings that NavigationService sends to the dashboard fallback.

**Files Needing Attention:** StudyDocumentManager/Views/OnboardingDialog.axaml, StudyDocumentManager/Views/MainWindow.axaml, StudyDocumentManager/Models/MainWindowModel.cs, StudyDocumentManager/Services/NavigationService.cs
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| StudyDocumentManager/Models/OnboardingModel.cs | Adds bounded five-step navigation state, derived progress properties, and commands for moving between tour steps. |
| StudyDocumentManager/Views/OnboardingDialog.axaml | Replaces the static dialog with the tabbed tour, feature catalog, shortcut table, and step-navigation controls. |
| StudyDocumentManager.Tests/OnboardingModelTests.cs | Adds coverage for forward, backward, direct, out-of-bounds, and completion behavior. |
| StudyDocumentManager/Resources/Strings.resx | Adds Japanese localization for the new onboarding content. |
| StudyDocumentManager/Resources/Strings.en.resx | Adds English onboarding localization and retains the Office Workspace confidentiality labels. |
| StudyDocumentManager/Resources/Strings.vi.resx | Adds Vietnamese onboarding localization and restores the affected confidentiality labels. |
| StudyDocumentManager/Resources/Strings.zh.resx | Adds Chinese onboarding localization and restores the affected confidentiality labels. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Open[Open onboarding] --> Hub[Onboarding hub]
  Hub --> Tour[Five-step quick tour]
  Hub --> Catalog[Feature catalog]
  Hub --> Shortcuts[Shortcut reference]
  Tour --> Complete[Persist completion]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(localization): Strings リソースの全言語キー同期と..."](https://github.com/hayato-shino05/document-manager/commit/11f48ae58a430f1abe4aa4c2471fe9f1754b0dd9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59833285)</sub>

<!-- /greptile_comment -->