### PR TITLE
右クリックメニューの重複メモ項目を削除し絵文字をベクターアイコンに統一する

### DIFF
--- a/StudyDocumentManager.Tests/MainWindowTaxonomyTests.cs
+++ b/StudyDocumentManager.Tests/MainWindowTaxonomyTests.cs
@@ -108,7 +108,6 @@ public sealed class MainWindowTaxonomyTests
             "Context_CopyPath",
             "Context_OpenFolder",
             "Context_EditTags",
-            "Context_EditNotes",
             "Context_MarkImportant",
             "Context_PersonalNote",
             "Context_AddToCollection",

--- a/StudyDocumentManager.Tests/ViewVisualEvaluationTests.cs
+++ b/StudyDocumentManager.Tests/ViewVisualEvaluationTests.cs
@@ -234,4 +234,20 @@ public sealed class ViewVisualEvaluationTests
         var view = new RecoveryCenterView { DataContext = model };
         RenderAndAuditView(view, 1280, 800, "Screen_RecoveryCenter");
     }
+
+    [Avalonia.Headless.XUnit.AvaloniaFact]
+    public void ViewAudit_DashboardContextMenu_IsUnifiedAndHasNoEditNotes()
+    {
+        var dashboard = new Dashboard();
+        var dataGrid = dashboard.FindControl<DataGrid>("dgvDocuments");
+        Assert.NotNull(dataGrid);
+        Assert.NotNull(dataGrid!.ContextMenu);
+
+        var menuItems = dataGrid.ContextMenu!.Items.OfType<MenuItem>().ToList();
+        var editNotes = menuItems.FirstOrDefault(m => AutomationProperties.GetAutomationId(m) == "Context_EditNotes");
+        var personalNote = menuItems.FirstOrDefault(m => AutomationProperties.GetAutomationId(m) == "Context_PersonalNote");
+
+        Assert.Null(editNotes);
+        Assert.NotNull(personalNote);
+    }
 }

--- a/StudyDocumentManager/Themes/AppTheme.axaml
+++ b/StudyDocumentManager/Themes/AppTheme.axaml
@@ -526,6 +526,22 @@
             </DrawingGroup>
         </DrawingImage>
 
+        <!-- Pin: pushpin icon -->
+        <DrawingImage x:Key="IconPin">
+            <DrawingGroup>
+                <GeometryDrawing Brush="{StaticResource BrushIconNeutral}"
+                    Geometry="M16,12 L16,4 L17,4 L17,2 L7,2 L7,4 L8,4 L8,12 L6,14 L6,16 L11,16 L11,22 L13,22 L13,16 L18,16 L18,14 L16,12 Z"/>
+            </DrawingGroup>
+        </DrawingImage>
+
+        <!-- Pin Filled: active pinned icon -->
+        <DrawingImage x:Key="IconPinFilled">
+            <DrawingGroup>
+                <GeometryDrawing Brush="{StaticResource BrushIconStarFill}"
+                    Geometry="M16,12 L16,4 L17,4 L17,2 L7,2 L7,4 L8,4 L8,12 L6,14 L6,16 L11,16 L11,22 L13,22 L13,16 L18,16 L18,14 L16,12 Z"/>
+            </DrawingGroup>
+        </DrawingImage>
+
     </Styles.Resources>
 
     <!-- ══════════════     COMPONENT STYLES     ══════════════ -->

--- a/StudyDocumentManager/Views/Dashboard.axaml
+++ b/StudyDocumentManager/Views/Dashboard.axaml
@@ -503,12 +503,6 @@
                                               ToolTip.Tip="{loc:Localize Dashboard_TipEditTags}">
                                         <MenuItem.Icon><Image Source="{StaticResource IconTag}" Width="14" Height="14"/></MenuItem.Icon>
                                     </MenuItem>
-                                    <MenuItem AutomationProperties.AutomationId="Context_EditNotes"
-                                              Header="{loc:Localize Dashboard_CtxEditNotes}"
-                                              Command="{Binding $parent[DataGrid].DataContext.QuickEditGhiChuCommand}"
-                                              ToolTip.Tip="{loc:Localize Dashboard_TipEditNotes}">
-                                        <MenuItem.Icon><Image Source="{StaticResource IconNote}" Width="14" Height="14"/></MenuItem.Icon>
-                                    </MenuItem>
                                     <Separator/>
                                     <!-- Mark &amp; manage -->
                                     <MenuItem AutomationProperties.AutomationId="Context_MarkImportant"
@@ -520,7 +514,7 @@
                                               Header="{loc:Localize Dashboard_CtxPersonalNote}"
                                               Command="{Binding $parent[DataGrid].DataContext.OpenPersonalNoteCommand}"
                                               ToolTip.Tip="{loc:Localize Dashboard_TipPersonalNote}">
-                                        <MenuItem.Icon><Image Source="{StaticResource IconBook}" Width="14" Height="14"/></MenuItem.Icon>
+                                        <MenuItem.Icon><Image Source="{StaticResource IconNote}" Width="14" Height="14"/></MenuItem.Icon>
                                     </MenuItem>
                                     <MenuItem AutomationProperties.AutomationId="Context_AddToCollection"
                                               Header="{loc:Localize Dashboard_CtxAddToCollection}"

--- a/StudyDocumentManager/Views/PersonalNote.axaml
+++ b/StudyDocumentManager/Views/PersonalNote.axaml
@@ -163,11 +163,13 @@
                                                        FontWeight="Bold"
                                                        Foreground="{StaticResource StatPurpleFg}"/>
                                         </Border>
-                                        <TextBlock Grid.Column="1"
-                                                   Text="📌 "
-                                                   IsVisible="{Binding IsPinned}"
-                                                   FontSize="{StaticResource FontSizeXs}"
-                                                   VerticalAlignment="Center"/>
+                                        <Image Grid.Column="1"
+                                               Source="{StaticResource IconPinFilled}"
+                                               Width="12"
+                                               Height="12"
+                                               IsVisible="{Binding IsPinned}"
+                                               VerticalAlignment="Center"
+                                               Margin="0,0,4,0"/>
                                         <TextBlock Grid.Column="2"
                                                    Text="{Binding Content}"
                                                    FontSize="{StaticResource FontSizeSm}"
@@ -238,7 +240,7 @@
                                     AutomationProperties.AutomationId="PersonalNote_Pinned"
                                     AutomationProperties.Name="{loc:Localize PersonalNote_Pinned}">
                                 <StackPanel Orientation="Horizontal" Spacing="4">
-                                    <TextBlock Text="📌" FontSize="{StaticResource FontSizeXs}"/>
+                                    <Image Source="{StaticResource IconPin}" Width="12" Height="12" VerticalAlignment="Center"/>
                                     <TextBlock Text="{loc:Localize PersonalNote_Pinned}" FontSize="{StaticResource FontSizeXs}"/>
                                 </StackPanel>
                             </Button>


### PR DESCRIPTION
## 概要
ユーザーフィードバックに基づき、右クリックコンテキストメニューにおける旧「メモ編集」項目（Context_EditNotes）を完全削除して統合「個人メモ」（Context_PersonalNote）に一本化し、UI上の絵文字（📌等）をすべてテーマ管理されたベクターアイコン（IconPin, IconPinFilled）へ刷新しました。

## 主な変更点
1. **コンテキストメニューの重複解消（Dashboard.axaml）**:
   - Context_EditNotes を削除し、Context_PersonalNote（IconNote 付き）に一本化。
2. **ベクターアイコンの新規定義（AppTheme.axaml）**:
   - IconPin（通常ピン）および IconPinFilled（強調・固定中ピン）を DrawingImage として定義。
3. **絵文字の完全置換（PersonalNote.axaml）**:
   - リスト内ピン表示、固定ボタン（tnNotePinned）、固定状態表示から絵文字を撤廃し、ベクターアイコン（Image Source="{StaticResource IconPin}"）に置換。
4. **テスト更新と拡充**:
   - MainWindowTaxonomyTests.cs: コンテキストメニューのアサーションを更新。
   - ViewVisualEvaluationTests.cs: ViewAudit_DashboardContextMenu_IsUnifiedAndHasNoEditNotes を追加し、重複項目の不在と統合項目の存在を検証。

## 検証
- dotnet test (41/41 PASS)
- GitNexus: detect_changes 実施（Risk: LOW）

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
右クリックメニューから旧「メモ編集」（`Context_EditNotes`）を削除し、「個人メモ」（`Context_PersonalNote`）に一本化しました。個人メモのピン表示と固定ボタンは絵文字からテーマ管理のベクターアイコンに変わり、表示を統一しています。

**検証**

- `dotnet test` で41件すべて成功。
- 旧項目がなく、統合項目が存在することをビュー監査テストで確認。

<sup>Written for commit 0cf19e23fdeed3f796c3a0bbfe4ee2a21c11e269. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hayato-shino05/Document-Manager/pull/85?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR consolidates the dashboard context menu around the personal-note workflow and replaces pushpin emoji with theme-managed vector resources.
- Removes the legacy Context_EditNotes menu item and updates menu taxonomy coverage.
- Adds neutral and highlighted pushpin DrawingImage resources.
- Uses the new resources in pinned-note indicators and controls.
- Adds a dashboard context-menu regression test.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the removed action intentionally consolidated and the new icon resources correctly scoped and referenced.

The retained personal-note workflow preserves the relevant general-note synchronization, while the vector resources follow existing application-level resource and layout patterns without introducing a concrete failure.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| StudyDocumentManager/Views/Dashboard.axaml | Removes the intentionally deprecated note-edit action and gives the retained personal-note action the note icon. |
| StudyDocumentManager/Views/PersonalNote.axaml | Replaces pushpin emoji with fixed-size themed vector images without disrupting the existing grid layout or bindings. |
| StudyDocumentManager/Themes/AppTheme.axaml | Adds application-scoped pushpin resources using existing brush tokens and established DrawingImage syntax. |
| StudyDocumentManager.Tests/ViewVisualEvaluationTests.cs | Adds regression coverage asserting that only the unified personal-note menu entry remains. |
| StudyDocumentManager.Tests/MainWindowTaxonomyTests.cs | Updates the expected dashboard context-menu automation taxonomy after removing the legacy entry. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(ui): 右クリックメニューの重複メモ項目を削除し絵文字をベクターアイ..."](https://github.com/hayato-shino05/document-manager/commit/0cf19e23fdeed3f796c3a0bbfe4ee2a21c11e269) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59941071)</sub>

<!-- /greptile_comment -->